### PR TITLE
Slice 3: Design system + home page shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,13 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.9",
+        "@tailwindcss/vite": "^4.2.4",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "concurrently": "^9.2.1",
+        "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.5",
@@ -171,31 +173,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1141,6 +1118,50 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1530,6 +1551,278 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -1934,6 +2227,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -2066,6 +2373,13 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2093,6 +2407,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/kleur": {
@@ -2454,7 +2779,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2753,6 +3077,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinybench": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1129,17 +1165,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
@@ -1149,17 +1174,6 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1180,14 +1194,14 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2415,7 +2429,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2779,6 +2792,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.9",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.2.1",
+    "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,10 +1,52 @@
-// Placeholder authed SPA shell. Slice 1 is just an empty routed shell —
-// real screens (dashboard, add watch, log reading) land in later slices.
+// Authed SPA chrome. Renders the shared Header/Footer equivalent for the
+// app surface and an <Outlet /> for the current placeholder page. Slice 3
+// only wires the design language — real auth gating, nav links, and
+// screen content come in later slices.
+import { Link, Outlet } from "react-router";
+
 export function App() {
   return (
-    <main>
-      <h1>rated.watch app</h1>
-      <p>Placeholder shell. Authed screens ship in a later slice.</p>
-    </main>
+    <div className="min-h-screen flex flex-col bg-cf-bg-100 text-cf-text font-sans">
+      <header className="border-b border-cf-border bg-cf-bg-100">
+        <div className="mx-auto flex max-w-[1200px] items-center justify-between gap-4 px-6 py-4">
+          <Link
+            to="/app"
+            className="font-mono text-base font-medium tracking-tight text-cf-text hover:text-cf-text"
+            aria-label="rated.watch app home"
+          >
+            rated<span className="text-cf-orange">.</span>watch
+          </Link>
+          <nav
+            aria-label="App primary"
+            className="flex gap-6 text-sm text-cf-text-muted"
+          >
+            <Link to="/app/dashboard" className="hover:text-cf-text">
+              Dashboard
+            </Link>
+            <Link to="/app/settings" className="hover:text-cf-text">
+              Settings
+            </Link>
+            <a
+              href="/"
+              className="hover:text-cf-text"
+              aria-label="Back to public site"
+            >
+              ← Site
+            </a>
+          </nav>
+        </div>
+      </header>
+      <main className="flex-1">
+        <div className="mx-auto max-w-[1200px] px-6 py-12">
+          <Outlet />
+        </div>
+      </main>
+      <footer className="border-t border-cf-border py-8 text-sm text-cf-text-subtle">
+        <div className="mx-auto max-w-[1200px] px-6">
+          rated.watch — authed area. Placeholder screens ship in a later
+          slice.
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -3,10 +3,20 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>rated.watch</title>
+    <meta
+      name="theme-color"
+      content="#FFFBF5"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#121212"
+      media="(prefers-color-scheme: dark)"
+    />
+    <title>rated.watch — app</title>
+    <script type="module" src="./main.tsx"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./main.tsx"></script>
   </body>
 </html>

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -2,6 +2,12 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";
 import { App } from "./App";
+import { LoginPage } from "./pages/LoginPage";
+import { RegisterPage } from "./pages/RegisterPage";
+import { DashboardPage } from "./pages/DashboardPage";
+import { SettingsPage } from "./pages/SettingsPage";
+import { NotFoundPage } from "./pages/NotFoundPage";
+import "./styles.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -12,7 +18,22 @@ createRoot(rootElement).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/*" element={<App />} />
+        {/*
+         * Public-inside-the-SPA landing for /app. Until slice 4 ships real
+         * screens, every route below is a "not implemented yet" placeholder
+         * that shares the same chrome (<App /> shell) so the design language
+         * feels consistent end-to-end.
+         */}
+        <Route path="/app" element={<App />}>
+          <Route index element={<DashboardPage />} />
+          <Route path="login" element={<LoginPage />} />
+          <Route path="register" element={<RegisterPage />} />
+          <Route path="dashboard" element={<DashboardPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+        </Route>
+        {/* SPA fallback: any path the Worker let fall through to the SPA
+            that isn't one of the /app/* placeholders renders this. */}
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -1,0 +1,15 @@
+// Placeholder authed dashboard. Real content — "my watches", current
+// session drift, log-reading shortcuts — lands in the dashboard slice.
+export function DashboardPage() {
+  return (
+    <section>
+      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
+        Dashboard
+      </h1>
+      <p className="text-cf-text-muted max-w-[56ch]">
+        Not implemented yet. Your watches, current session drift, and
+        quick-log shortcuts appear here once the dashboard slice ships.
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,0 +1,15 @@
+// Placeholder login screen. Better Auth wiring lands in a later slice
+// (see PRD §auth). Slice 3 only needs this route to resolve + render
+// the shared design language so the shell feels cohesive.
+export function LoginPage() {
+  return (
+    <section className="mx-auto max-w-md">
+      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
+        Sign in
+      </h1>
+      <p className="text-cf-text-muted">
+        Not implemented yet. The authed flow lands in an upcoming slice.
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/NotFoundPage.tsx
+++ b/src/app/pages/NotFoundPage.tsx
@@ -1,0 +1,26 @@
+// Client-side 404 fallback for SPA routes that don't match. This only
+// fires for paths the Worker let fall through to Workers Assets, so
+// anything the router doesn't recognise ends up here rather than the
+// browser's default blank screen.
+import { Link } from "react-router";
+
+export function NotFoundPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-[1200px] flex-col items-start justify-center gap-4 bg-cf-bg-100 px-6 font-sans text-cf-text">
+      <p className="font-mono text-sm text-cf-text-subtle">404</p>
+      <h1 className="text-4xl font-medium tracking-tight">
+        This page doesn't exist yet.
+      </h1>
+      <p className="max-w-[56ch] text-cf-text-muted">
+        The rated.watch SPA is still growing. If you followed a link here
+        from an earlier slice, the target probably hasn't shipped yet.
+      </p>
+      <Link
+        to="/app/dashboard"
+        className="mt-4 inline-flex items-center gap-2 rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover"
+      >
+        Back to dashboard →
+      </Link>
+    </main>
+  );
+}

--- a/src/app/pages/RegisterPage.tsx
+++ b/src/app/pages/RegisterPage.tsx
@@ -1,0 +1,14 @@
+// Placeholder registration screen. Better Auth sign-up + email
+// verification wiring lands in a later slice.
+export function RegisterPage() {
+  return (
+    <section className="mx-auto max-w-md">
+      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
+        Create an account
+      </h1>
+      <p className="text-cf-text-muted">
+        Not implemented yet. Registration ships with the auth slice.
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -1,0 +1,15 @@
+// Placeholder settings screen. Profile, privacy toggles, email, and
+// account deletion controls land in a later slice.
+export function SettingsPage() {
+  return (
+    <section className="mx-auto max-w-2xl">
+      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
+        Settings
+      </h1>
+      <p className="text-cf-text-muted">
+        Not implemented yet. Profile and privacy controls ship with the
+        settings slice.
+      </p>
+    </section>
+  );
+}

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,0 +1,79 @@
+/*
+ * rated.watch SPA styles.
+ *
+ * Tailwind v4 is included via @tailwindcss/vite. We register the CF
+ * Workers design-system palette in a @theme block so that `bg-cf-bg-100`,
+ * `text-cf-text`, `text-cf-orange`, etc. become first-class utilities
+ * inside the SPA. Public SSR pages declare the same variables inline in
+ * src/public/components/layout.tsx — keep the two in sync when tokens
+ * change.
+ *
+ * Dark-mode strategy: we use the standard `prefers-color-scheme` media
+ * query at the :root level (same as the public pages) rather than a
+ * `.dark` class, because slice 3 doesn't ship a theme toggle yet. When
+ * one lands (later slice), flip to a class-based strategy via Tailwind's
+ * custom-variant and a localStorage-backed <html class="dark"> switch.
+ */
+
+@import "tailwindcss";
+
+@theme {
+  --color-cf-orange: #ff4801;
+  --color-cf-orange-hover: #ff7038;
+  --color-cf-text: #521000;
+  --color-cf-text-muted: rgba(82, 16, 0, 0.6);
+  --color-cf-text-subtle: rgba(82, 16, 0, 0.38);
+  --color-cf-bg-page: #f5f1eb;
+  --color-cf-bg-100: #fffbf5;
+  --color-cf-bg-200: #fffdfb;
+  --color-cf-bg-300: #fef7ed;
+  --color-cf-border: #ebd5c1;
+
+  --font-sans:
+    "FT Kunst Grotesk", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  --font-mono:
+    "Apercu Mono Pro", "JetBrains Mono", "SF Mono", "Fira Code", Consolas,
+    monospace;
+
+  --radius-cf-full: 9999px;
+}
+
+/*
+ * Dark-mode token overrides. Tailwind's `dark:` variants default to a
+ * `prefers-color-scheme: dark` media query, which is exactly what we
+ * want here: the tokens flip automatically based on OS preference.
+ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-cf-orange: #f14602;
+    --color-cf-orange-hover: #ff6d33;
+    --color-cf-text: #f0e3de;
+    --color-cf-text-muted: rgba(255, 253, 251, 0.56);
+    --color-cf-text-subtle: rgba(255, 253, 251, 0.38);
+    --color-cf-bg-page: #0d0d0d;
+    --color-cf-bg-100: #121212;
+    --color-cf-bg-200: #191817;
+    --color-cf-bg-300: #2a2927;
+    --color-cf-border: rgba(240, 227, 222, 0.13);
+    color-scheme: dark;
+  }
+}
+
+:root {
+  color-scheme: light;
+}
+
+html,
+body {
+  background: var(--color-cf-bg-100);
+  color: var(--color-cf-text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  margin: 0;
+}

--- a/src/public/components/button.tsx
+++ b/src/public/components/button.tsx
@@ -1,0 +1,57 @@
+// Button primitive for public SSR pages. Server-rendered only — this has
+// no onClick / no hydration. For authed app interactions use the SPA-side
+// button (to be added under src/app/ui/ later).
+//
+// Two variants in slice 3:
+//   - "primary": orange fill, white text. CTAs.
+//   - "ghost":   border + muted text. Secondary actions.
+//
+// The `as` prop lets the same styling apply to <a>, so link-buttons on the
+// hero ("Browse leaderboards") can share the exact same classes.
+import type { Child } from "hono/jsx";
+
+export type ButtonVariant = "primary" | "ghost";
+
+type BaseProps = {
+  variant?: ButtonVariant;
+  children: Child;
+  class?: string;
+};
+
+type ButtonProps = BaseProps & {
+  as?: "button";
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+};
+
+type LinkProps = BaseProps & {
+  as: "a";
+  href: string;
+  target?: "_self" | "_blank";
+  rel?: string;
+};
+
+function variantClass(v: ButtonVariant | undefined): string {
+  return v === "ghost" ? "cf-btn cf-btn--ghost" : "cf-btn cf-btn--primary";
+}
+
+export const Button = (props: ButtonProps | LinkProps) => {
+  const cls = `${variantClass(props.variant)}${props.class ? ` ${props.class}` : ""}`;
+  if (props.as === "a") {
+    return (
+      <a
+        class={cls}
+        href={props.href}
+        target={props.target}
+        rel={props.target === "_blank" ? (props.rel ?? "noreferrer") : props.rel}
+      >
+        {props.children}
+      </a>
+    );
+  }
+  return (
+    <button class={cls} type={props.type ?? "button"} disabled={props.disabled}>
+      {props.children}
+    </button>
+  );
+};

--- a/src/public/components/card.tsx
+++ b/src/public/components/card.tsx
@@ -1,0 +1,28 @@
+// Card primitive with the signature CF Workers corner-bracket decoration.
+// The four 8px squares sit outside the border radius — purely decorative,
+// rendered via ::before/::after pseudo-elements on an absolutely-positioned
+// overlay. See ~/design/CF-WORKERS-DESIGN.md §11.1.
+//
+// The `corners` prop defaults to true because ~every card in the design
+// uses them. Pass `corners={false}` to opt out (e.g. on a card inside a
+// bigger bracketed container).
+import type { Child } from "hono/jsx";
+
+export type CardProps = {
+  title?: string;
+  children: Child;
+  corners?: boolean;
+  class?: string;
+};
+
+export const Card = ({ title, children, corners = true, class: className }: CardProps) => (
+  <div class={`cf-card${className ? ` ${className}` : ""}`}>
+    {corners ? (
+      <div class="cf-brackets" aria-hidden="true">
+        <span />
+      </div>
+    ) : null}
+    {title ? <h2 class="cf-card__title">{title}</h2> : null}
+    <div class="cf-card__body">{children}</div>
+  </div>
+);

--- a/src/public/components/footer.tsx
+++ b/src/public/components/footer.tsx
@@ -1,0 +1,18 @@
+// Minimal site footer. No tracking, no cookie banner — we don't do either.
+// The © year is computed at render time; that's safe because Workers
+// execute per-request and the value doesn't leak across tenants.
+export const Footer = () => {
+  const year = new Date().getUTCFullYear();
+  return (
+    <footer class="cf-footer">
+      <div class="cf-container cf-footer__inner">
+        <span>
+          © {year} rated.watch — competitive accuracy tracking for watch enthusiasts.
+        </span>
+        <nav aria-label="Footer">
+          <a href="/">Home</a>
+        </nav>
+      </div>
+    </footer>
+  );
+};

--- a/src/public/components/header.tsx
+++ b/src/public/components/header.tsx
@@ -1,0 +1,16 @@
+// Public site header — logo + top-level nav. All links are real paths; the
+// ones that don't exist yet (leaderboard, app) 404/SPA-fallback gracefully.
+// Slice 3 is just the shell; destinations land in slices 4 onwards.
+export const Header = () => (
+  <header class="cf-header">
+    <div class="cf-container cf-header__inner">
+      <a href="/" class="cf-logo" aria-label="rated.watch home">
+        rated<span class="cf-logo__accent">.</span>watch
+      </a>
+      <nav class="cf-nav" aria-label="Primary">
+        <a href="/leaderboard">Leaderboard</a>
+        <a href="/app/login">Sign in</a>
+      </nav>
+    </div>
+  </header>
+);

--- a/src/public/components/layout.tsx
+++ b/src/public/components/layout.tsx
@@ -1,0 +1,302 @@
+// Shared <Layout> for every public SSR page. Owns the <head>, the social
+// share meta, and the single inlined stylesheet that gives public pages
+// their design-system tokens. Public pages emit ZERO client JS — see the
+// "no <script> tag" contract in tests/integration/home.test.ts.
+//
+// Fonts: we prefer the licensed CF Workers faces (FT Kunst Grotesk, Apercu
+// Mono Pro) when they're available via self-hosted @font-face rules, but
+// fall back to open alternatives (Geist Sans, JetBrains Mono) and finally
+// to system sans/mono when no webfont is present. Slice 3 leaves the
+// @font-face rules as TODOs — fonts land in a later slice once the licence
+// + R2 bucket are ready. See ~/design/CF-WORKERS-DESIGN.md §3.
+import type { Child } from "hono/jsx";
+import { tokens } from "./tokens";
+
+export type LayoutProps = {
+  title: string;
+  description: string;
+  /** Path relative to origin, used for og:url. No leading origin please. */
+  pathname?: string;
+  children: Child;
+};
+
+/**
+ * Emits the CF Workers design tokens as CSS custom properties, swapping
+ * values at the `prefers-color-scheme: dark` breakpoint. Rendered once per
+ * page in the <head>. Kept in this file because it's tightly coupled to
+ * the <Layout> contract (tests assert the tokens appear in the response).
+ */
+function DesignTokensStyle() {
+  const l = tokens.light;
+  const d = tokens.dark;
+  // Deliberately hand-rolled CSS string (not JSX) — hono/jsx escapes `<style>`
+  // children otherwise. Dangerously-set-innerHTML is unavailable in hono/jsx;
+  // the idiomatic approach is to pass the raw string as a child and rely on
+  // hono/jsx's raw HTML insertion via the `html` helper, but a plain <style>
+  // tag with static CSS text is fine since no user data flows in here.
+  const css = `
+:root {
+  --cf-orange: ${l.orange};
+  --cf-orange-hover: ${l.orangeHover};
+  --cf-text: ${l.text};
+  --cf-text-muted: ${l.textMuted};
+  --cf-text-subtle: ${l.textSubtle};
+  --cf-bg-page: ${l.bgPage};
+  --cf-bg-100: ${l.bg100};
+  --cf-bg-200: ${l.bg200};
+  --cf-bg-300: ${l.bg300};
+  --cf-border: ${l.border};
+  --cf-border-light: ${l.borderLight};
+  --cf-font-sans: ${tokens.font.sans};
+  --cf-font-mono: ${tokens.font.mono};
+  --cf-radius-sm: ${tokens.radius.sm};
+  --cf-radius-md: ${tokens.radius.md};
+  --cf-radius-lg: ${tokens.radius.lg};
+  --cf-radius-xl: ${tokens.radius.xl};
+  --cf-radius-full: ${tokens.radius.full};
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cf-orange: ${d.orange};
+    --cf-orange-hover: ${d.orangeHover};
+    --cf-text: ${d.text};
+    --cf-text-muted: ${d.textMuted};
+    --cf-text-subtle: ${d.textSubtle};
+    --cf-bg-page: ${d.bgPage};
+    --cf-bg-100: ${d.bg100};
+    --cf-bg-200: ${d.bg200};
+    --cf-bg-300: ${d.bg300};
+    --cf-border: ${d.border};
+    --cf-border-light: ${d.borderLight};
+    color-scheme: dark;
+  }
+}
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--cf-bg-100);
+  color: var(--cf-text);
+  font-family: var(--cf-font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "kern" 1, "liga" 1;
+}
+
+a {
+  color: var(--cf-orange);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+a:hover { color: var(--cf-orange-hover); }
+
+:focus-visible {
+  outline: 2px solid var(--cf-orange);
+  outline-offset: 2px;
+  border-radius: var(--cf-radius-sm);
+}
+
+.cf-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.cf-hero {
+  padding: 96px 0 64px;
+}
+.cf-hero h1 {
+  font-size: clamp(2.25rem, 4vw + 1rem, 3rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 16px;
+  font-weight: 500;
+}
+.cf-hero p {
+  max-width: 56ch;
+  margin: 0 0 32px;
+  color: var(--cf-text-muted);
+  font-size: 1.125rem;
+  line-height: 1.56;
+}
+
+.cf-section {
+  padding: 48px 0;
+  border-top: 1px dashed var(--cf-border);
+}
+
+.cf-card {
+  position: relative;
+  background: var(--cf-bg-200);
+  border: 1px solid var(--cf-border);
+  border-radius: var(--cf-radius-lg);
+  padding: 24px;
+}
+.cf-card__title {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+.cf-card__body {
+  margin: 0;
+  color: var(--cf-text-muted);
+}
+
+.cf-brackets {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.cf-brackets::before,
+.cf-brackets::after,
+.cf-brackets > span::before,
+.cf-brackets > span::after {
+  content: "";
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: var(--cf-bg-100);
+  border: 1px solid var(--cf-border);
+  border-radius: 1.5px;
+}
+.cf-brackets::before { top: -4px; left: -4px; }
+.cf-brackets::after { top: -4px; right: -4px; }
+.cf-brackets > span::before { bottom: -4px; left: -4px; }
+.cf-brackets > span::after { bottom: -4px; right: -4px; }
+
+.cf-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: var(--cf-radius-full);
+  font-family: var(--cf-font-sans);
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.16s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              color 0.16s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              border-color 0.16s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.cf-btn--primary {
+  background: var(--cf-orange);
+  color: #FFFBF5;
+}
+.cf-btn--primary:hover { background: var(--cf-orange-hover); color: #FFFBF5; }
+.cf-btn--ghost {
+  background: transparent;
+  color: var(--cf-text);
+  border-color: var(--cf-border);
+}
+.cf-btn--ghost:hover {
+  background: var(--cf-bg-300);
+  color: var(--cf-text);
+}
+
+.cf-header {
+  border-bottom: 1px solid var(--cf-border);
+  padding: 16px 0;
+  background: var(--cf-bg-100);
+}
+.cf-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.cf-logo {
+  font-family: var(--cf-font-mono);
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+  color: var(--cf-text);
+  font-weight: 500;
+}
+.cf-logo__accent { color: var(--cf-orange); }
+
+.cf-nav {
+  display: flex;
+  gap: 24px;
+  font-size: 0.875rem;
+}
+.cf-nav a { color: var(--cf-text-muted); }
+.cf-nav a:hover { color: var(--cf-text); }
+
+.cf-footer {
+  border-top: 1px solid var(--cf-border);
+  padding: 32px 0;
+  color: var(--cf-text-subtle);
+  font-size: 0.875rem;
+}
+.cf-footer__inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.cf-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+@media (min-width: 768px) {
+  .cf-grid-2 { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+}
+`;
+  return <style>{css}</style>;
+}
+
+export const Layout = ({ title, description, pathname, children }: LayoutProps) => {
+  const url = pathname ? `https://rated.watch${pathname}` : "https://rated.watch/";
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title}</title>
+        <meta name="description" content={description} />
+
+        {/* Dual theme-color so browser chrome matches the palette in both
+            schemes. Tests assert both tags are present. */}
+        <meta
+          name="theme-color"
+          content={tokens.light.bg100}
+          media="(prefers-color-scheme: light)"
+        />
+        <meta
+          name="theme-color"
+          content={tokens.dark.bg100}
+          media="(prefers-color-scheme: dark)"
+        />
+
+        {/* Open Graph + Twitter card for share previews. */}
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+
+        <link rel="canonical" href={url} />
+
+        <DesignTokensStyle />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+};

--- a/src/public/components/tokens.ts
+++ b/src/public/components/tokens.ts
@@ -1,0 +1,49 @@
+// CF Workers design tokens — single source of truth for palette, radii,
+// typography, and motion used by both the public SSR pages and the SPA.
+//
+// We expose the raw hex/token values here (not a CSS string) so components
+// that render inline colour (e.g. the <meta name="theme-color">) don't have
+// to grep out of a stylesheet. The matching CSS custom properties are
+// emitted by `<DesignTokensStyle />` in `layout.tsx`.
+//
+// See ~/design/CF-WORKERS-DESIGN.md §2 and §3 for the full reference.
+
+export const tokens = {
+  light: {
+    orange: "#FF4801",
+    orangeHover: "#FF7038",
+    text: "#521000",
+    textMuted: "rgba(82, 16, 0, 0.6)",
+    textSubtle: "rgba(82, 16, 0, 0.38)",
+    bgPage: "#F5F1EB",
+    bg100: "#FFFBF5",
+    bg200: "#FFFDFB",
+    bg300: "#FEF7ED",
+    border: "#EBD5C1",
+    borderLight: "rgba(235, 213, 193, 0.5)",
+  },
+  dark: {
+    orange: "#F14602",
+    orangeHover: "#FF6D33",
+    text: "#F0E3DE",
+    textMuted: "rgba(255, 253, 251, 0.56)",
+    textSubtle: "rgba(255, 253, 251, 0.38)",
+    bgPage: "#0D0D0D",
+    bg100: "#121212",
+    bg200: "#191817",
+    bg300: "#2A2927",
+    border: "rgba(240, 227, 222, 0.13)",
+    borderLight: "rgba(240, 227, 222, 0.08)",
+  },
+  font: {
+    sans: '"FT Kunst Grotesk", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    mono: '"Apercu Mono Pro", "JetBrains Mono", "SF Mono", "Fira Code", Consolas, monospace',
+  },
+  radius: {
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+    xl: "16px",
+    full: "9999px",
+  },
+} as const;

--- a/src/public/landing.tsx
+++ b/src/public/landing.tsx
@@ -1,22 +1,57 @@
-// Server-rendered landing page. Slice 1 is deliberately minimal — it exists
-// so the walking-skeleton integration test can prove the Worker + Hono + JSX
-// toolchain is wired up correctly. Real design lands in a later slice.
+// Server-rendered public home page. Zero client JS (asserted by the
+// "no <script> tag" integration test). The shared <Layout> owns the
+// design-system tokens and OG meta; this file only owns copy.
+import { Layout } from "./components/layout";
+import { Header } from "./components/header";
+import { Footer } from "./components/footer";
+import { Button } from "./components/button";
+import { Card } from "./components/card";
+
+const TITLE = "rated.watch — competitive accuracy tracking for watch enthusiasts";
+const DESCRIPTION =
+  "Competitive accuracy tracking for watch enthusiasts. Verified deviation, drift-rate leaderboards, grouped by movement.";
+
 export const LandingPage = () => (
-  <html lang="en">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>rated.watch — coming soon</title>
-      <meta
-        name="description"
-        content="Competitive accuracy tracking for watch enthusiasts."
-      />
-    </head>
-    <body>
-      <main>
-        <h1>rated.watch</h1>
-        <p>Competitive accuracy tracking for watch enthusiasts — coming soon.</p>
-      </main>
-    </body>
-  </html>
+  <Layout title={TITLE} description={DESCRIPTION} pathname="/">
+    <Header />
+    <main>
+      <section class="cf-container cf-hero" aria-labelledby="hero-title">
+        <h1 id="hero-title">
+          Competitive accuracy tracking for watch enthusiasts.
+        </h1>
+        <p>
+          Log verified readings, watch your drift rate settle, and climb the
+          leaderboards grouped by movement caliber. Spoof-resistant, public,
+          and mechanical-first.
+        </p>
+        <div style="display:flex;gap:12px;flex-wrap:wrap">
+          <Button as="a" href="/leaderboard" variant="primary">
+            Browse leaderboards →
+          </Button>
+          <Button as="a" href="/app/register" variant="ghost">
+            Create an account
+          </Button>
+        </div>
+      </section>
+
+      <section class="cf-container cf-section" aria-labelledby="next-title">
+        <h2 id="next-title" style="margin:0 0 24px;font-size:1.25rem;font-weight:500;letter-spacing:-0.02em;color:var(--cf-text-muted)">
+          Coming soon
+        </h2>
+        <div class="cf-grid-2">
+          <Card title="Leaderboards by movement">
+            Watches compete within their own caliber — a Calibre 3135 is judged
+            against other 3135s, not a quartz HAQ. Fair, apples-to-apples
+            rankings by drift rate over the last session.
+          </Card>
+          <Card title="Verified readings only">
+            In-app camera captures are timestamped by the server at receipt.
+            No trusting client clocks. Watches hit a verified badge when 25 %
+            of their current session is camera-sourced.
+          </Card>
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </Layout>
 );

--- a/tests/integration/home.test.ts
+++ b/tests/integration/home.test.ts
@@ -1,0 +1,87 @@
+import { exports } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+// Public home page contract. These tests assert the design-system shape that
+// slice 3 ships: warm palette tokens, zero client JS on /, hero tagline,
+// and the cross-browser `theme-color` meta tag in both colour schemes.
+//
+// See issue #4.
+
+describe("GET / — design system + home shell", () => {
+  it("returns 200 HTML with Content-Type text/html", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type") ?? "").toMatch(/text\/html/);
+  });
+
+  it("includes theme-color meta tags for both light and dark schemes", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+
+    // Warm cream in light, near-black in dark — see CF Workers design doc.
+    expect(body).toMatch(
+      /<meta\s+name="theme-color"\s+content="#FFFBF5"\s+media="\(prefers-color-scheme:\s*light\)"\s*\/?>/,
+    );
+    expect(body).toMatch(
+      /<meta\s+name="theme-color"\s+content="#121212"\s+media="\(prefers-color-scheme:\s*dark\)"\s*\/?>/,
+    );
+  });
+
+  it("embeds the CF Workers design tokens as CSS custom properties", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+
+    // Accent, background, and text tokens must be present either inlined or
+    // via a linked stylesheet. We assert the canonical hex values appear
+    // somewhere in the served HTML so future refactors (inline vs linked
+    // sheet) don't silently drop the palette.
+    expect(body).toContain("#FF4801"); // primary accent
+    expect(body).toContain("#FFFBF5"); // cream light bg
+    expect(body).toContain("#121212"); // dark bg
+  });
+
+  it("renders the hero tagline", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+
+    // The tagline anchors the home page and the social share card. It must
+    // appear in the SSR output so crawlers and no-JS clients see it.
+    expect(body).toMatch(/Competitive accuracy tracking/i);
+  });
+
+  it("teases leaderboards as the next thing to ship", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+    expect(body).toMatch(/leaderboards/i);
+  });
+
+  it("emits zero client-side JavaScript — no <script> tags on /", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+
+    // Public pages must be pure SSR — any <script> tag (classic, module,
+    // JSON-LD excluded intentionally here) is a regression against the
+    // "no hydration on public pages" contract.
+    expect(body).not.toMatch(/<script\b/i);
+  });
+
+  it("respects prefers-color-scheme via a CSS media query", async () => {
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/"),
+    );
+    const body = await response.text();
+    expect(body).toMatch(/prefers-color-scheme\s*:\s*dark/i);
+  });
+});

--- a/tests/integration/spa-shell.test.ts
+++ b/tests/integration/spa-shell.test.ts
@@ -1,0 +1,49 @@
+import { env } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+// The authed SPA lives at /app/*. Workers Assets serves the built
+// dist/index.html for every unknown path thanks to
+// not_found_handling=single-page-application, so the four placeholder
+// routes (/app/login, /app/register, /app/dashboard, /app/settings)
+// must each resolve to the SPA shell HTML. The SPA's client router
+// then renders the right placeholder page.
+//
+// In production the request flow is:
+//   request → CF assets layer → (no file match) → 200 with /index.html
+// The Worker's default handler only owns `/` and `/api/*` via
+// run_worker_first, so we test the assets layer directly through the
+// ASSETS binding instead of exports.default.fetch (which bypasses
+// assets routing — see vitest-pool-workers docs).
+
+const routes = [
+  "/app/login",
+  "/app/register",
+  "/app/dashboard",
+  "/app/settings",
+];
+
+describe("SPA shell — /app/*", () => {
+  for (const path of routes) {
+    it(`GET ${path} falls through to the SPA shell via Workers Assets`, async () => {
+      const response = await env.ASSETS.fetch(
+        new Request(`https://ratedwatch.test${path}`),
+      );
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      // The shell is dist/index.html, which mounts React at #root.
+      expect(body).toContain(`id="root"`);
+    });
+  }
+
+  it("SPA shell links a stylesheet (design-system CSS is wired)", async () => {
+    const response = await env.ASSETS.fetch(
+      new Request("https://ratedwatch.test/app/dashboard"),
+    );
+    const body = await response.text();
+    // Vite emits <link rel="stylesheet" href="/assets/..."> when the SPA
+    // imports a .css file. Presence of at least one stylesheet link is
+    // the minimum proof that Tailwind / the tokens CSS is part of the
+    // production bundle.
+    expect(body).toMatch(/<link[^>]+rel="stylesheet"[^>]+href="\/assets\//);
+  });
+});

--- a/tests/integration/spa-shell.test.ts
+++ b/tests/integration/spa-shell.test.ts
@@ -46,4 +46,32 @@ describe("SPA shell — /app/*", () => {
     // production bundle.
     expect(body).toMatch(/<link[^>]+rel="stylesheet"[^>]+href="\/assets\//);
   });
+
+  it("SPA stylesheet contains the CF Workers palette tokens", async () => {
+    const shell = await env.ASSETS.fetch(
+      new Request("https://ratedwatch.test/app/dashboard"),
+    );
+    const shellBody = await shell.text();
+    const match = shellBody.match(
+      /<link[^>]+rel="stylesheet"[^>]+href="(\/assets\/[^"]+)"/,
+    );
+    expect(match).not.toBeNull();
+    const cssHref = match![1]!;
+
+    const cssResponse = await env.ASSETS.fetch(
+      new Request(`https://ratedwatch.test${cssHref}`),
+    );
+    expect(cssResponse.status).toBe(200);
+    const css = await cssResponse.text();
+
+    // Canonical palette hex values — asserted via the @theme tokens
+    // registered in src/app/styles.css. If someone regresses the theme
+    // block or drops the import, this fires.
+    expect(css).toContain("#ff4801"); // primary accent (light)
+    expect(css).toContain("#fffbf5"); // cream bg (light)
+    expect(css).toContain("#121212"); // dark bg
+    // Dark-mode media query must be present — slice 3 ships no theme
+    // toggle, so OS preference is the only signal.
+    expect(css).toMatch(/prefers-color-scheme\s*:\s*dark/i);
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
 
 // The SPA lives at /src/app. The Worker owns `/`, `/api/*`, and future
 // public HTML routes via run_worker_first; everything else falls through
 // to the Workers Assets binding which serves the build output below.
+//
+// Tailwind v4 is wired via @tailwindcss/vite so its CSS engine runs at
+// Vite build time. Public SSR pages keep their tokens as inlined CSS
+// custom properties (see src/public/components/layout.tsx); the SPA
+// consumes the same palette through the @theme block in src/app/styles.css
+// so both surfaces stay visually identical without the Worker needing
+// a runtime Tailwind pass.
 export default defineConfig({
   root: path.resolve(process.cwd(), "src/app"),
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: { "@": path.resolve(process.cwd(), "./src") },
   },


### PR DESCRIPTION
Closes #4.

## Summary

- **Design tokens** wired as CSS custom properties: CF Workers warm-cream palette (`#FFFBF5` light / `#121212` dark), warm-brown text, `#FF4801` accent, radii, font stack. Single source of truth in `src/public/components/tokens.ts` (public SSR) and `src/app/styles.css` (`@theme` block for the SPA) — both reference the same canonical hex values.
- **Shared `hono/jsx` components** under `src/public/components/`: `Layout` (full `<head>` with dual `theme-color` meta + OG/Twitter tags), `Header`, `Footer`, `Button` (primary / ghost, with `as="a"` link variant), `Card` (with the CF-signature corner-bracket decoration).
- **Public home page** at `/` now renders a hero tagline (`Competitive accuracy tracking for watch enthusiasts.`), CTA pair, and a "Coming soon" section with two corner-bracketed cards teasing leaderboards and verified readings.
- **Tailwind v4** installed via `@tailwindcss/vite`. The SPA imports a single `styles.css` that wires the CF palette into `@theme` so classes like `bg-cf-bg-100`, `text-cf-orange`, `border-cf-border` work as first-class utilities.
- **SPA shell** scaffolded at `/app/*` with four placeholder routes sharing a common chrome (`App.tsx`): `/app/login`, `/app/register`, `/app/dashboard`, `/app/settings`. Each renders a one-paragraph "Not implemented yet" stub but in the shared design language. Plus a client-side `NotFoundPage` for unmatched SPA paths.
- **Dark mode** via `prefers-color-scheme: dark` media query at the `:root` level — no theme toggle yet (deliberate; a toggle slice lands later).
- **Zero client JS on `/`** — the integration test asserts the served HTML contains no `<script>` tag.

## Tests

18 tests green, up from 5.

New `tests/integration/home.test.ts` (7 tests):
- 200 + `text/html` content type
- both `<meta name="theme-color">` tags (light + dark)
- CF design tokens (`#FF4801`, `#FFFBF5`, `#121212`) appear in the response
- hero tagline copy is present
- "leaderboards" copy is present
- no `<script>` tag anywhere in the response
- `prefers-color-scheme: dark` media query is in the rendered CSS

New `tests/integration/spa-shell.test.ts` (6 tests):
- `/app/login`, `/app/register`, `/app/dashboard`, `/app/settings` each return 200 via `env.ASSETS.fetch()` and contain the React `#root` mount
- the SPA shell links a `/assets/*.css` stylesheet
- fetching that stylesheet shows the CF palette hex values + the dark-mode media query (catches `@theme` regressions)

Because `exports.default.fetch()` in `vitest-pool-workers` bypasses the assets layer, the SPA tests call `env.ASSETS.fetch()` directly — that's the same endpoint CF's edge calls for any path that doesn't match `run_worker_first`.

## Deviations from the issue

- **Fonts**: the issue allowed either R2/CDN self-hosting of FT Kunst Grotesk + Apercu Mono Pro, or open fallbacks. I took the fallback path for this slice — the licensed faces weren't locally available, so `Layout` and `styles.css` declare the stack `"FT Kunst Grotesk", "Geist", -apple-system, …` (sans) and `"Apercu Mono Pro", "JetBrains Mono", "SF Mono", …` (mono). No `@font-face` rules yet; the browser falls through to system faces. A follow-up slice should land actual `@font-face` declarations once the licence + R2 bucket are ready.

## Followups noted

- Font self-hosting via R2 (`@font-face` with `font-display: swap`) — own slice once the licensed files are available.
- User-toggleable theme (localStorage-backed `<html class="dark">`) — own slice with Tailwind's class-based dark variant.
- Real public pages for `/leaderboard`, `/m/:id`, `/u/:name`, `/w/:id` — start shipping from slice 4 onwards. The `Layout`/`Header`/`Footer`/`Card`/`Button` primitives are ready.
- Real authed screens behind `/app/*` — auth slice + dashboard slice.

## Files touched (perimeter-safe)

Did **not** touch: `infra/terraform/**`, `.github/workflows/**`, `wrangler.jsonc` (binding blocks), `worker-configuration.d.ts`, `tests/e2e/**`, `.prettierrc`, `.husky/**`.

## Verification

Locally on a clean state:

```
npm ci
npm run types:check   # passes
npm run typecheck     # passes
npm run build         # emits dist/index.html + assets/*.js + assets/*.css
npm run test          # 4 files, 18 tests, all passing
```