### PR TITLE
Slice 4: Better Auth — email/password + session + username generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Full product spec: see the `product-requirements` issue labelled `prd` on GitHub
   - E2E: Playwright against a deployed preview.
   - Tests live next to source (`foo.test.ts` beside `foo.ts`) for unit, and in `tests/integration/**` / `tests/e2e/**` for the other tiers.
 - **Feature flags:** KV-backed, single service with `isEnabled(flag, ctx)` signature. Default to off.
-- **Secrets:** `wrangler secret put` for Worker-side secrets; `.dev.vars` for local dev (gitignored). Never hardcode.
+- **Secrets:** `wrangler secret put` for Worker-side secrets; `.dev.vars` for local dev (gitignored). Never hardcode. Required production secrets:
+  - `BETTER_AUTH_SECRET` — 32+ char high-entropy value used by Better Auth for cookie signing. Set once per environment with `wrangler secret put BETTER_AUTH_SECRET` **before** any `wrangler deploy`. Generate with `openssl rand -base64 32`.
 - **Infra as code:** Terraform owns zone, route, D1, R2 bucket, access policies. Wrangler owns the Worker script. No overlap. State in the user's nmoura.cf R2 backend if possible.
 
 ## Things NOT to do

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,76 @@
+-- Slice 4 initial schema: Better Auth core tables + the rated.watch
+-- `username` column on `user`.
+--
+-- Better Auth's canonical Kysely schema (see
+-- node_modules/@better-auth/core/dist/db/get-tables.mjs) ships these
+-- four tables with the exact column names/types referenced here.
+-- Dates are stored as ISO 8601 TEXT because the Better Auth Kysely
+-- adapter for SQLite expects the driver to accept/emit ISO strings —
+-- D1's prepared-statement binder stringifies Date objects to ISO by
+-- default.
+--
+-- `username` is rated.watch-specific and added as an additional field
+-- on the `user` model via `user.additionalFields` in src/server/auth.ts.
+-- NOCASE collation gives us case-insensitive uniqueness so the public
+-- URL /u/:name is stable regardless of how it was typed during signup.
+
+CREATE TABLE IF NOT EXISTS user (
+  id TEXT PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  emailVerified INTEGER NOT NULL DEFAULT 0,
+  image TEXT,
+  username TEXT NOT NULL COLLATE NOCASE,
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL
+);
+
+-- Username uniqueness is enforced case-insensitively so "Foo" and "foo"
+-- can't both exist. Declared as a separate index because SQLite only
+-- honours COLLATE on a UNIQUE index when the collation is attached to
+-- the index, not the column-level UNIQUE constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS user_username_unique
+  ON user (username COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT PRIMARY KEY NOT NULL,
+  userId TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expiresAt TEXT NOT NULL,
+  ipAddress TEXT,
+  userAgent TEXT,
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS session_userId_idx ON session (userId);
+
+CREATE TABLE IF NOT EXISTS account (
+  id TEXT PRIMARY KEY NOT NULL,
+  userId TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  accountId TEXT NOT NULL,
+  providerId TEXT NOT NULL,
+  accessToken TEXT,
+  refreshToken TEXT,
+  idToken TEXT,
+  accessTokenExpiresAt TEXT,
+  refreshTokenExpiresAt TEXT,
+  scope TEXT,
+  password TEXT,
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS account_userId_idx ON account (userId);
+
+CREATE TABLE IF NOT EXISTS verification (
+  id TEXT PRIMARY KEY NOT NULL,
+  identifier TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expiresAt TEXT NOT NULL,
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS verification_identifier_idx
+  ON verification (identifier);

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,6 +580,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2662,6 +2687,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
       "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -2676,12 +2702,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/better-call/node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "license": "MIT"
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
@@ -4080,6 +4100,12 @@
         }
       }
     },
+    "node_modules/react-router/node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4188,9 +4214,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
     "node_modules/sharp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "better-auth": "^1.6.8",
         "hono": "^4.12.14",
+        "kysely": "^0.28.16",
+        "kysely-d1": "^0.4.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-router": "^7.14.2"
+        "react-router": "^7.14.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.9",
@@ -277,6 +281,141 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-YVLkvMvUDeP3W0Wl9PHgwF2etWxKL9rntP0NjZ3YXsiuf05O5Gx0BNvWSeG9fcUaAFjjkiVdFOEvpYtDPpehog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.8.tgz",
+      "integrity": "sha512-iAQ8KWPfGppcakZXStbX7aWGeK0pLlDlzkQN6NhFM7Qm2KwBcc0X1EyRGIiLSIiGw8hTNppGp8igliMm2ti0zw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.8.tgz",
+      "integrity": "sha512-Imqh8yxb/IlS8bmfsjdhcaE2vQ9ohoFXh2UY0PIsY/oWUiJ1tG8WHheNYRK2C9Chh1+b6GTq7ta3wVCD0cUEDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.14"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.8.tgz",
+      "integrity": "sha512-A/h7Y/AL7dxsff4gNizbpT+O5AppNSvcbRrkrxRrwr8/DvnajnSVxN6bqG/H+SR/L4/nJUDC0p5wMfOJSvTk8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.8.tgz",
+      "integrity": "sha512-z2NxSf890g24co33av3SqBKilP8QesNkIp27zIKRE3AqXjii4zQhN7M17DtAsGWJMH2Z336e/mypR2pYYn9DpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.8.tgz",
+      "integrity": "sha512-eyPCQwFXFgGo82acjvQpL5iPNi4h3SWhpTG6Ck0mROkqYU9H0v3lpf9vnO/EraOkB6o7VGDPmOirJNYGcFd4lQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.8.tgz",
+      "integrity": "sha512-EkYehns4SH04kGOjVJ++THnGtpjvmktF5+bGbDAanMd6IjP4O7sCaDGrT62xraj4lgj3UO1vQXpR6/M1Xlmixg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
@@ -320,6 +459,16 @@
         "@vitest/runner": "^4.1.0",
         "@vitest/snapshot": "^4.1.0",
         "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -429,31 +578,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1445,7 +1569,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1478,11 +1602,44 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1818,7 +1975,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -2108,7 +2264,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -2119,14 +2275,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2217,7 +2373,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
       "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -2235,7 +2391,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
       "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.5",
@@ -2262,7 +2418,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
       "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -2275,7 +2431,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
       "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2290,7 +2446,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
       "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2307,7 +2463,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
       "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2317,7 +2473,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
       "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.5",
@@ -2377,7 +2533,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2395,6 +2551,137 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/better-auth": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.8.tgz",
+      "integrity": "sha512-5QEDdsLdsBchmMjRWw4tm3CwMFBEGVxnbz8B7UE/4YiDow6ydU/N7HQfhSg6eOy3qvODM3i2jDblSug9YObDug==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.8",
+        "@better-auth/drizzle-adapter": "1.6.8",
+        "@better-auth/kysely-adapter": "1.6.8",
+        "@better-auth/memory-adapter": "1.6.8",
+        "@better-auth/mongo-adapter": "1.6.8",
+        "@better-auth/prisma-adapter": "1.6.8",
+        "@better-auth/telemetry": "1.6.8",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.14",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-call/node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
@@ -2463,7 +2750,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2686,7 +2973,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2727,11 +3014,17 @@
         }
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2792,7 +3085,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2851,7 +3144,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -2868,7 +3161,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -2878,7 +3171,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3067,6 +3360,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3110,11 +3413,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/kysely": {
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
+      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/kysely-d1": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.4.0.tgz",
+      "integrity": "sha512-wUcVvQNtm30OTfuo7Ad5vYJ1qHqPXOCZc+zWchVKNyuvqY3u8OuGw4gmUx1Ypdx2wRVFLHVQC9I7v0pTmF7Nkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "kysely": "*"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -3477,7 +3799,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -3569,7 +3891,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3584,6 +3906,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -3595,7 +3933,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -3629,21 +3967,21 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3656,7 +3994,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3780,7 +4118,7 @@
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
@@ -3814,7 +4152,13 @@
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
       "license": "MIT"
     },
     "node_modules/rxjs": {
@@ -3924,7 +4268,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -3974,7 +4318,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3984,14 +4328,14 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -4078,14 +4422,14 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
       "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4095,7 +4439,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4112,7 +4456,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4212,7 +4556,7 @@
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4291,7 +4635,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4382,7 +4726,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -4666,11 +5010,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,13 @@
     "wrangler": "^4.84.1"
   },
   "dependencies": {
+    "better-auth": "^1.6.8",
     "hono": "^4.12.14",
+    "kysely": "^0.28.16",
+    "kysely-d1": "^0.4.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-router": "^7.14.2"
+    "react-router": "^7.14.2",
+    "zod": "^4.3.6"
   }
 }

--- a/src/app/auth/RequireAuth.tsx
+++ b/src/app/auth/RequireAuth.tsx
@@ -1,0 +1,25 @@
+// Route-level guard. Wraps every authed /app/* route and redirects to
+// /app/login when `GET /api/v1/me` returns 401. Renders a minimal
+// loading screen during the initial session probe so we don't flash
+// the protected content to anonymous viewers.
+
+import { Navigate, Outlet } from "react-router";
+import { useSession } from "./useSession";
+
+export function RequireAuth() {
+  const { status } = useSession();
+
+  if (status === "loading") {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-[1200px] items-center justify-center">
+        <p className="font-mono text-sm text-cf-text-subtle">Checking session…</p>
+      </section>
+    );
+  }
+
+  if (status === "anonymous") {
+    return <Navigate to="/app/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/app/auth/api.ts
+++ b/src/app/auth/api.ts
@@ -1,0 +1,75 @@
+// Thin wrapper around the Better Auth HTTP API mounted at
+// /api/v1/auth/*. The SPA shares the same origin as the Worker in
+// production, so `credentials: "include"` is technically not
+// required, but being explicit is safer and future-proofs us if the
+// SPA ever moves off-origin.
+
+export interface MeResponse {
+  id: string;
+  email: string;
+  username: string | null;
+}
+
+export interface AuthError {
+  message: string;
+  code?: string;
+}
+
+async function readError(response: Response): Promise<AuthError> {
+  try {
+    const body = (await response.json()) as Partial<AuthError>;
+    if (body && typeof body.message === "string") {
+      return { message: body.message, code: body.code };
+    }
+  } catch {
+    /* fall through */
+  }
+  return {
+    message: `Request failed with status ${response.status}`,
+  };
+}
+
+export async function register(body: {
+  name: string;
+  email: string;
+  password: string;
+}): Promise<{ ok: true } | { ok: false; error: AuthError }> {
+  const response = await fetch("/api/v1/auth/sign-up/email", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  return { ok: true };
+}
+
+export async function login(body: {
+  email: string;
+  password: string;
+}): Promise<{ ok: true } | { ok: false; error: AuthError }> {
+  const response = await fetch("/api/v1/auth/sign-in/email", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  return { ok: true };
+}
+
+export async function logout(): Promise<void> {
+  await fetch("/api/v1/auth/sign-out", {
+    method: "POST",
+    credentials: "include",
+  });
+}
+
+export async function fetchMe(): Promise<MeResponse | null> {
+  const response = await fetch("/api/v1/me", { credentials: "include" });
+  if (response.status === 401) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to fetch session: ${response.status}`);
+  }
+  return (await response.json()) as MeResponse;
+}

--- a/src/app/auth/useSession.ts
+++ b/src/app/auth/useSession.ts
@@ -1,0 +1,45 @@
+// Client-side session hook. Polls `/api/v1/me` once on mount and
+// exposes `{ status, user, refresh }` so pages can render a loading
+// state, an anonymous state, or the authenticated user's data.
+//
+// Kept intentionally minimal — no SWR / react-query dependency; the
+// session is fetched at most a couple of times in a normal SPA
+// lifecycle (mount, after sign-in/out), so a plain useEffect is fine.
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchMe, type MeResponse } from "./api";
+
+export type SessionStatus = "loading" | "authed" | "anonymous";
+
+export interface UseSessionResult {
+  status: SessionStatus;
+  user: MeResponse | null;
+  refresh: () => Promise<void>;
+}
+
+export function useSession(): UseSessionResult {
+  const [status, setStatus] = useState<SessionStatus>("loading");
+  const [user, setUser] = useState<MeResponse | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const me = await fetchMe();
+      if (me) {
+        setUser(me);
+        setStatus("authed");
+      } else {
+        setUser(null);
+        setStatus("anonymous");
+      }
+    } catch {
+      setUser(null);
+      setStatus("anonymous");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { status, user, refresh };
+}

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";
 import { App } from "./App";
+import { RequireAuth } from "./auth/RequireAuth";
 import { LoginPage } from "./pages/LoginPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { DashboardPage } from "./pages/DashboardPage";
@@ -19,20 +20,23 @@ createRoot(rootElement).render(
     <BrowserRouter>
       <Routes>
         {/*
-         * Public-inside-the-SPA landing for /app. Until slice 4 ships real
-         * screens, every route below is a "not implemented yet" placeholder
-         * that shares the same chrome (<App /> shell) so the design language
-         * feels consistent end-to-end.
+         * /app is the authed SPA root. The public auth screens
+         * (/app/login, /app/register) sit directly under <App /> so
+         * anonymous users can reach them. Everything else lives behind
+         * <RequireAuth />, which redirects to /app/login when
+         * `GET /api/v1/me` returns 401.
          */}
         <Route path="/app" element={<App />}>
-          <Route index element={<DashboardPage />} />
           <Route path="login" element={<LoginPage />} />
           <Route path="register" element={<RegisterPage />} />
-          <Route path="dashboard" element={<DashboardPage />} />
-          <Route path="settings" element={<SettingsPage />} />
+          <Route element={<RequireAuth />}>
+            <Route index element={<DashboardPage />} />
+            <Route path="dashboard" element={<DashboardPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+          </Route>
         </Route>
-        {/* SPA fallback: any path the Worker let fall through to the SPA
-            that isn't one of the /app/* placeholders renders this. */}
+        {/* SPA fallback: any path the Worker let fall through to the
+            SPA that isn't one of the /app/* routes renders this. */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -1,15 +1,42 @@
-// Placeholder authed dashboard. Real content — "my watches", current
-// session drift, log-reading shortcuts — lands in the dashboard slice.
+// Authed dashboard. Reads the session via `useSession` (already
+// resolved by the RequireAuth wrapper that guards this route), so we
+// can render the username + sign-out affordance immediately without
+// a second network call.
+
+import { useNavigate } from "react-router";
+import { logout } from "../auth/api";
+import { useSession } from "../auth/useSession";
+
 export function DashboardPage() {
+  const navigate = useNavigate();
+  const { user } = useSession();
+
+  async function onLogout() {
+    await logout();
+    navigate("/app/login", { replace: true });
+  }
+
   return (
     <section>
-      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
-        Dashboard
-      </h1>
-      <p className="text-cf-text-muted max-w-[56ch]">
-        Not implemented yet. Your watches, current session drift, and
-        quick-log shortcuts appear here once the dashboard slice ships.
+      <h1 className="mb-4 text-4xl font-medium tracking-tight text-cf-text">Dashboard</h1>
+      {user ? (
+        <p className="mb-6 text-cf-text">
+          Logged in as <span className="font-mono text-cf-orange">@{user.username}</span>.
+        </p>
+      ) : (
+        <p className="mb-6 text-cf-text-muted">Loading profile…</p>
+      )}
+      <p className="mb-8 max-w-[56ch] text-cf-text-muted">
+        Your watches, current session drift, and quick-log shortcuts will appear here as
+        later slices ship.
       </p>
+      <button
+        type="button"
+        onClick={onLogout}
+        className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"
+      >
+        Sign out
+      </button>
     </section>
   );
 }

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,14 +1,81 @@
-// Placeholder login screen. Better Auth wiring lands in a later slice
-// (see PRD §auth). Slice 3 only needs this route to resolve + render
-// the shared design language so the shell feels cohesive.
+// Sign-in screen. Posts to /api/v1/auth/sign-in/email and redirects
+// to the dashboard on success. No "remember me" UI yet — Better
+// Auth's default (remember) is on, which is the right choice for a
+// hobbyist accuracy-tracking app.
+
+import { type FormEvent, useState } from "react";
+import { useNavigate, Link } from "react-router";
+import { login } from "../auth/api";
+
 export function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    const result = await login({ email, password });
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error.message);
+      return;
+    }
+    navigate("/app/dashboard", { replace: true });
+  }
+
   return (
     <section className="mx-auto max-w-md">
-      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
-        Sign in
-      </h1>
-      <p className="text-cf-text-muted">
-        Not implemented yet. The authed flow lands in an upcoming slice.
+      <h1 className="mb-6 text-4xl font-medium tracking-tight text-cf-text">Sign in</h1>
+      <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Email
+          <input
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Password
+          <input
+            type="password"
+            autoComplete="current-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+        </label>
+        {error ? (
+          <p
+            role="alert"
+            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          >
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+        >
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+      <p className="mt-6 text-sm text-cf-text-muted">
+        New here?{" "}
+        <Link to="/app/register" className="text-cf-orange hover:underline">
+          Create an account
+        </Link>
+        .
       </p>
     </section>
   );

--- a/src/app/pages/RegisterPage.tsx
+++ b/src/app/pages/RegisterPage.tsx
@@ -1,13 +1,101 @@
-// Placeholder registration screen. Better Auth sign-up + email
-// verification wiring lands in a later slice.
+// Registration screen. Posts to /api/v1/auth/sign-up/email — Better
+// Auth's default `autoSignIn` is on, so a successful sign-up already
+// yields a session cookie and we can jump straight to the dashboard.
+// The display-name input maps to Better Auth's required `name` field;
+// the slug `username` is server-generated, so we don't expose it here.
+
+import { type FormEvent, useState } from "react";
+import { useNavigate, Link } from "react-router";
+import { register } from "../auth/api";
+
 export function RegisterPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    const result = await register({ name, email, password });
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error.message);
+      return;
+    }
+    navigate("/app/dashboard", { replace: true });
+  }
+
   return (
     <section className="mx-auto max-w-md">
-      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
+      <h1 className="mb-2 text-4xl font-medium tracking-tight text-cf-text">
         Create an account
       </h1>
-      <p className="text-cf-text-muted">
-        Not implemented yet. Registration ships with the auth slice.
+      <p className="mb-6 text-cf-text-muted">
+        You'll get an auto-generated username you can rename later.
+      </p>
+      <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Display name
+          <input
+            type="text"
+            autoComplete="name"
+            required
+            minLength={1}
+            maxLength={100}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Email
+          <input
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Password
+          <input
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+        </label>
+        {error ? (
+          <p
+            role="alert"
+            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          >
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+        >
+          {submitting ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+      <p className="mt-6 text-sm text-cf-text-muted">
+        Already have an account?{" "}
+        <Link to="/app/login" className="text-cf-orange hover:underline">
+          Sign in
+        </Link>
+        .
       </p>
     </section>
   );

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,23 @@
+// Kysely factory. One place that wraps a D1 binding in a typed Kysely
+// client so handlers never call `env.DB.prepare(...)` directly — that
+// would bypass the typed query builder and is explicitly out-of-bounds
+// per AGENTS.md ("No raw `db.prepare(...)` outside the data layer").
+//
+// The Database interface lives in ./schema.ts and is the single source
+// of truth for column names + types across the app.
+
+import { Kysely } from "kysely";
+import { D1Dialect } from "kysely-d1";
+import type { Database } from "./schema";
+
+export type DB = Kysely<Database>;
+
+/**
+ * Build a Kysely client bound to the Worker's D1 database. Call this
+ * once per request; Kysely instances are cheap and stateless.
+ */
+export function createDb(env: { DB: D1Database }): DB {
+  return new Kysely<Database>({
+    dialect: new D1Dialect({ database: env.DB }),
+  });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,64 @@
+// Kysely `Database` interface matching the slice 4 init migration
+// (migrations/0001_init.sql). Column types mirror the SQL declarations;
+// SQLite has no native boolean or date types so those columns are
+// surfaced here as their storage type (integer for booleans, ISO-string
+// text for dates). Better Auth's Kysely adapter handles the marshalling
+// on its side — when our own code reads these tables (e.g. username
+// uniqueness check in src/server/auth.ts), we work with the raw types.
+//
+// Future slices extend this interface with rated.watch's own tables
+// (movement, watch, reading, …).
+
+export interface UserTable {
+  id: string;
+  name: string;
+  email: string;
+  emailVerified: number; // 0 | 1 — SQLite has no bool
+  image: string | null;
+  username: string;
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
+export interface SessionTable {
+  id: string;
+  userId: string;
+  token: string;
+  expiresAt: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AccountTable {
+  id: string;
+  userId: string;
+  accountId: string;
+  providerId: string;
+  accessToken: string | null;
+  refreshToken: string | null;
+  idToken: string | null;
+  accessTokenExpiresAt: string | null;
+  refreshTokenExpiresAt: string | null;
+  scope: string | null;
+  password: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VerificationTable {
+  id: string;
+  identifier: string;
+  value: string;
+  expiresAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Database {
+  user: UserTable;
+  session: SessionTable;
+  account: AccountTable;
+  verification: VerificationTable;
+}

--- a/src/domain/username.test.ts
+++ b/src/domain/username.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateSlugUsername } from "./username";
+
+// Collision-resistant slug generator. Format is `adjective-noun-NNN`
+// where NNN is three digits (000-999). The function takes an abstract
+// `exists(username)` check so it stays a pure domain function — the
+// Better Auth `createUser` hook plugs in a real Kysely call.
+
+describe("generateSlugUsername — format + curated words", () => {
+  it("returns a string shaped like adjective-noun-NNN", async () => {
+    const username = await generateSlugUsername({
+      exists: async () => false,
+    });
+
+    // Three lowercase hyphen-separated parts, last is exactly 3 digits.
+    expect(username).toMatch(/^[a-z]+-[a-z]+-\d{3}$/);
+  });
+
+  it("picks adjective + noun from the curated word lists", async () => {
+    // Run many times and collect unique first/second segments. Each
+    // list has ~100 entries — over 200 draws we should see at least
+    // a handful of distinct adjectives and nouns. This fires if the
+    // lists ever get truncated to a single word.
+    const adjectives = new Set<string>();
+    const nouns = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const u = await generateSlugUsername({ exists: async () => false });
+      const parts = u.split("-");
+      expect(parts).toHaveLength(3);
+      adjectives.add(parts[0]!);
+      nouns.add(parts[1]!);
+    }
+    expect(adjectives.size).toBeGreaterThan(5);
+    expect(nouns.size).toBeGreaterThan(5);
+  });
+});
+
+describe("generateSlugUsername — retry + fallback", () => {
+  it("retries when the first candidate collides, then returns a unique one", async () => {
+    let call = 0;
+    // First call says the slug exists (collision), second call says it
+    // doesn't. The returned username should therefore come from the
+    // second candidate.
+    const exists = vi.fn(async () => {
+      call += 1;
+      return call === 1;
+    });
+
+    const username = await generateSlugUsername({ exists });
+
+    expect(exists).toHaveBeenCalledTimes(2);
+    expect(username).toMatch(/^[a-z]+-[a-z]+-\d{3}$/);
+  });
+
+  it("falls back to user-<timestamp> after 5 failed retries", async () => {
+    const exists = vi.fn(async () => true); // always collides
+
+    const username = await generateSlugUsername({ exists });
+
+    expect(exists).toHaveBeenCalledTimes(5);
+    expect(username).toMatch(/^user-\d+$/);
+  });
+});

--- a/src/domain/username.ts
+++ b/src/domain/username.ts
@@ -1,0 +1,304 @@
+// Slug username generator.
+//
+// On every registration we mint an auto-generated username in the shape
+// `adjective-noun-NNN` (e.g. "fast-otter-042"). This keeps the public URLs
+// (/u/:username) human-friendly without asking the user to pick anything
+// up-front; they can rename later if we ship that feature.
+//
+// The function is pure domain logic: it takes a caller-supplied `exists`
+// probe rather than a Kysely instance so we can unit-test the retry path
+// without D1, and so the call-site in Better Auth's createUser hook
+// stays small.
+
+// Curated word lists. Chosen to be unambiguous, safe-for-work, and
+// largely single-syllable so generated usernames stay short and
+// pronounceable. Word counts are comfortably above 100 each, giving
+// ~10k adjective-noun combinations before the NNN suffix widens the
+// space to ~10m total — collision retry is therefore a rare fallback.
+const ADJECTIVES: readonly string[] = [
+  "fast",
+  "quick",
+  "swift",
+  "steady",
+  "sturdy",
+  "silent",
+  "stoic",
+  "brave",
+  "bold",
+  "calm",
+  "clever",
+  "crafty",
+  "cunning",
+  "daring",
+  "deft",
+  "eager",
+  "even",
+  "fierce",
+  "fine",
+  "firm",
+  "fluid",
+  "gentle",
+  "glad",
+  "graceful",
+  "grand",
+  "hardy",
+  "hasty",
+  "honest",
+  "humble",
+  "ideal",
+  "jovial",
+  "keen",
+  "kind",
+  "lively",
+  "loyal",
+  "lucid",
+  "lucky",
+  "merry",
+  "mighty",
+  "mild",
+  "modest",
+  "neat",
+  "nimble",
+  "noble",
+  "patient",
+  "plucky",
+  "polite",
+  "precise",
+  "proud",
+  "prudent",
+  "quiet",
+  "ready",
+  "ruddy",
+  "shiny",
+  "sharp",
+  "sleek",
+  "snug",
+  "sober",
+  "solid",
+  "sound",
+  "spry",
+  "stable",
+  "strong",
+  "subtle",
+  "sunny",
+  "tame",
+  "taut",
+  "terse",
+  "tidy",
+  "tireless",
+  "trusty",
+  "warm",
+  "wise",
+  "witty",
+  "zealous",
+  "amber",
+  "azure",
+  "copper",
+  "crimson",
+  "golden",
+  "iron",
+  "ivory",
+  "jade",
+  "onyx",
+  "pearl",
+  "ruby",
+  "silver",
+  "vivid",
+  "agile",
+  "bright",
+  "candid",
+  "earnest",
+  "frank",
+  "robust",
+  "shrewd",
+  "staunch",
+  "steadfast",
+  "tenacious",
+  "upright",
+  "valiant",
+  "vigilant",
+  "zesty",
+  "adept",
+  "astute",
+  "canny",
+  "dashing",
+  "glowing",
+  "hale",
+  "lithe",
+  "poised",
+  "radiant",
+  "rugged",
+  "savvy",
+  "serene",
+  "intrepid",
+  "mellow",
+  "nifty",
+  "regal",
+  "sprightly",
+  "gallant",
+  "buoyant",
+  "chipper",
+  "dapper",
+  "earthy",
+  "fleet",
+  "genial",
+  "jaunty",
+];
+
+const NOUNS: readonly string[] = [
+  "otter",
+  "falcon",
+  "hawk",
+  "eagle",
+  "sparrow",
+  "robin",
+  "owl",
+  "raven",
+  "crow",
+  "heron",
+  "puffin",
+  "gull",
+  "tern",
+  "swan",
+  "goose",
+  "duck",
+  "stork",
+  "crane",
+  "ibis",
+  "lark",
+  "wren",
+  "finch",
+  "magpie",
+  "kestrel",
+  "osprey",
+  "merlin",
+  "hornet",
+  "beetle",
+  "cricket",
+  "firefly",
+  "moth",
+  "dragonfly",
+  "mantis",
+  "anchor",
+  "arbor",
+  "atlas",
+  "axis",
+  "beacon",
+  "bramble",
+  "breeze",
+  "brook",
+  "canyon",
+  "cedar",
+  "clover",
+  "comet",
+  "cove",
+  "crest",
+  "delta",
+  "dune",
+  "ember",
+  "fjord",
+  "forge",
+  "frost",
+  "glacier",
+  "grove",
+  "harbor",
+  "isle",
+  "lantern",
+  "lattice",
+  "meadow",
+  "mesa",
+  "mirror",
+  "mountain",
+  "oak",
+  "orbit",
+  "peak",
+  "pebble",
+  "pine",
+  "plume",
+  "prairie",
+  "quartz",
+  "reed",
+  "ridge",
+  "river",
+  "rune",
+  "sable",
+  "sage",
+  "shore",
+  "spruce",
+  "stone",
+  "summit",
+  "tide",
+  "timber",
+  "valley",
+  "willow",
+  "zenith",
+  "badger",
+  "beaver",
+  "bison",
+  "cougar",
+  "coyote",
+  "deer",
+  "ferret",
+  "fox",
+  "gecko",
+  "hare",
+  "heifer",
+  "ibex",
+  "jackal",
+  "lynx",
+  "marten",
+  "moose",
+  "panda",
+  "puma",
+  "rabbit",
+  "raccoon",
+  "stoat",
+  "wolf",
+  "wolverine",
+  "yak",
+];
+
+const MAX_RETRIES = 5;
+
+/**
+ * Dependency shape the generator needs. An existence probe is enough;
+ * the caller decides whether to ask Kysely, a mock, or something else.
+ */
+export interface SlugUsernameDeps {
+  exists(username: string): Promise<boolean>;
+}
+
+function pickRandom<T>(list: readonly T[]): T {
+  // Word lists are non-empty constants above. Assert + fallback keeps
+  // TypeScript's noUncheckedIndexedAccess happy without a cast.
+  if (list.length === 0) throw new Error("word list must be non-empty");
+  const idx = Math.floor(Math.random() * list.length);
+  return list[idx]!;
+}
+
+function formatNumber(n: number): string {
+  return n.toString().padStart(3, "0");
+}
+
+function makeCandidate(): string {
+  const adjective = pickRandom(ADJECTIVES);
+  const noun = pickRandom(NOUNS);
+  const suffix = formatNumber(Math.floor(Math.random() * 1000));
+  return `${adjective}-${noun}-${suffix}`;
+}
+
+/**
+ * Generate a unique slug username. Retries up to MAX_RETRIES times if a
+ * candidate collides with an existing user. After that many collisions
+ * we fall back to `user-<unix-ms>` — globally unique in practice because
+ * D1 is single-writer per request and Date.now() advances monotonically.
+ */
+export async function generateSlugUsername(deps: SlugUsernameDeps): Promise<string> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const candidate = makeCandidate();
+    if (!(await deps.exists(candidate))) {
+      return candidate;
+    }
+  }
+  return `user-${Date.now()}`;
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -15,7 +15,13 @@ import { betterAuth } from "better-auth";
 import { createDb } from "@/db";
 import { generateSlugUsername } from "@/domain/username";
 
-export type Auth = ReturnType<typeof betterAuth>;
+// We keep `Auth` a loose alias of betterAuth's return type. Using
+// `ReturnType<typeof betterAuth>` directly was flaky: tsc kept
+// widening the options generic so the cached value didn't assign back.
+// `any` on the generic arg lets consumers hold a reference without
+// fighting the generic.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Auth = ReturnType<typeof betterAuth<any>>;
 
 // Narrow env shape we need. Keeps the module unit-testable without
 // pulling in the entire generated Cloudflare Env.
@@ -30,7 +36,7 @@ export function getAuth(env: AuthEnv): Auth {
   const cached = cache.get(env);
   if (cached) return cached;
 
-  const auth = betterAuth({
+  const auth: Auth = betterAuth({
     // Secret used for cookie signing. Provided via Worker secret in
     // production; the test harness seeds a high-entropy value via
     // miniflare bindings (see vitest.config.ts).

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,95 @@
+// Better Auth configuration for rated.watch.
+//
+// Slice 4 wires email + password only. OAuth providers arrive in slice
+// 5. The D1 binding is passed as the `database` value; Better Auth's
+// Kysely adapter auto-detects it by shape (batch + exec + prepare) and
+// builds its own D1SqliteDialect internally — see
+// node_modules/@better-auth/kysely-adapter/dist/index.mjs.
+//
+// Because the D1 binding is per-request, the Better Auth instance
+// itself is built per-request too. `getAuth(env)` memoises per-env so
+// a single Worker request only pays the wiring cost once even if
+// several middlewares call it.
+
+import { betterAuth } from "better-auth";
+import { createDb } from "@/db";
+import { generateSlugUsername } from "@/domain/username";
+
+export type Auth = ReturnType<typeof betterAuth>;
+
+// Narrow env shape we need. Keeps the module unit-testable without
+// pulling in the entire generated Cloudflare Env.
+export interface AuthEnv {
+  DB: D1Database;
+  BETTER_AUTH_SECRET: string;
+}
+
+const cache = new WeakMap<AuthEnv, Auth>();
+
+export function getAuth(env: AuthEnv): Auth {
+  const cached = cache.get(env);
+  if (cached) return cached;
+
+  const auth = betterAuth({
+    // Secret used for cookie signing. Provided via Worker secret in
+    // production; the test harness seeds a high-entropy value via
+    // miniflare bindings (see vitest.config.ts).
+    secret: env.BETTER_AUTH_SECRET,
+    // Auth API is mounted under the versioned API path alongside the
+    // rest of our app's v1 endpoints.
+    basePath: "/api/v1/auth",
+    // D1 binding. Better Auth's Kysely adapter auto-detects the D1
+    // shape and builds a SqliteDialect for it.
+    database: env.DB,
+    // In Workers we always cross HTTPS, and SPA/API share the same
+    // origin, so Lax is safe and strict-enough to protect against
+    // CSRF. No need to relax cookies for cross-subdomain here.
+    advanced: {
+      defaultCookieAttributes: {
+        sameSite: "lax",
+        secure: true,
+      },
+    },
+    emailAndPassword: {
+      enabled: true,
+    },
+    user: {
+      // Custom `username` slug on the user row. `input: false` keeps
+      // clients from setting it during sign-up; the before-create hook
+      // below always overwrites it with a unique server-minted value.
+      // `required: false` at the API level — the database column is
+      // NOT NULL (migrations/0001_init.sql) and the hook guarantees
+      // every user row gets one.
+      additionalFields: {
+        username: {
+          type: "string",
+          required: false,
+          input: false,
+        },
+      },
+    },
+    databaseHooks: {
+      user: {
+        create: {
+          before: async (user) => {
+            const db = createDb(env);
+            const username = await generateSlugUsername({
+              exists: async (candidate) => {
+                const row = await db
+                  .selectFrom("user")
+                  .select("id")
+                  .where("username", "=", candidate)
+                  .executeTakeFirst();
+                return row !== undefined;
+              },
+            });
+            return { data: { ...user, username } };
+          },
+        },
+      },
+    },
+  });
+
+  cache.set(env, auth);
+  return auth;
+}

--- a/src/server/middleware/require-auth.ts
+++ b/src/server/middleware/require-auth.ts
@@ -1,0 +1,49 @@
+// Session gate. Loads the Better Auth session (cookie or bearer token)
+// and sets `c.var.user` + `c.var.session`. On miss it returns a 401
+// JSON response so API consumers (the SPA, the future Expo client)
+// can uniformly treat "not authed" as an error shape.
+//
+// The middleware is generic over the bindings because different routes
+// may have different Env extensions, but all of them must carry the
+// Better Auth prerequisites (DB + BETTER_AUTH_SECRET).
+
+import type { MiddlewareHandler } from "hono";
+import { getAuth, type Auth, type AuthEnv } from "@/server/auth";
+
+type SessionUser =
+  ReturnType<Auth["api"]["getSession"]> extends Promise<infer R>
+    ? R extends null
+      ? never
+      : R extends { user: infer U }
+        ? U
+        : never
+    : never;
+
+type SessionObject =
+  ReturnType<Auth["api"]["getSession"]> extends Promise<infer R>
+    ? R extends null
+      ? never
+      : R extends { session: infer S }
+        ? S
+        : never
+    : never;
+
+export interface RequireAuthVariables {
+  user: SessionUser;
+  session: SessionObject;
+}
+
+export const requireAuth: MiddlewareHandler<{
+  Bindings: AuthEnv & { [key: string]: unknown };
+  Variables: RequireAuthVariables;
+}> = async (c, next) => {
+  const auth = getAuth(c.env);
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  if (!session) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  c.set("user", session.user as SessionUser);
+  c.set("session", session.session as SessionObject);
+  await next();
+  return;
+};

--- a/src/server/routes/me.ts
+++ b/src/server/routes/me.ts
@@ -1,0 +1,38 @@
+// GET /api/v1/me — "who am I" probe used by the SPA's auth gate.
+//
+// Returns `{ id, email, username }` on 200 for an authenticated
+// request, or 401 JSON on an unauthenticated one. Session is resolved
+// from Better Auth (cookie by default; also works with Authorization:
+// Bearer <token> because Better Auth's session lookup honours both).
+
+import { Hono } from "hono";
+import { getAuth, type AuthEnv } from "@/server/auth";
+import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
+
+type Bindings = AuthEnv & { [key: string]: unknown };
+
+export const meRoute = new Hono<{
+  Bindings: Bindings;
+  Variables: RequireAuthVariables;
+}>();
+
+meRoute.use("*", requireAuth);
+
+meRoute.get("/", (c) => {
+  const user = c.get("user");
+  // Better Auth's additionalFields appear on the user object at
+  // runtime. Type them narrowly for the JSON payload we expose to
+  // the SPA; the full user may carry more fields we don't want to
+  // leak (timestamps, email verification flag, etc.) in a later slice.
+  const payload = {
+    id: user.id,
+    email: user.email,
+    username: (user as { username?: string }).username ?? null,
+  };
+  return c.json(payload);
+});
+
+// Re-export so the worker can mount the route without importing the
+// getAuth helper directly (keeps the auth module as a leaf dep of
+// the worker entry).
+export { getAuth };

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -1,15 +1,37 @@
 // Worker entry. Composes the Hono app from the route modules.
 //
-// Slice 1 only serves the server-rendered landing page. Future slices will add
-// the API surface under /api/*, more public pages (/leaderboard, /m/:id,
-// /u/:name, /w/:id), and the authed SPA fall-through via the ASSETS binding.
+// Slice 4 adds the auth surface at /api/v1/auth/* (handed off to Better
+// Auth verbatim) and the `requireAuth`-gated /api/v1/me endpoint. The
+// landing page at `/` is unchanged from slice 3.
 import { Hono } from "hono";
 import { LandingPage } from "@/public/landing";
+import { getAuth, type AuthEnv } from "@/server/auth";
+import { meRoute } from "@/server/routes/me";
 
-const app = new Hono();
+// The Worker's full env extends the narrower AuthEnv used by getAuth.
+type Bindings = AuthEnv & {
+  // Keep the rest untyped here — the generated Cloudflare.Env
+  // already provides full shape information for the other bindings
+  // when a handler reaches for them.
+  [key: string]: unknown;
+};
+
+const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/", (c) => {
   return c.html(<LandingPage />);
 });
+
+// Better Auth owns every method under /api/v1/auth/*. We pass the raw
+// Request straight through — Better Auth reads method, URL, headers,
+// and body directly off it.
+app.all("/api/v1/auth/*", (c) => {
+  const auth = getAuth(c.env);
+  return auth.handler(c.req.raw);
+});
+
+// App API surface. Currently just the "who am I" probe used by the
+// SPA's auth gate; later slices add watches/readings/movements here.
+app.route("/api/v1/me", meRoute);
 
 export default app;

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,0 +1,67 @@
+import { exports } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+// Auth integration tests. These run against the real Better Auth
+// instance mounted at /api/v1/auth/*, with a real D1 backing store
+// (miniflare's local SQLite) populated by migrations/0001_init.sql
+// via the setup in tests/integration/setup/apply-migrations.ts.
+
+// Unique email per call so tests can run isolated even when the D1
+// store isn't reset between them (vitest-pool-workers provides per-test
+// storage isolation, but being explicit makes failures easier to read).
+function makeEmail(prefix = "test"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function register(body: {
+  email: string;
+  password: string;
+  name?: string;
+}): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: body.name ?? body.email.split("@")[0]!,
+        email: body.email,
+        password: body.password,
+      }),
+    }),
+  );
+}
+
+describe("POST /api/v1/auth/sign-up/email — happy path", () => {
+  it("creates a user with a generated slug username", async () => {
+    const email = makeEmail();
+    const response = await register({ email, password: "correct-horse-42" });
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      user: { id: string; email: string; username: string };
+    };
+
+    expect(data.user.email).toBe(email);
+    expect(data.user.id).toBeTruthy();
+    // Generated slug shape: adjective-noun-NNN.
+    expect(data.user.username).toMatch(/^[a-z]+-[a-z]+-\d{3}$/);
+  });
+
+  it("assigns different usernames to different users", async () => {
+    const a = await register({
+      email: makeEmail("a"),
+      password: "correct-horse-42",
+    });
+    const b = await register({
+      email: makeEmail("b"),
+      password: "correct-horse-42",
+    });
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+
+    const aData = (await a.json()) as { user: { username: string } };
+    const bData = (await b.json()) as { user: { username: string } };
+
+    expect(aData.user.username).not.toBe(bData.user.username);
+  });
+});

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,6 +1,22 @@
 import { exports } from "cloudflare:workers";
 import { describe, it, expect } from "vitest";
 
+async function login(body: { email: string; password: string }): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function me(headers: HeadersInit = {}): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/me", { headers }),
+  );
+}
+
 // Auth integration tests. These run against the real Better Auth
 // instance mounted at /api/v1/auth/*, with a real D1 backing store
 // (miniflare's local SQLite) populated by migrations/0001_init.sql
@@ -63,5 +79,86 @@ describe("POST /api/v1/auth/sign-up/email — happy path", () => {
     const bData = (await b.json()) as { user: { username: string } };
 
     expect(aData.user.username).not.toBe(bData.user.username);
+  });
+});
+
+describe("POST /api/v1/auth/sign-up/email — duplicate email", () => {
+  it("rejects a second registration with the same email", async () => {
+    const email = makeEmail("dup");
+    const first = await register({ email, password: "correct-horse-42" });
+    expect(first.status).toBe(200);
+
+    const second = await register({ email, password: "correct-horse-42" });
+    // Better Auth's default behaviour (autoSignIn + no
+    // requireEmailVerification) returns a 4xx with a friendly error
+    // code. The exact status is 422, but we assert the "not a 2xx"
+    // shape so we don't couple the test to an implementation detail
+    // that Better Auth could tweak in a minor release.
+    expect(second.status).toBeGreaterThanOrEqual(400);
+    expect(second.status).toBeLessThan(500);
+    const body = (await second.json()) as { message?: string };
+    expect(body.message?.toLowerCase() ?? "").toMatch(/already|exist|use/);
+  });
+});
+
+describe("POST /api/v1/auth/sign-in/email", () => {
+  it("issues a session cookie on valid credentials", async () => {
+    const email = makeEmail("login");
+    const password = "correct-horse-42";
+    await register({ email, password });
+
+    const response = await login({ email, password });
+    expect(response.status).toBe(200);
+    // Better Auth sets its session cookie via Set-Cookie on 200.
+    const setCookie = response.headers.get("set-cookie");
+    expect(setCookie).not.toBeNull();
+    // The cookie name is prefixed with "better-auth." by default.
+    expect(setCookie!.toLowerCase()).toContain("better-auth.session");
+  });
+
+  it("returns 401 on wrong password", async () => {
+    const email = makeEmail("badpw");
+    await register({ email, password: "correct-horse-42" });
+
+    const response = await login({ email, password: "wrong-password-00" });
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("GET /api/v1/me", () => {
+  it("returns 401 JSON when unauthenticated", async () => {
+    const response = await me();
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("returns { id, email, username } when authenticated", async () => {
+    const email = makeEmail("me");
+    const password = "correct-horse-42";
+    const reg = await register({ email, password });
+    expect(reg.status).toBe(200);
+    const regBody = (await reg.json()) as {
+      user: { id: string; email: string; username: string };
+    };
+
+    // Sign in to get a fresh session cookie — register typically also
+    // returns one (autoSignIn), but replaying /me via the sign-in
+    // cookie matches what the real SPA does.
+    const loginRes = await login({ email, password });
+    expect(loginRes.status).toBe(200);
+    const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+    const cookie = rawCookie.split(";")[0] ?? "";
+
+    const response = await me({ cookie });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      id: string;
+      email: string;
+      username: string;
+    };
+    expect(body.id).toBe(regBody.user.id);
+    expect(body.email).toBe(email);
+    expect(body.username).toBe(regBody.user.username);
   });
 });

--- a/tests/integration/setup/apply-migrations.ts
+++ b/tests/integration/setup/apply-migrations.ts
@@ -1,0 +1,15 @@
+// vitest setup file. Runs once per worker before any test file.
+//
+// `applyD1Migrations` is idempotent — it only applies migrations that
+// haven't already been recorded in D1's internal `d1_migrations`
+// table, so re-running inside miniflare's per-test storage isolation
+// is safe.
+
+import { applyD1Migrations, env } from "cloudflare:test";
+
+const ambient = env as {
+  DB: D1Database;
+  TEST_MIGRATIONS: D1Migration[];
+};
+
+await applyD1Migrations(ambient.DB, ambient.TEST_MIGRATIONS);

--- a/tests/integration/setup/apply-migrations.ts
+++ b/tests/integration/setup/apply-migrations.ts
@@ -5,9 +5,12 @@
 // table, so re-running inside miniflare's per-test storage isolation
 // is safe.
 
-import { applyD1Migrations, env } from "cloudflare:test";
+import { applyD1Migrations, env, type D1Migration } from "cloudflare:test";
 
-const ambient = env as {
+// The wrangler-generated `Env` only covers real Worker bindings; our
+// TEST_MIGRATIONS binding is a miniflare-only extension declared in
+// vitest.config.ts, so narrow the env through unknown.
+const ambient = env as unknown as {
   DB: D1Database;
   TEST_MIGRATIONS: D1Migration[];
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
-    "types": ["@cloudflare/vitest-pool-workers"],
+    "types": ["@cloudflare/vitest-pool-workers", "@cloudflare/vitest-pool-workers/types"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,38 +1,60 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 const srcDir = path.resolve(process.cwd(), "./src");
+const migrationsDir = path.resolve(process.cwd(), "./migrations");
 
-export default defineConfig({
-  plugins: [
-    cloudflareTest({
-      wrangler: { configPath: "./wrangler.jsonc" },
-    }),
-  ],
-  resolve: {
-    alias: { "@": srcDir },
-  },
-  test: {
-    include: ["tests/integration/**/*.test.ts", "src/**/*.test.ts"],
-    exclude: ["tests/e2e/**", "node_modules/**", "dist/**", ".wrangler/**"],
-    coverage: {
-      // Istanbul (source instrumentation) works with workerd; v8 requires
-      // a Node inspector Session that the Workers pool does not expose.
-      provider: "istanbul",
-      reporter: ["text", "html", "json-summary"],
-      reportsDirectory: "./coverage",
-      exclude: [
-        "node_modules/**",
-        "dist/**",
-        ".wrangler/**",
-        "coverage/**",
-        "tests/e2e/**",
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.config.{ts,mjs,js}",
-        "worker-configuration.d.ts",
-      ],
+// vitest-pool-workers spins up a miniflare Worker per test run; we
+// pipe the Better Auth SQL migrations in via readD1Migrations() and
+// apply them in a setup file (tests/integration/setup/apply-migrations.ts)
+// so every test file sees a schema-initialised D1 database. The test
+// pool provides per-test-file storage isolation so no explicit reset
+// is needed between files.
+export default defineConfig(async () => {
+  const migrations = await readD1Migrations(migrationsDir);
+
+  return {
+    plugins: [
+      cloudflareTest({
+        wrangler: { configPath: "./wrangler.jsonc" },
+        miniflare: {
+          bindings: {
+            // Secret used by Better Auth in tests. Matches the shape
+            // the Worker expects; production secrets come from
+            // `wrangler secret put BETTER_AUTH_SECRET`.
+            BETTER_AUTH_SECRET: "test-better-auth-secret-please-change-in-prod-32chars",
+            TEST_MIGRATIONS: migrations,
+          },
+        },
+      }),
+    ],
+    resolve: {
+      alias: { "@": srcDir },
     },
-  },
+    test: {
+      include: ["tests/integration/**/*.test.ts", "src/**/*.test.ts"],
+      exclude: ["tests/e2e/**", "node_modules/**", "dist/**", ".wrangler/**"],
+      setupFiles: ["./tests/integration/setup/apply-migrations.ts"],
+      coverage: {
+        // Istanbul (source instrumentation) works with workerd; v8
+        // requires a Node inspector Session that the Workers pool
+        // does not expose.
+        provider: "istanbul",
+        reporter: ["text", "html", "json-summary"],
+        reportsDirectory: "./coverage",
+        exclude: [
+          "node_modules/**",
+          "dist/**",
+          ".wrangler/**",
+          "coverage/**",
+          "tests/e2e/**",
+          "**/*.test.ts",
+          "**/*.test.tsx",
+          "**/*.config.{ts,mjs,js}",
+          "worker-configuration.d.ts",
+        ],
+      },
+    },
+  };
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineConfig, type ViteUserConfig } from "vitest/config";
 import path from "node:path";
 
 const srcDir = path.resolve(process.cwd(), "./src");
@@ -11,10 +11,10 @@ const migrationsDir = path.resolve(process.cwd(), "./migrations");
 // so every test file sees a schema-initialised D1 database. The test
 // pool provides per-test-file storage isolation so no explicit reset
 // is needed between files.
-export default defineConfig(async () => {
+export default defineConfig(async (_env): Promise<ViteUserConfig> => {
   const migrations = await readD1Migrations(migrationsDir);
 
-  return {
+  const config: ViteUserConfig = {
     plugins: [
       cloudflareTest({
         wrangler: { configPath: "./wrangler.jsonc" },
@@ -57,4 +57,5 @@ export default defineConfig(async () => {
       },
     },
   };
+  return config;
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,7 +29,12 @@
     {
       "binding": "DB",
       "database_name": "rated-watch-db",
-      "database_id": "476d116f-b684-4f23-bdfb-119ad08f1e55"
+      "database_id": "476d116f-b684-4f23-bdfb-119ad08f1e55",
+      // Schema lives in ./migrations. `wrangler d1 migrations apply` and
+      // vitest-pool-workers' readD1Migrations() both read from this
+      // directory. Files are numbered (0001_…, 0002_…, …) and applied
+      // in lexical order.
+      "migrations_dir": "./migrations"
     }
   ],
   "r2_buckets": [


### PR DESCRIPTION
Closes #5.

## Summary

Slice 4 wires Better Auth on D1 via Kysely, backs sign-up with a curated slug-username generator, and replaces the SPA's auth placeholder pages with working forms.

## What shipped

### Backend (Worker)
- **`migrations/0001_init.sql`** — Canonical Better Auth tables (`user`, `session`, `account`, `verification`) plus a case-insensitive unique `username` column on `user`. `migrations_dir: ./migrations` added to the D1 binding in `wrangler.jsonc`.
- **`src/db/`** — `createDb(env)` factory returning `Kysely<Database>` via `kysely-d1`, with the Database interface as single source of truth.
- **`src/domain/username.ts`** — Pure `generateSlugUsername({ exists })` with ~110 adjectives × ~110 nouns × 1000 suffixes ≈ 12M unique slugs. Retries up to 5 times on collision; falls back to `user-<unix-ms>`.
- **`src/server/auth.ts`** — Better Auth instance with `basePath: /api/v1/auth`, email+password, a `user.additionalFields.username` (server-generated, `input: false`), and a `databaseHooks.user.create.before` hook that calls `generateSlugUsername` with a Kysely probe. Instance is cached per-`env` via a `WeakMap`.
- **`src/server/middleware/require-auth.ts`** — Hono middleware reading the Better Auth session (cookie or bearer); sets `c.var.user` + `c.var.session`, returns `{ error: "unauthorized" }` 401 JSON on miss.
- **`src/server/routes/me.ts`** — `GET /api/v1/me` returns `{ id, email, username }` for the authed user.
- **`src/worker/index.tsx`** — Mounts `/api/v1/auth/*` onto Better Auth's handler and `/api/v1/me` under the middleware.

### SPA (`src/app/`)
- **`auth/api.ts`** — Thin `fetch` wrappers with `credentials: "include"` (future-proofs against an off-origin SPA split).
- **`auth/useSession.ts`** — Hook that resolves `{ status, user, refresh }` from `/api/v1/me`.
- **`auth/RequireAuth.tsx`** — Router-level gate that redirects to `/app/login` on 401.
- **`pages/RegisterPage.tsx`** — Display-name + email + password form → `/app/dashboard` on success.
- **`pages/LoginPage.tsx`** — Email + password form, same success redirect.
- **`pages/DashboardPage.tsx`** — Reads the session, shows `@username`, POSTs to `sign-out` on click.
- **`main.tsx`** — Puts `/app/login` and `/app/register` at the shell level and wraps the other `/app/*` routes in `<RequireAuth />`.

### Test harness
- **`tests/integration/setup/apply-migrations.ts`** — Setup file that runs `applyD1Migrations` via miniflare's `TEST_MIGRATIONS` binding.
- **`vitest.config.ts`** — Reads the migrations dir with `readD1Migrations`, pipes them in via miniflare bindings, and seeds a deterministic test `BETTER_AUTH_SECRET` so tests don't depend on a local `.dev.vars`.

### Tests added (11 new, 29 total)
- Unit (`src/domain/username.test.ts`, 4 tests): slug format, curated-list breadth, retry-on-collision mock, fallback after 5 collisions.
- Integration (`tests/integration/auth.test.ts`, 7 tests): sign-up happy path + unique usernames, duplicate-email rejection, login cookie issuance, login wrong password → 401, `/me` 401 without session, `/me` 200 with `{ id, email, username }` via the sign-in cookie.

All 29 tests + `npm run typecheck` + `npm run build` green locally.

## Deviations from the issue

- **Playwright E2E deferred to slice 22b** per the orchestrator brief. The integration suite already exercises every code path the smoke test would touch. A `<!-- e2e smoke: covered by slice 22b -->` stays in scope for that slice.
- **`BETTER_AUTH_URL` warning at test time** — Better Auth logs `[better-auth] Base URL could not be determined` during tests. This is informational only (callbacks/redirects use it; our tests don't). Setting it in CI/prod is trivial but deferred to avoid coupling to a specific public hostname before slice 2's domain wiring is verified end-to-end.

## Production secret setup (operator action required)

Before the next `wrangler deploy`, run:

\`\`\`bash
# Generate a fresh 32-byte high-entropy secret and register it.
openssl rand -base64 32 | wrangler secret put BETTER_AUTH_SECRET
\`\`\`

Local dev reads from `.dev.vars` (gitignored); CI seeds a dedicated test value via miniflare. Documented in `AGENTS.md` under the Secrets section.

## Follow-ups

- OAuth sign-in (GitHub / Google) — slice 5.
- Playwright smoke — slice 22b.
- Rename-your-username UI — later slice (DB column is already case-insensitive unique so the path is open).
- `BETTER_AUTH_URL` wiring once a public hostname is locked.