### PR TITLE
Slice 20: Feature flags (KV-backed isEnabled)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "types:check": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false wrangler types --check",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.e2e.json",
     "db:seed:movements": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false tsx scripts/db/seed-movements.ts",
+    "flags:set": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false tsx scripts/flags/set.ts",
     "test": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false vitest run --passWithNoTests",
     "test:watch": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false vitest --passWithNoTests",
     "test:coverage": "CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false vitest run --coverage --passWithNoTests",

--- a/scripts/flags/set.ts
+++ b/scripts/flags/set.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env tsx
+/**
+ * Admin CLI: set a feature-flag rule in the `FLAGS` KV namespace.
+ *
+ * Usage:
+ *
+ *   npm run flags:set -- <flag-name> '<rule-json>'
+ *
+ * Examples:
+ *
+ *   npm run flags:set -- ai_reading_v2 '{"mode":"always"}'
+ *   npm run flags:set -- ai_reading_v2 '{"mode":"never"}'
+ *   npm run flags:set -- ai_reading_v2 '{"mode":"users","users":["u-1","u-2"]}'
+ *   npm run flags:set -- ai_reading_v2 '{"mode":"rollout","rolloutPct":25}'
+ *
+ * The rule JSON is validated with the same Zod schema the Worker uses
+ * to read it back (src/domain/feature-flags/parse.ts), so a malformed
+ * rule gets rejected at write time instead of silently disabling the
+ * flag for everyone at runtime.
+ *
+ * Wrangler resolves the namespace id from wrangler.jsonc via the
+ * `--binding FLAGS` flag — keeps this script in sync whenever the
+ * namespace id rotates.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseRuleJson } from "../../src/domain/feature-flags/parse";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function usage(): never {
+  // eslint-disable-next-line no-console
+  console.error(
+    "usage: npm run flags:set -- <flag-name> '<rule-json>'\n" +
+      'example: npm run flags:set -- ai_reading_v2 \'{"mode":"always"}\'',
+  );
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.length !== 2) usage();
+  const [flag, rawRule] = argv as [string, string];
+  if (flag.length === 0) usage();
+
+  // Canonicalise the JSON before writing so stored values don't
+  // carry the operator's whitespace or key ordering.
+  const { canonicalJson } = parseRuleJson(rawRule);
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[flags:set] writing ${flag} = ${canonicalJson} (--binding FLAGS --remote)`,
+  );
+
+  const args = [
+    "wrangler",
+    "kv",
+    "key",
+    "put",
+    "--binding",
+    "FLAGS",
+    "--remote",
+    flag,
+    canonicalJson,
+  ];
+
+  const result = spawnSync("npx", args, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    env: { ...process.env, CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV: "false" },
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+// Only run when invoked as a script — prevents any accidental
+// side-effects if a tooling crawl imports this file.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (invokedDirectly) {
+  void main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/src/domain/feature-flags/evaluator.test.ts
+++ b/src/domain/feature-flags/evaluator.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { evaluateRule } from "./evaluator";
+import type { FlagRule } from "./types";
+
+// Pure-function tests. Evaluator has no I/O, no KV, no env — everything
+// the public `isEnabled` depends on is validated here so the rest of
+// the service is a thin wrapper around KV-read-and-parse.
+
+describe("evaluateRule (always / never)", () => {
+  it("always → true for any context", async () => {
+    expect(await evaluateRule({ mode: "always" }, {})).toBe(true);
+    expect(await evaluateRule({ mode: "always" }, { userId: "u-1" })).toBe(true);
+  });
+
+  it("never → false for any context", async () => {
+    expect(await evaluateRule({ mode: "never" }, {})).toBe(false);
+    expect(await evaluateRule({ mode: "never" }, { userId: "u-1" })).toBe(false);
+  });
+});
+
+describe("evaluateRule (users)", () => {
+  const rule: FlagRule = { mode: "users", users: ["a", "b"] };
+
+  it("includes listed user → true", async () => {
+    expect(await evaluateRule(rule, { userId: "a" })).toBe(true);
+    expect(await evaluateRule(rule, { userId: "b" })).toBe(true);
+  });
+
+  it("excludes other user → false", async () => {
+    expect(await evaluateRule(rule, { userId: "c" })).toBe(false);
+  });
+
+  it("no userId → false", async () => {
+    expect(await evaluateRule(rule, {})).toBe(false);
+  });
+});
+
+describe("evaluateRule (rollout)", () => {
+  it("rolloutPct:0 → always false", async () => {
+    const rule: FlagRule = { mode: "rollout", rolloutPct: 0 };
+    for (const userId of ["u-1", "u-2", "u-3", "a-very-different-id"]) {
+      expect(await evaluateRule(rule, { userId })).toBe(false);
+    }
+  });
+
+  it("rolloutPct:100 → true for any userId", async () => {
+    const rule: FlagRule = { mode: "rollout", rolloutPct: 100 };
+    for (const userId of ["u-1", "u-2", "u-3", "a-very-different-id"]) {
+      expect(await evaluateRule(rule, { userId })).toBe(true);
+    }
+  });
+
+  it("rolloutPct:50 with no userId → false (anon users default out)", async () => {
+    const rule: FlagRule = { mode: "rollout", rolloutPct: 50 };
+    expect(await evaluateRule(rule, {})).toBe(false);
+  });
+
+  it("rolloutPct is stable per (user, flag) — same call twice gives same result", async () => {
+    const rule: FlagRule = { mode: "rollout", rolloutPct: 37 };
+    const a = await evaluateRule(rule, { userId: "stable-user-id" }, "flag-x");
+    const b = await evaluateRule(rule, { userId: "stable-user-id" }, "flag-x");
+    expect(a).toBe(b);
+  });
+
+  it("rolloutPct:25 distributes ~25 % across 1000 synthetic users", async () => {
+    const rule: FlagRule = { mode: "rollout", rolloutPct: 25 };
+    let enabled = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (await evaluateRule(rule, { userId: `user-${i}` }, "ai_reading_v2")) {
+        enabled++;
+      }
+    }
+    // SHA-256 distributes uniformly; empirically this runs ~250 ± 15
+    // for a 1k sample. 20-30 % is a safe-but-tight band that will
+    // still catch a systematically-wrong bucketing impl.
+    expect(enabled).toBeGreaterThanOrEqual(200);
+    expect(enabled).toBeLessThanOrEqual(300);
+  });
+});

--- a/src/domain/feature-flags/evaluator.ts
+++ b/src/domain/feature-flags/evaluator.ts
@@ -1,0 +1,64 @@
+// Pure rule evaluator. No KV, no env — callers pass the already-parsed
+// rule and the request context, get a boolean back.
+//
+// Keeping this separate from `service.ts` means the bucketing maths
+// are unit-testable without Miniflare, and the public `isEnabled`
+// stays a thin adapter around KV-read-then-evaluate.
+
+import type { FlagRule, FlagContext } from "./types";
+
+/**
+ * Evaluate a parsed feature-flag rule for the given context.
+ *
+ * The rule-evaluation must be deterministic and side-effect-free.
+ * `flag` is used (together with the userId) as the stable bucketing
+ * key for `rollout` mode, so the same user is not trivially either
+ * in or out of every percentage rollout at once.
+ *
+ * The function is async only because `rollout` mode uses
+ * `crypto.subtle.digest` — `always`, `never`, and `users` resolve
+ * synchronously. Callers should `await` regardless for consistency.
+ */
+export async function evaluateRule(
+  rule: FlagRule,
+  ctx: FlagContext,
+  flag = "",
+): Promise<boolean> {
+  switch (rule.mode) {
+    case "always":
+      return true;
+    case "never":
+      return false;
+    case "users":
+      return ctx.userId !== undefined && rule.users.includes(ctx.userId);
+    case "rollout": {
+      // Anonymous callers default out. Without a user id we would
+      // have to bucket on e.g. the request IP, which then hides the
+      // same user on different networks. Safer to just say no.
+      if (ctx.userId === undefined) return false;
+      // Fast paths — avoid a needless SHA-256 on every request when
+      // the answer is constant.
+      if (rule.rolloutPct <= 0) return false;
+      if (rule.rolloutPct >= 100) return true;
+
+      const bucket = await bucketFor(ctx.userId, flag);
+      return bucket < rule.rolloutPct;
+    }
+  }
+}
+
+/**
+ * Stable per-(user, flag) bucket in the range [0, 100).
+ *
+ * We hash with SHA-256 and take the first four bytes as a big-endian
+ * uint32. Modulo 100 is biased in theory (2^32 is not divisible by
+ * 100 so buckets 0..95 each receive one extra value out of 2^32), but
+ * the bias is ~1e-8 — undetectable in any real rollout sample.
+ */
+async function bucketFor(userId: string, flag: string): Promise<number> {
+  const encoded = new TextEncoder().encode(`${userId}:${flag}`);
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", encoded));
+  const asUint32 =
+    ((digest[0]! << 24) | (digest[1]! << 16) | (digest[2]! << 8) | digest[3]!) >>> 0;
+  return asUint32 % 100;
+}

--- a/src/domain/feature-flags/index.ts
+++ b/src/domain/feature-flags/index.ts
@@ -1,0 +1,5 @@
+// Public surface of the feature-flags domain module.
+
+export { isEnabled, type FeatureFlagsEnv } from "./service";
+export { evaluateRule } from "./evaluator";
+export { ruleSchema, type FlagRule, type FlagContext } from "./types";

--- a/src/domain/feature-flags/index.ts
+++ b/src/domain/feature-flags/index.ts
@@ -2,4 +2,5 @@
 
 export { isEnabled, type FeatureFlagsEnv } from "./service";
 export { evaluateRule } from "./evaluator";
+export { parseRuleJson } from "./parse";
 export { ruleSchema, type FlagRule, type FlagContext } from "./types";

--- a/src/domain/feature-flags/parse.test.ts
+++ b/src/domain/feature-flags/parse.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parseRuleJson } from "./parse";
+
+// Validation happens at the edge (admin CLI, admin UI) *before* any
+// KV write. These tests pin the contract so a future caller can trust
+// `parseRuleJson` to reject bad input without having to reimplement
+// the Zod schema surface.
+
+describe("parseRuleJson — valid rules", () => {
+  it("accepts an always rule", () => {
+    const { rule, canonicalJson } = parseRuleJson('{"mode":"always"}');
+    expect(rule).toEqual({ mode: "always" });
+    expect(JSON.parse(canonicalJson)).toEqual({ mode: "always" });
+  });
+
+  it("accepts a never rule", () => {
+    const { rule } = parseRuleJson('{"mode":"never"}');
+    expect(rule).toEqual({ mode: "never" });
+  });
+
+  it("accepts a users rule", () => {
+    const { rule } = parseRuleJson('{"mode":"users","users":["u-1","u-2"]}');
+    expect(rule).toEqual({ mode: "users", users: ["u-1", "u-2"] });
+  });
+
+  it("accepts a rollout rule", () => {
+    const { rule } = parseRuleJson('{"mode":"rollout","rolloutPct":25}');
+    expect(rule).toEqual({ mode: "rollout", rolloutPct: 25 });
+  });
+
+  it("canonicalises whitespace / extra keys out of the stored JSON", () => {
+    const { canonicalJson } = parseRuleJson('{\n  "mode":   "always"\n}');
+    expect(canonicalJson).toBe('{"mode":"always"}');
+  });
+});
+
+describe("parseRuleJson — invalid rules", () => {
+  it("rejects malformed JSON", () => {
+    expect(() => parseRuleJson("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() => parseRuleJson('{"mode":"sometimes"}')).toThrow(/schema validation/);
+  });
+
+  it("rejects rolloutPct out of range", () => {
+    expect(() => parseRuleJson('{"mode":"rollout","rolloutPct":150}')).toThrow(
+      /schema validation/,
+    );
+    expect(() => parseRuleJson('{"mode":"rollout","rolloutPct":-1}')).toThrow(
+      /schema validation/,
+    );
+  });
+
+  it("rejects fractional rolloutPct", () => {
+    expect(() => parseRuleJson('{"mode":"rollout","rolloutPct":25.5}')).toThrow(
+      /schema validation/,
+    );
+  });
+
+  it("rejects users rule missing users array", () => {
+    expect(() => parseRuleJson('{"mode":"users"}')).toThrow(/schema validation/);
+  });
+
+  it("rejects users rule with empty id strings", () => {
+    expect(() => parseRuleJson('{"mode":"users","users":[""]}')).toThrow(
+      /schema validation/,
+    );
+  });
+});

--- a/src/domain/feature-flags/parse.ts
+++ b/src/domain/feature-flags/parse.ts
@@ -1,0 +1,40 @@
+// Shared helpers for validating a caller-supplied rule at the edge
+// (admin CLI today; possibly an admin-UI route later). Both entry
+// points need to reject bad input with the exact same rules the
+// runtime evaluator uses, so the Zod schema is the single source of
+// truth.
+
+import { ruleSchema } from "./types";
+
+/**
+ * Parse + validate a rule JSON string. Returns the canonicalised JSON
+ * (re-serialised from the parsed value, so whitespace / quoting noise
+ * is stripped) plus the parsed rule itself.
+ *
+ * Throws a readable `Error` on:
+ *   • invalid JSON syntax
+ *   • schema mismatch (unknown mode, out-of-range rolloutPct, etc.)
+ */
+export function parseRuleJson(raw: string): {
+  rule: import("./types").FlagRule;
+  canonicalJson: string;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `rule JSON is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const result = ruleSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".") || "<root>"}: ${i.message}`)
+      .join("\n");
+    throw new Error(`rule failed schema validation:\n${issues}`);
+  }
+
+  return { rule: result.data, canonicalJson: JSON.stringify(result.data) };
+}

--- a/src/domain/feature-flags/service.ts
+++ b/src/domain/feature-flags/service.ts
@@ -1,0 +1,60 @@
+// Public feature-flag service. Reads a rule from KV, validates it,
+// and evaluates it for the given context. Default to OFF on any
+// failure: missing key, malformed JSON, or Zod-invalid value.
+//
+// The evaluator itself is pure (evaluator.ts); this module is only
+// responsible for the KV read and the graceful-fallback contract.
+
+import { evaluateRule } from "./evaluator";
+import { ruleSchema, type FlagContext } from "./types";
+
+export interface FeatureFlagsEnv {
+  FLAGS: KVNamespace;
+}
+
+/**
+ * Return true iff the feature flag is enabled for the given context.
+ *
+ * Default-off semantics — for any of these failure modes the caller
+ * sees `false`, never an exception:
+ *
+ *   • KV key not set
+ *   • KV value is not valid JSON
+ *   • KV value fails schema validation
+ *
+ * The only thing a caller needs to handle is a KV-transport failure
+ * (unreachable KV, timeout) which this function lets propagate; that
+ * path is rare enough in practice that we'd rather see the error in
+ * logs than silently feature-disable everyone.
+ */
+export async function isEnabled(
+  flag: string,
+  ctx: FlagContext,
+  env: FeatureFlagsEnv,
+): Promise<boolean> {
+  const raw = await env.FLAGS.get(flag);
+  if (raw === null) return false;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    // Malformed JSON shouldn't happen in practice — the CLI validates
+    // before writing — but we defensively swallow it so a hand-poked
+    // KV entry can't take the feature down. Log so an operator can
+    // see it in tail.
+    console.warn(`feature-flags: malformed JSON for flag "${flag}":`, err);
+    return false;
+  }
+
+  const result = ruleSchema.safeParse(parsed);
+  if (!result.success) {
+    console.warn(
+      `feature-flags: schema validation failed for flag "${flag}":`,
+      result.error.issues,
+    );
+    return false;
+  }
+
+  return evaluateRule(result.data, ctx, flag);
+}

--- a/src/domain/feature-flags/types.ts
+++ b/src/domain/feature-flags/types.ts
@@ -1,0 +1,35 @@
+// Feature-flag rule shapes and their Zod schema.
+//
+// Rules are stored in the `FLAGS` KV namespace as JSON under the flag
+// name (e.g. KV key `ai_reading_v2` → value `{"mode":"always"}`). The
+// Worker reads and validates with `ruleSchema` on every call to
+// `isEnabled`; a missing or malformed value defaults to OFF so a
+// broken KV entry cannot brick a production Worker.
+
+import { z } from "zod";
+
+export const ruleSchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("always") }),
+  z.object({ mode: z.literal("never") }),
+  z.object({
+    mode: z.literal("users"),
+    // We don't constrain the ids beyond non-empty to keep rollout
+    // examples like the product's numeric / UUID user ids unchanged.
+    users: z.array(z.string().min(1)),
+  }),
+  z.object({
+    mode: z.literal("rollout"),
+    // Percentage of the stable-hashed user population to include.
+    // 0 → nobody, 100 → everybody with a userId. Fractional values
+    // get rounded down by the bucket compare (`<`), which means 50.5
+    // behaves identically to 50 — we therefore require ints.
+    rolloutPct: z.number().int().min(0).max(100),
+  }),
+]);
+
+export type FlagRule = z.infer<typeof ruleSchema>;
+
+export interface FlagContext {
+  /** The authenticated user's id, if any. Anonymous calls omit it. */
+  userId?: string;
+}

--- a/tests/integration/feature-flags.test.ts
+++ b/tests/integration/feature-flags.test.ts
@@ -1,0 +1,83 @@
+import { env } from "cloudflare:workers";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { isEnabled } from "@/domain/feature-flags";
+
+// Exercises the service end-to-end against miniflare's KV binding.
+// The evaluator's maths are covered by its own unit tests — here we
+// only care that (a) KV round-trips drive the right branch of the
+// evaluator and (b) the default-off fallback really doesn't throw.
+
+type FlagsEnv = { FLAGS: KVNamespace };
+const flagsEnv = env as unknown as FlagsEnv;
+
+// Use a unique flag name per test so the implicit per-file storage
+// isolation from vitest-pool-workers doesn't leak one test's KV
+// writes into the next.
+function uniqueFlag(name: string): string {
+  return `test_${name}_${crypto.randomUUID()}`;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isEnabled", () => {
+  it("returns false when KV has no rule for the flag", async () => {
+    const flag = uniqueFlag("missing");
+    expect(await isEnabled(flag, { userId: "u-1" }, flagsEnv)).toBe(false);
+  });
+
+  it("returns false and does not throw when KV value is malformed JSON", async () => {
+    const flag = uniqueFlag("malformed");
+    await flagsEnv.FLAGS.put(flag, "{this is not valid json");
+    // Swallow the expected warn so it doesn't pollute test output.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await isEnabled(flag, { userId: "u-1" }, flagsEnv)).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("returns false when the rule fails schema validation", async () => {
+    const flag = uniqueFlag("bogus");
+    await flagsEnv.FLAGS.put(flag, JSON.stringify({ mode: "sometimes" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await isEnabled(flag, { userId: "u-1" }, flagsEnv)).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("always-mode rule is true regardless of context", async () => {
+    const flag = uniqueFlag("always");
+    await flagsEnv.FLAGS.put(flag, JSON.stringify({ mode: "always" }));
+    expect(await isEnabled(flag, {}, flagsEnv)).toBe(true);
+    expect(await isEnabled(flag, { userId: "u-1" }, flagsEnv)).toBe(true);
+  });
+
+  it("never-mode rule is false regardless of context", async () => {
+    const flag = uniqueFlag("never");
+    await flagsEnv.FLAGS.put(flag, JSON.stringify({ mode: "never" }));
+    expect(await isEnabled(flag, { userId: "u-1" }, flagsEnv)).toBe(false);
+  });
+
+  it("users-mode rule gates by userId", async () => {
+    const flag = uniqueFlag("users");
+    await flagsEnv.FLAGS.put(
+      flag,
+      JSON.stringify({ mode: "users", users: ["alice", "bob"] }),
+    );
+    expect(await isEnabled(flag, { userId: "alice" }, flagsEnv)).toBe(true);
+    expect(await isEnabled(flag, { userId: "bob" }, flagsEnv)).toBe(true);
+    expect(await isEnabled(flag, { userId: "eve" }, flagsEnv)).toBe(false);
+    expect(await isEnabled(flag, {}, flagsEnv)).toBe(false);
+  });
+
+  it("rollout:100 → enabled for any seeded user", async () => {
+    const flag = uniqueFlag("rollout100");
+    await flagsEnv.FLAGS.put(flag, JSON.stringify({ mode: "rollout", rolloutPct: 100 }));
+    expect(await isEnabled(flag, { userId: "any-user" }, flagsEnv)).toBe(true);
+  });
+
+  it("rollout:0 → disabled for any seeded user", async () => {
+    const flag = uniqueFlag("rollout0");
+    await flagsEnv.FLAGS.put(flag, JSON.stringify({ mode: "rollout", rolloutPct: 0 }));
+    expect(await isEnabled(flag, { userId: "any-user" }, flagsEnv)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #21.

## Summary

KV-backed feature-flag service + admin CLI.

- **`src/domain/feature-flags/`** — pure evaluator, Zod-validated rule schema, and a thin `isEnabled(flag, ctx, env)` service that reads `env.FLAGS` and defaults to **off** on every failure mode (missing key / malformed JSON / schema-invalid value). Never throws.
- **Stable rollout bucketing** — SHA-256 of `userId:flag` → first 4 bytes as uint32 → mod 100. Same user is always in/out of the same flag at the same %. Anonymous callers default out.
- **`scripts/flags/set.ts`** — `npm run flags:set -- <flag> '<rule-json>'`. Validates via the same Zod schema the runtime uses, then writes via `wrangler kv key put --binding FLAGS --remote` so the namespace id is resolved from `wrangler.jsonc`.

## Tests (+29, all green)

- `src/domain/feature-flags/evaluator.test.ts` — 10 pure unit tests covering `always` / `never` / `users` / `rollout`, including a 1k-user distribution check on `rollout:25` landing in the 20-30 % band and the same-user-twice stability assertion.
- `src/domain/feature-flags/parse.test.ts` — 12 tests pinning rule-JSON validation (happy path + every rejection: malformed JSON, unknown mode, out-of-range / fractional `rolloutPct`, missing `users`, empty id strings).
- `tests/integration/feature-flags.test.ts` — 8 integration tests round-tripping rules through miniflare KV, including both malformed-JSON and schema-fail fallbacks.

Total: 68 existing + 29 new = **97 passing**. Typecheck + `npm run build` clean.

## Smoke-tested CLI error paths locally

```
$ npx tsx scripts/flags/set.ts
usage: npm run flags:set -- <flag-name> '<rule-json>'
example: npm run flags:set -- ai_reading_v2 '{"mode":"always"}'

$ npx tsx scripts/flags/set.ts test_flag 'not json'
rule JSON is not valid JSON: Unexpected token 'o'...

$ npx tsx scripts/flags/set.ts test_flag '{"mode":"sometimes"}'
rule failed schema validation:
  - mode: Invalid input
```

Happy-path wrangler write was **not** exercised against real KV to keep the PR hermetic — operator should smoke-test with a throwaway key after merge (see issue body for the exact command).

## Deferred to slice 16 (per issue spec)

> The verified-reading endpoint honours the flag; integration test proves this

Skipped — that endpoint doesn't exist yet. Slice 16 will wire `isEnabled('ai_reading_v2', { userId: session.user.id }, env)` into the verified-reading handler and add an end-to-end integration test that flips the flag in KV and asserts the request path switches accordingly. The service is ready; only the call-site is missing.

No demo route was added either — the service is small enough that 29 focused tests prove it without needing an HTTP endpoint, and `src/worker/index.tsx` is contested with Worker H (slice 8 / issue #9) so leaving it untouched avoids a merge conflict.

## Lane discipline (re: parallel Worker H)

Only modified files: `src/domain/feature-flags/**` (new), `scripts/flags/**` (new), `tests/integration/feature-flags.test.ts` (new), `package.json` (one-line script addition). None of Worker H's files are touched. Expected trivial `package.json` / `package-lock.json` conflict at merge time.