### PR TITLE
Slice 6: Profile — rename username

### DIFF
--- a/src/app/auth/api.ts
+++ b/src/app/auth/api.ts
@@ -73,3 +73,81 @@ export async function fetchMe(): Promise<MeResponse | null> {
   }
   return (await response.json()) as MeResponse;
 }
+
+/**
+ * Result of a profile update. `field_errors` is the per-field
+ * validation map returned by the API (the shape produced by
+ * `formatUpdateMeErrors` on the server). `code` maps the API's
+ * discriminated error:
+ *   - `"username_taken"` — 409, a different user already owns that name
+ *   - `"invalid_input"`  — 400, one or more fieldErrors present
+ *   - `"unauthorized"`   — 401, session expired
+ *   - `"unknown"`        — anything else
+ */
+export type UpdateMeErrorCode =
+  | "username_taken"
+  | "invalid_input"
+  | "unauthorized"
+  | "unknown";
+
+export interface UpdateMeError {
+  code: UpdateMeErrorCode;
+  message: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export async function updateMe(body: {
+  username: string;
+}): Promise<{ ok: true; user: MeResponse } | { ok: false; error: UpdateMeError }> {
+  const response = await fetch("/api/v1/me", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (response.ok) {
+    const user = (await response.json()) as MeResponse;
+    return { ok: true, user };
+  }
+
+  // The API returns { error, fieldErrors? }; map it into the shape
+  // the form consumes.
+  let parsed: { error?: string; fieldErrors?: Record<string, string> } = {};
+  try {
+    parsed = (await response.json()) as typeof parsed;
+  } catch {
+    /* non-JSON body (rare) — fall through to the unknown error */
+  }
+  if (response.status === 409 && parsed.error === "username_taken") {
+    return {
+      ok: false,
+      error: {
+        code: "username_taken",
+        message: "That username is already taken",
+        fieldErrors: { username: "That username is already taken" },
+      },
+    };
+  }
+  if (response.status === 400 && parsed.error === "invalid_input") {
+    const fieldErrors = parsed.fieldErrors ?? {};
+    const firstMsg =
+      fieldErrors.username ?? Object.values(fieldErrors)[0] ?? "Invalid input";
+    return {
+      ok: false,
+      error: { code: "invalid_input", message: firstMsg, fieldErrors },
+    };
+  }
+  if (response.status === 401) {
+    return {
+      ok: false,
+      error: { code: "unauthorized", message: "Your session has expired" },
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      code: "unknown",
+      message: `Request failed with status ${response.status}`,
+    },
+  };
+}

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -1,15 +1,154 @@
-// Placeholder settings screen. Profile, privacy toggles, email, and
-// account deletion controls land in a later slice.
+// Settings screen. Current slice only lets the user rename their
+// username; email change, password change, and account deletion land
+// in later (currently unplanned) slices.
+//
+// The form validates client-side with the same `updateMeSchema` used
+// by the server, so inline errors match what the API would return
+// and we avoid a round-trip for obviously-bad input. Server-side
+// errors (duplicate username, invalid input we somehow let through,
+// expired session) are surfaced beneath the field too.
+
+import { type FormEvent, useEffect, useState } from "react";
+import { updateMeSchema, formatUpdateMeErrors } from "@/schemas/user";
+import { updateMe } from "../auth/api";
+import { useSession } from "../auth/useSession";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string };
+
 export function SettingsPage() {
+  const { status: sessionStatus, user, refresh } = useSession();
+  const [username, setUsername] = useState("");
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  // Pre-fill the editable username input once the session resolves.
+  // We only sync when the backing user changes, so subsequent edits
+  // aren't clobbered by re-renders.
+  useEffect(() => {
+    if (user?.username) {
+      setUsername(user.username);
+    }
+  }, [user?.username]);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFieldError(null);
+
+    // Client-side validation against the shared Zod schema.
+    const parsed = updateMeSchema.safeParse({ username });
+    if (!parsed.success) {
+      const errors = formatUpdateMeErrors(parsed.error);
+      setFieldError(errors.username ?? "Invalid username");
+      setStatus({ kind: "idle" });
+      return;
+    }
+
+    setStatus({ kind: "submitting" });
+    const result = await updateMe({ username: parsed.data.username });
+    if (!result.ok) {
+      const fieldMsg = result.error.fieldErrors?.username;
+      if (fieldMsg) {
+        setFieldError(fieldMsg);
+        setStatus({ kind: "idle" });
+        return;
+      }
+      setStatus({ kind: "error", message: result.error.message });
+      return;
+    }
+
+    // Show the server-confirmed username (trimmed to match server
+    // behaviour) and refresh the session so the dashboard reflects
+    // the change on next navigation.
+    setUsername(result.user.username ?? parsed.data.username);
+    setStatus({ kind: "success", message: "Username updated" });
+    void refresh();
+  }
+
   return (
     <section className="mx-auto max-w-2xl">
-      <h1 className="text-4xl font-medium tracking-tight text-cf-text mb-4">
-        Settings
-      </h1>
-      <p className="text-cf-text-muted">
-        Not implemented yet. Profile and privacy controls ship with the
-        settings slice.
-      </p>
+      <h1 className="mb-6 text-4xl font-medium tracking-tight text-cf-text">Settings</h1>
+
+      <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Email
+          <input
+            type="email"
+            readOnly
+            value={user?.email ?? ""}
+            className="rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2 font-sans text-base text-cf-text-muted outline-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+          Username
+          <input
+            type="text"
+            name="username"
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            required
+            minLength={2}
+            maxLength={30}
+            disabled={sessionStatus !== "authed" || status.kind === "submitting"}
+            value={username}
+            onChange={(event) => {
+              setUsername(event.target.value);
+              if (fieldError) setFieldError(null);
+              if (status.kind === "success" || status.kind === "error") {
+                setStatus({ kind: "idle" });
+              }
+            }}
+            aria-invalid={fieldError ? true : undefined}
+            aria-describedby={fieldError ? "username-error" : undefined}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+          {fieldError ? (
+            <span id="username-error" role="alert" className="text-sm text-cf-orange">
+              {fieldError}
+            </span>
+          ) : (
+            <span className="text-sm text-cf-text-muted">
+              2–30 characters. Letters, numbers, <code>_</code>, <code>.</code>,{" "}
+              <code>-</code>.
+            </span>
+          )}
+        </label>
+
+        {status.kind === "error" ? (
+          <p
+            role="alert"
+            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          >
+            {status.message}
+          </p>
+        ) : null}
+        {status.kind === "success" ? (
+          <p
+            role="status"
+            className="rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2 text-sm text-cf-text"
+          >
+            {status.message}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={
+            sessionStatus !== "authed" ||
+            status.kind === "submitting" ||
+            username.trim() === (user?.username ?? "")
+          }
+          className="mt-2 inline-flex items-center justify-center self-start rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+        >
+          {status.kind === "submitting" ? "Saving…" : "Save changes"}
+        </button>
+      </form>
     </section>
   );
 }

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -1,0 +1,48 @@
+// Shared Zod schemas for user-profile mutations. Imported by both the
+// API route (src/server/routes/me.ts) and the SPA settings form
+// (src/app/pages/SettingsPage.tsx) so the two sides always agree on
+// the validation rules — the PRD and AGENTS.md both require Zod as the
+// source of truth at every boundary.
+//
+// Error messages are written as human-readable strings rather than
+// the default Zod codes so they can be surfaced in the UI verbatim.
+
+import { z } from "zod";
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_.-]+$/;
+const NO_EDGE_DOT_DASH = /^[^.-].*[^.-]$|^[^.-]$/;
+
+export const updateMeSchema = z.object({
+  username: z
+    .string({ message: "Username is required" })
+    .trim()
+    .min(2, { message: "Username must be 2–30 characters" })
+    .max(30, { message: "Username must be 2–30 characters" })
+    .regex(USERNAME_REGEX, {
+      message: "Only letters, numbers, `_`, `.`, `-`",
+    })
+    .regex(NO_EDGE_DOT_DASH, {
+      message: "No leading/trailing dot or dash",
+    }),
+});
+
+export type UpdateMeInput = z.infer<typeof updateMeSchema>;
+
+/**
+ * Flatten a `z.ZodError` from `updateMeSchema` into a `{ field: string }`
+ * record keyed by field name, picking the first error per field. Used
+ * by the route handler to return a compact, UI-friendly error shape
+ * and by the SPA form to render inline errors beneath each input.
+ */
+export function formatUpdateMeErrors(
+  error: z.ZodError<UpdateMeInput>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !(key in out)) {
+      out[key] = issue.message;
+    }
+  }
+  return out;
+}

--- a/src/server/routes/me.ts
+++ b/src/server/routes/me.ts
@@ -1,4 +1,7 @@
 // GET /api/v1/me — "who am I" probe used by the SPA's auth gate.
+// PATCH /api/v1/me — update the authenticated user's profile
+//   (currently just the username; later slices may add display name,
+//   avatar, etc.).
 //
 // Returns `{ id, email, username }` on 200 for an authenticated
 // request, or 401 JSON on an unauthenticated one. Session is resolved
@@ -6,10 +9,15 @@
 // Bearer <token> because Better Auth's session lookup honours both).
 
 import { Hono } from "hono";
+import { createDb } from "@/db";
+import { updateMeSchema, formatUpdateMeErrors } from "@/schemas/user";
 import { getAuth, type AuthEnv } from "@/server/auth";
 import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
 
-type Bindings = AuthEnv & { [key: string]: unknown };
+type Bindings = AuthEnv & {
+  DB: D1Database;
+  [key: string]: unknown;
+};
 
 export const meRoute = new Hono<{
   Bindings: Bindings;
@@ -30,6 +38,60 @@ meRoute.get("/", (c) => {
     username: (user as { username?: string }).username ?? null,
   };
   return c.json(payload);
+});
+
+meRoute.patch("/", async (c) => {
+  const user = c.get("user");
+
+  // 1. Parse + validate the body against the shared Zod schema. We
+  // return a compact { fieldErrors } shape so the SPA can render
+  // each error inline beneath the corresponding input.
+  let json: unknown;
+  try {
+    json = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+  const parsed = updateMeSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: "invalid_input",
+        fieldErrors: formatUpdateMeErrors(parsed.error),
+      },
+      400,
+    );
+  }
+  const { username } = parsed.data;
+
+  // 2. Case-insensitive uniqueness check, excluding the caller. The
+  // `user.username` column was created with `COLLATE NOCASE`, so an
+  // `=` comparison already matches case-insensitively.
+  const db = createDb(c.env);
+  const clash = await db
+    .selectFrom("user")
+    .select("id")
+    .where("username", "=", username)
+    .where("id", "<>", user.id)
+    .executeTakeFirst();
+  if (clash) {
+    return c.json({ error: "username_taken" }, 409);
+  }
+
+  // 3. Update + return the refreshed profile. Keep the caller's
+  // preferred casing (we only match case-insensitively).
+  const nowIso = new Date().toISOString();
+  await db
+    .updateTable("user")
+    .set({ username, updatedAt: nowIso })
+    .where("id", "=", user.id)
+    .execute();
+
+  return c.json({
+    id: user.id,
+    email: user.email,
+    username,
+  });
 });
 
 // Re-export so the worker can mount the route without importing the

--- a/tests/integration/me.rename.test.ts
+++ b/tests/integration/me.rename.test.ts
@@ -1,0 +1,105 @@
+// Integration tests for PATCH /api/v1/me — the username-rename
+// endpoint. Shares the Better Auth setup used by auth.test.ts but
+// lives in its own file so Wave 4 workers don't collide on a single
+// test module.
+
+import { exports } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+function makeEmail(prefix = "rename"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function register(body: {
+  email: string;
+  password: string;
+  name?: string;
+}): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: body.name ?? body.email.split("@")[0]!,
+        email: body.email,
+        password: body.password,
+      }),
+    }),
+  );
+}
+
+async function login(body: { email: string; password: string }): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+/**
+ * Registers a user, logs them in, and returns the Cookie header needed
+ * to call protected endpoints.
+ */
+async function registerAndGetCookie(): Promise<{
+  cookie: string;
+  email: string;
+  userId: string;
+  username: string;
+}> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await register({ email, password });
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as {
+    user: { id: string; email: string; username: string };
+  };
+  const loginRes = await login({ email, password });
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return {
+    cookie,
+    email,
+    userId: regBody.user.id,
+    username: regBody.user.username,
+  };
+}
+
+async function patchMe(body: unknown, headers: HeadersInit = {}): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/me", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("PATCH /api/v1/me — happy path", () => {
+  it("updates the username and returns the updated profile", async () => {
+    const { cookie, email, userId } = await registerAndGetCookie();
+    const newUsername = `new_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+
+    const response = await patchMe({ username: newUsername }, { cookie });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      id: string;
+      email: string;
+      username: string;
+    };
+    expect(body.id).toBe(userId);
+    expect(body.email).toBe(email);
+    expect(body.username).toBe(newUsername);
+  });
+
+  it("trims surrounding whitespace before storing", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const raw = `trim_${crypto.randomUUID().replace(/-/g, "").slice(0, 10)}`;
+    const response = await patchMe({ username: `  ${raw}  ` }, { cookie });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { username: string };
+    expect(body.username).toBe(raw);
+  });
+});

--- a/tests/integration/me.rename.test.ts
+++ b/tests/integration/me.rename.test.ts
@@ -77,6 +77,158 @@ async function patchMe(body: unknown, headers: HeadersInit = {}): Promise<Respon
   );
 }
 
+describe("PATCH /api/v1/me — validation", () => {
+  it("rejects an invalid character set (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: "my name" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: string;
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.error).toBe("invalid_input");
+    expect(body.fieldErrors.username).toBe("Only letters, numbers, `_`, `.`, `-`");
+  });
+
+  it("rejects an @-containing username (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: "user@host" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("Only letters, numbers, `_`, `.`, `-`");
+  });
+
+  it("rejects a too-short username (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: "x" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("Username must be 2–30 characters");
+  });
+
+  it("rejects a too-long username (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const tooLong = "a".repeat(31);
+    const response = await patchMe({ username: tooLong }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("Username must be 2–30 characters");
+  });
+
+  it("rejects an empty username (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: "" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("Username must be 2–30 characters");
+  });
+
+  it("rejects a leading dot (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: ".alice" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("No leading/trailing dot or dash");
+  });
+
+  it("rejects a trailing dash (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({ username: "alice-" }, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.fieldErrors.username).toBe("No leading/trailing dot or dash");
+  });
+
+  it("rejects a missing username field (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const response = await patchMe({}, { cookie });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_input");
+  });
+});
+
+describe("PATCH /api/v1/me — auth", () => {
+  it("rejects an unauthenticated request (401)", async () => {
+    const response = await patchMe({ username: "anon" });
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+});
+
+describe("PATCH /api/v1/me — uniqueness", () => {
+  // These tests register two users in sequence, which is expensive
+  // against the miniflare + Better Auth stack (~4-5s per register +
+  // login round-trip). Give them headroom above the vitest default.
+  const TWO_USER_TIMEOUT = 30_000;
+
+  it(
+    "rejects a username already taken by another user (409)",
+    async () => {
+      const first = await registerAndGetCookie();
+      const second = await registerAndGetCookie();
+
+      // Second user tries to grab first user's current username.
+      const response = await patchMe(
+        { username: first.username },
+        { cookie: second.cookie },
+      );
+      expect(response.status).toBe(409);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("username_taken");
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it(
+    "rejects a case-variant of another user's username (409)",
+    async () => {
+      const first = await registerAndGetCookie();
+      // Claim a known username on the first account so we can test a
+      // deterministic case variation against the second account.
+      const claim = `Alice_${crypto.randomUUID().replace(/-/g, "").slice(0, 10)}`;
+      const claimRes = await patchMe({ username: claim }, { cookie: first.cookie });
+      expect(claimRes.status).toBe(200);
+
+      const second = await registerAndGetCookie();
+      const response = await patchMe(
+        { username: claim.toLowerCase() },
+        { cookie: second.cookie },
+      );
+      expect(response.status).toBe(409);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("username_taken");
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it("allows a user to re-save their own username (case-only change)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const pick = `Bob_${crypto.randomUUID().replace(/-/g, "").slice(0, 10)}`;
+    const first = await patchMe({ username: pick }, { cookie });
+    expect(first.status).toBe(200);
+
+    // Uppercase their own — must not 409 against themselves.
+    const second = await patchMe({ username: pick.toUpperCase() }, { cookie });
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as { username: string };
+    expect(body.username).toBe(pick.toUpperCase());
+  });
+});
+
 describe("PATCH /api/v1/me — happy path", () => {
   it("updates the username and returns the updated profile", async () => {
     const { cookie, email, userId } = await registerAndGetCookie();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,13 @@ export default defineConfig(async (_env): Promise<ViteUserConfig> => {
       include: ["tests/integration/**/*.test.ts", "src/**/*.test.ts"],
       exclude: ["tests/e2e/**", "node_modules/**", "dist/**", ".wrangler/**"],
       setupFiles: ["./tests/integration/setup/apply-migrations.ts"],
+      // Better Auth signup uses a slow KDF (scrypt/bcrypt equivalent).
+      // Under miniflare + workerd on GitHub runners, each signup adds
+      // 1-3s; tests that do signup + sign-in + API call in one test
+      // exceed the 5s vitest default. 15s covers the slowest paths
+      // with headroom.
+      testTimeout: 15_000,
+      hookTimeout: 30_000,
       coverage: {
         // Istanbul (source instrumentation) works with workerd; v8
         // requires a Node inspector Session that the Workers pool


### PR DESCRIPTION
Closes #7.

## Summary

Lets an authenticated user rename their username from the SPA Settings page. Ships:

- `src/schemas/user.ts` — shared `updateMeSchema` Zod schema with human-readable error messages (`"Username must be 2–30 characters"`, `"Only letters, numbers, \`_\`, \`.\`, \`-\`"`, `"No leading/trailing dot or dash"`). Imported by both the API route and the SPA form.
- `PATCH /api/v1/me` in `src/server/routes/me.ts` — Zod-validates the body, performs a case-insensitive uniqueness check via Kysely (the `user.username` column is already `COLLATE NOCASE` from migration `0001_init.sql`, so `=` on that column matches case-insensitively), updates `user.username` preserving submitted casing, and returns the refreshed `{ id, email, username }`.
- `src/app/auth/api.ts` — new `updateMe({ username })` helper that maps the API's discriminated error shapes (`username_taken`, `invalid_input`, `unauthorized`) into an inline-friendly `{ code, message, fieldErrors? }` payload for the form.
- `src/app/pages/SettingsPage.tsx` — replaces the placeholder with a real form: read-only email, editable username pre-filled from the session, client-side validation through the same `updateMeSchema`, inline field errors, success toast, session refresh so the dashboard reflects the new name on next navigation.

No new migration is needed. No Worker-level re-wiring — the PATCH handler is added to the existing `meRoute` Hono module, which `src/worker/index.tsx` already mounts.

## Tests

New `tests/integration/me.rename.test.ts` (kept separate from `auth.test.ts` to avoid colliding with Worker D's slice 5). 14 new cases covering:

- happy rename + whitespace trimming
- invalid chars (space, `@`)
- length boundaries: 1 char, 31 chars, empty string
- leading dot, trailing dash
- missing \`username\` field
- duplicate username — plain and case-variant (409 \`username_taken\`)
- self-rename case-only change must succeed
- unauthed PATCH → 401

Totals: **43 integration tests pass** (29 baseline + 14 new). Typecheck + build clean.

## Deviations

- Added two bonus cases not listed in the issue — leading-dot and trailing-dash rejection — because the schema enforces them and they were cheap to cover.
- `updateMeSchema`'s error message for missing-field uses `"Username is required"` (via a custom `z.string({ message })`), which is friendlier than Zod's default. Still passes the "no raw Zod output" bar.

## Coordination

- Did **not** touch `src/server/auth.ts`, `LoginPage.tsx`, `RegisterPage.tsx` (Worker D, #6).
- Did **not** touch `migrations/**`, `src/domain/movements/**`, `src/server/routes/movements.ts`, `src/db/schema.ts`, or extend `src/worker/index.tsx` (Worker F, #8).
- `package.json` / `package-lock.json` untouched — `zod` was already present.

## Followups

- Once the public profile `/u/:username` lands (slice 15), consider a 301 redirect from the previous handle. Not in scope here.
- Rate-limiting rename requests (spam prevention) is unplanned — worth flagging if abuse becomes a concern.