### PR TITLE
Slice 9: Submit unknown movement (pending moderation)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,77 @@
+# Infra + operator runbooks
+
+This directory holds everything that lives outside of the Worker
+script itself:
+
+- `terraform/` — Terraform code that owns the D1 database, R2 bucket,
+  KV namespace, and DNS / routes. See `terraform/README.md` for the
+  IaC workflow.
+- Operator-level runbooks (below) — manual SQL + `wrangler` commands
+  used during phase-1 moderation before a real admin UI lands.
+
+## Phase-1 movement moderation
+
+Users can submit new movements when their watch's caliber isn't in the
+curated list (issue #10). The submission lands with
+`status = 'pending'` and `submitted_by_user_id` attached; the row is
+visible to the submitter in the add-watch typeahead but excluded from
+all public leaderboards and from other users' searches until it is
+approved.
+
+Approval is **manual SQL in phase 1** — no admin UI yet.
+
+### Listing pending submissions
+
+```bash
+CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 execute rated-watch-db --remote --command \
+  "SELECT id, canonical_name, manufacturer, caliber, type, submitted_by_user_id, created_at FROM movements WHERE status = 'pending' ORDER BY created_at DESC;"
+```
+
+Cross-reference the `submitted_by_user_id` against the `user` table if
+you need to reach out to the submitter for more detail:
+
+```bash
+CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 execute rated-watch-db --remote --command \
+  "SELECT id, email, username FROM user WHERE id = '<submitted_by_user_id>';"
+```
+
+### Approving a submission
+
+```bash
+CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 execute rated-watch-db --remote --command \
+  "UPDATE movements SET status = 'approved' WHERE id = 'submitted-slug-here';"
+```
+
+After approval the movement shows up in the default typeahead for
+every user and in leaderboard queries (once slice #14 ships the
+aggregation).
+
+### Rejecting a submission
+
+No soft-reject flow in phase 1. If a submission is clearly spam or
+duplicates an existing row with a different spelling, delete it:
+
+```bash
+CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 execute rated-watch-db --remote --command \
+  "DELETE FROM movements WHERE id = 'submitted-slug-here';"
+```
+
+Watches still linked to the deleted movement will have their
+`movement_id` set to `NULL` (ON DELETE SET NULL at the FK), so they
+simply drop off the per-movement leaderboard until the owner re-attaches
+them via the add/edit flow.
+
+### Editing a pending submission before approval
+
+If the submitter typed the wrong manufacturer or display name, it's OK
+to fix it in place before flipping the status:
+
+```bash
+CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 execute rated-watch-db --remote --command \
+  "UPDATE movements SET canonical_name = 'Seiko NH36A', manufacturer = 'Seiko', caliber = 'NH36A' WHERE id = 'seiko-nh36a' AND status = 'pending';"
+```
+
+Note the `id` is the generated slug (`<manufacturer>-<caliber>` kebab)
+and changing `manufacturer`/`caliber` does **not** re-generate it — the
+slug is locked in at submit time. If the slug itself is wrong, delete
+the row and ask the submitter to re-submit with the corrected fields.

--- a/src/app/watches/MovementTypeahead.tsx
+++ b/src/app/watches/MovementTypeahead.tsx
@@ -15,6 +15,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { searchMovements, type MovementOption } from "./api";
 import { useDebouncedValue } from "./useDebouncedValue";
+import {
+  SubmitMovementSubForm,
+  type SubmitMovementNotice,
+} from "./SubmitMovementSubForm";
 
 export interface MovementTypeaheadProps {
   /** Pre-selected movement, for edit flows. */
@@ -39,8 +43,13 @@ export function MovementTypeahead({
   const [selection, setSelection] = useState<MovementOption | null>(initialSelection);
   const [query, setQuery] = useState("");
   const [options, setOptions] = useState<MovementOption[]>([]);
+  const [suggestions, setSuggestions] = useState<MovementOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  // Slice #10: inline sub-form to submit a new movement when the
+  // current query has no match and the user clicks "Can't find it?".
+  const [submitOpen, setSubmitOpen] = useState(false);
+  const [submitNotice, setSubmitNotice] = useState<SubmitMovementNotice>(null);
   const inputId = useMemo(() => `movement-${Math.random().toString(36).slice(2, 8)}`, []);
 
   // Sync when a parent passes a new initial selection (e.g. after the
@@ -58,6 +67,7 @@ export function MovementTypeahead({
     if (selection) return;
     if (debouncedQuery.trim().length < 1) {
       setOptions([]);
+      setSuggestions([]);
       setLoading(false);
       return;
     }
@@ -65,12 +75,15 @@ export function MovementTypeahead({
     const controller = new AbortController();
     abortRef.current = controller;
     setLoading(true);
-    searchMovements(debouncedQuery.trim(), controller.signal).then(({ approved }) => {
-      if (controller.signal.aborted) return;
-      setOptions(approved);
-      setLoading(false);
-      setOpen(true);
-    });
+    searchMovements(debouncedQuery.trim(), controller.signal).then(
+      ({ approved, suggestions: suggested }) => {
+        if (controller.signal.aborted) return;
+        setOptions(approved);
+        setSuggestions(suggested);
+        setLoading(false);
+        setOpen(true);
+      },
+    );
     return () => controller.abort();
   }, [debouncedQuery, selection]);
 
@@ -78,6 +91,7 @@ export function MovementTypeahead({
     setSelection(option);
     setQuery("");
     setOptions([]);
+    setSuggestions([]);
     setOpen(false);
     onSelect(option);
   }
@@ -86,8 +100,19 @@ export function MovementTypeahead({
     setSelection(null);
     setQuery("");
     setOptions([]);
+    setSuggestions([]);
     setOpen(false);
+    setSubmitOpen(false);
+    setSubmitNotice(null);
     onClear();
+  }
+
+  function handleSubmitResolved(movement: MovementOption, notice: SubmitMovementNotice) {
+    setSubmitOpen(false);
+    setSubmitNotice(notice);
+    // Auto-select the new (or collided) movement so the outer form can
+    // submit the watch against it right away.
+    handleSelect(movement);
   }
 
   return (
@@ -96,7 +121,14 @@ export function MovementTypeahead({
 
       {selection ? (
         <div className="flex items-center gap-2 rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2">
-          <span className="flex-1 text-cf-text">{selection.canonical_name}</span>
+          <span className="flex-1 text-cf-text">
+            {selection.canonical_name}
+            {selection.status === "pending" ? (
+              <span className="ml-2 rounded-full bg-cf-orange/20 px-2 py-0.5 text-xs text-cf-orange">
+                Pending approval
+              </span>
+            ) : null}
+          </span>
           <button
             type="button"
             onClick={handleClear}
@@ -124,7 +156,7 @@ export function MovementTypeahead({
               // closes the dropdown.
               setTimeout(() => setOpen(false), 150);
             }}
-            onFocus={() => setOpen(options.length > 0)}
+            onFocus={() => setOpen(options.length > 0 || suggestions.length > 0)}
             placeholder="Search calibers — e.g. ETA 2892-A2"
             aria-invalid={errorMessage ? true : undefined}
             aria-describedby={errorMessage ? `${inputId}-error` : undefined}
@@ -138,38 +170,118 @@ export function MovementTypeahead({
             >
               {loading ? (
                 <li className="px-3 py-2 text-sm text-cf-text-muted">Searching…</li>
-              ) : options.length === 0 ? (
+              ) : options.length === 0 && suggestions.length === 0 ? (
                 <li className="px-3 py-2 text-sm text-cf-text-muted">
-                  No calibers match “{query.trim()}”.
+                  No calibers match “{query.trim()}”.{" "}
+                  <button
+                    type="button"
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      setSubmitOpen(true);
+                      setOpen(false);
+                    }}
+                    className="text-cf-orange hover:underline"
+                  >
+                    Can&rsquo;t find it? Submit new movement
+                  </button>
                 </li>
               ) : (
-                options.map((option) => (
-                  <li key={option.id}>
+                <>
+                  {options.map((option) => (
+                    <li key={option.id}>
+                      <button
+                        type="button"
+                        onMouseDown={(event) => {
+                          // preventDefault stops the blur that would
+                          // otherwise race the click and close the list
+                          // before onClick fires.
+                          event.preventDefault();
+                          handleSelect(option);
+                        }}
+                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-bg-200"
+                      >
+                        <span className="font-sans text-base text-cf-text">
+                          {option.canonical_name}
+                        </span>
+                        <span className="text-xs text-cf-text-muted">
+                          {option.manufacturer} · {option.caliber} · {option.type}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                  {suggestions.length > 0 ? (
+                    <li className="border-t border-cf-border bg-cf-bg-200 px-3 py-1 text-xs font-medium uppercase tracking-wide text-cf-text-muted">
+                      Your pending submissions
+                    </li>
+                  ) : null}
+                  {suggestions.map((option) => (
+                    <li key={`suggestion-${option.id}`}>
+                      <button
+                        type="button"
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          handleSelect(option);
+                        }}
+                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-bg-200"
+                      >
+                        <span className="font-sans text-base text-cf-text">
+                          {option.canonical_name}
+                          <span className="ml-2 rounded-full bg-cf-orange/20 px-2 py-0.5 text-xs text-cf-orange">
+                            Pending
+                          </span>
+                        </span>
+                        <span className="text-xs text-cf-text-muted">
+                          {option.manufacturer} · {option.caliber} · {option.type}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                  <li className="border-t border-cf-border px-3 py-2 text-sm">
                     <button
                       type="button"
                       onMouseDown={(event) => {
-                        // preventDefault stops the blur that would
-                        // otherwise race the click and close the list
-                        // before onClick fires.
                         event.preventDefault();
-                        handleSelect(option);
+                        setSubmitOpen(true);
+                        setOpen(false);
                       }}
-                      className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-bg-200"
+                      className="text-cf-orange hover:underline"
                     >
-                      <span className="font-sans text-base text-cf-text">
-                        {option.canonical_name}
-                      </span>
-                      <span className="text-xs text-cf-text-muted">
-                        {option.manufacturer} · {option.caliber} · {option.type}
-                      </span>
+                      Can&rsquo;t find it? Submit new movement
                     </button>
                   </li>
-                ))
+                </>
               )}
             </ul>
           ) : null}
         </div>
       )}
+
+      {submitOpen ? (
+        <SubmitMovementSubForm
+          initialCaliber={query.trim()}
+          onCancel={() => setSubmitOpen(false)}
+          onResolved={handleSubmitResolved}
+        />
+      ) : null}
+
+      {submitNotice ? (
+        <p
+          role="status"
+          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+        >
+          {submitNotice.kind === "created" ? (
+            <>
+              Submitted “{submitNotice.canonicalName}” for approval. Your watch can use it
+              right away; it&rsquo;ll appear on leaderboards once an admin reviews it.
+            </>
+          ) : (
+            <>
+              We already have “{submitNotice.canonicalName}” in the catalog — your watch
+              is now linked to the approved movement.
+            </>
+          )}
+        </p>
+      ) : null}
 
       {errorMessage ? (
         <span id={`${inputId}-error`} role="alert" className="text-sm text-cf-orange">

--- a/src/app/watches/SubmitMovementSubForm.tsx
+++ b/src/app/watches/SubmitMovementSubForm.tsx
@@ -1,0 +1,237 @@
+// Inline "submit a new movement" sub-form (slice #10).
+//
+// Rendered below <MovementTypeahead> when the user has no match for
+// their current query and clicks the "Can't find it?" affordance. On
+// successful submit the parent wires the returned movement into the
+// typeahead selection so the user can immediately add the watch
+// against the newly-created pending row. On an approved-slug collision
+// the backend returns the existing approved row and we do the same
+// auto-select (with a different notice).
+
+import { type FormEvent, useState } from "react";
+import { submitMovement, type MovementOption, type SubmitMovementBody } from "./api";
+
+export type SubmitMovementNotice =
+  | null
+  | { kind: "created"; canonicalName: string }
+  | { kind: "already_approved"; canonicalName: string };
+
+export interface SubmitMovementSubFormProps {
+  /** Pre-fills the caliber input so the user doesn't retype it. */
+  initialCaliber?: string;
+  /** Called when the user cancels without submitting. */
+  onCancel: () => void;
+  /**
+   * Called with the movement row to use for the parent watch form.
+   * The hosting component auto-selects it in the typeahead and
+   * collapses this sub-form. `notice` is an optional user-facing hint
+   * the parent renders (e.g. "Submitted for approval").
+   */
+  onResolved: (movement: MovementOption, notice: SubmitMovementNotice) => void;
+}
+
+type MovementType = SubmitMovementBody["type"];
+
+const TYPE_OPTIONS: { value: MovementType; label: string }[] = [
+  { value: "automatic", label: "Automatic" },
+  { value: "manual", label: "Manual wind" },
+  { value: "quartz", label: "Quartz" },
+  { value: "spring-drive", label: "Spring Drive" },
+  { value: "other", label: "Other" },
+];
+
+export function SubmitMovementSubForm({
+  initialCaliber = "",
+  onCancel,
+  onResolved,
+}: SubmitMovementSubFormProps) {
+  const [canonicalName, setCanonicalName] = useState("");
+  const [manufacturer, setManufacturer] = useState("");
+  const [caliber, setCaliber] = useState(initialCaliber);
+  const [type, setType] = useState<MovementType>("automatic");
+  const [notes, setNotes] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFieldErrors({});
+    setFormError(null);
+    setSubmitting(true);
+    const result = await submitMovement({
+      canonical_name: canonicalName.trim(),
+      manufacturer: manufacturer.trim(),
+      caliber: caliber.trim(),
+      type,
+      notes: notes.trim() || undefined,
+    });
+    setSubmitting(false);
+
+    switch (result.status) {
+      case "created":
+      case "exists_pending_own":
+        onResolved(result.movement, {
+          kind: "created",
+          canonicalName: result.movement.canonical_name,
+        });
+        return;
+      case "exists_approved":
+      case "exists_pending_other":
+        // The slug already exists — hand the existing movement to the
+        // parent so the watch can still be created, but flag it so the
+        // UI renders a "we already have this" notice instead of the
+        // "submitted for approval" one.
+        onResolved(result.movement, {
+          kind: "already_approved",
+          canonicalName: result.movement.canonical_name,
+        });
+        return;
+      case "invalid_input":
+        setFieldErrors(result.fieldErrors);
+        return;
+      case "unauthorized":
+        setFormError("Your session has expired. Please sign in again.");
+        return;
+      case "unknown":
+        setFormError(result.message);
+        return;
+    }
+  }
+
+  return (
+    <form
+      className="mt-2 flex flex-col gap-3 rounded-md border border-cf-border bg-cf-bg-200 p-4 text-sm"
+      onSubmit={handleSubmit}
+      noValidate
+    >
+      <p className="text-cf-text-muted">
+        Tell us about the caliber. An admin will review and approve it — you can still add
+        your watch right now.
+      </p>
+
+      <label className="flex flex-col gap-1 font-medium text-cf-text">
+        Display name
+        <input
+          type="text"
+          required
+          maxLength={100}
+          value={canonicalName}
+          onChange={(event) => setCanonicalName(event.target.value)}
+          placeholder="e.g. Seiko NH36A"
+          aria-invalid={fieldErrors.canonical_name ? true : undefined}
+          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+        />
+        {fieldErrors.canonical_name ? (
+          <span role="alert" className="text-sm text-cf-orange">
+            {fieldErrors.canonical_name}
+          </span>
+        ) : null}
+      </label>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 font-medium text-cf-text">
+          Manufacturer
+          <input
+            type="text"
+            required
+            maxLength={50}
+            value={manufacturer}
+            onChange={(event) => setManufacturer(event.target.value)}
+            placeholder="e.g. Seiko"
+            aria-invalid={fieldErrors.manufacturer ? true : undefined}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+          {fieldErrors.manufacturer ? (
+            <span role="alert" className="text-sm text-cf-orange">
+              {fieldErrors.manufacturer}
+            </span>
+          ) : null}
+        </label>
+        <label className="flex flex-col gap-1 font-medium text-cf-text">
+          Caliber
+          <input
+            type="text"
+            required
+            maxLength={50}
+            value={caliber}
+            onChange={(event) => setCaliber(event.target.value)}
+            placeholder="e.g. NH36A"
+            aria-invalid={fieldErrors.caliber ? true : undefined}
+            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          />
+          {fieldErrors.caliber ? (
+            <span role="alert" className="text-sm text-cf-orange">
+              {fieldErrors.caliber}
+            </span>
+          ) : null}
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1 font-medium text-cf-text">
+        Type
+        <select
+          value={type}
+          onChange={(event) => setType(event.target.value as MovementType)}
+          aria-invalid={fieldErrors.type ? true : undefined}
+          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+        >
+          {TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {fieldErrors.type ? (
+          <span role="alert" className="text-sm text-cf-orange">
+            {fieldErrors.type}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 font-medium text-cf-text">
+        Notes (optional)
+        <textarea
+          rows={2}
+          maxLength={500}
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder="Where did you learn about this caliber? Any references?"
+          aria-invalid={fieldErrors.notes ? true : undefined}
+          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+        />
+        {fieldErrors.notes ? (
+          <span role="alert" className="text-sm text-cf-orange">
+            {fieldErrors.notes}
+          </span>
+        ) : null}
+      </label>
+
+      {formError ? (
+        <p
+          role="alert"
+          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-cf-text"
+        >
+          {formError}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-full bg-cf-orange px-5 py-2 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+        >
+          {submitting ? "Submitting…" : "Submit movement"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm text-cf-text-muted hover:text-cf-text"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/watches/api.ts
+++ b/src/app/watches/api.ts
@@ -150,7 +150,7 @@ export interface MovementOption {
 export async function searchMovements(
   query: string,
   signal?: AbortSignal,
-): Promise<{ approved: MovementOption[] }> {
+): Promise<{ approved: MovementOption[]; suggestions: MovementOption[] }> {
   const qs = new URLSearchParams({ q: query, limit: "10" });
   const response = await fetch(`/api/v1/movements?${qs.toString()}`, {
     credentials: "include",
@@ -159,11 +159,87 @@ export async function searchMovements(
   if (!response.ok) {
     // Swallow errors in the typeahead — an empty list is the right UI
     // for "something went sideways mid-keystroke".
-    return { approved: [] };
+    return { approved: [], suggestions: [] };
   }
   const body = (await response.json()) as {
     approved: MovementOption[];
     suggestions: MovementOption[];
   };
-  return { approved: body.approved ?? [] };
+  return {
+    approved: body.approved ?? [],
+    suggestions: body.suggestions ?? [],
+  };
+}
+
+// Slice #10: submit a user-proposed movement. Mirrors the route's
+// discriminated response:
+//
+//   * 201 → { status: "created", movement }
+//   * 200 → { status: "exists_pending_own", movement } (idempotent)
+//   * 409 → { status: "exists_approved" | "exists_pending_other", movement }
+//   * 400 → { status: "invalid_input", fieldErrors }
+//   * 401 → { status: "unauthorized" }
+//
+// Any other response collapses to { status: "unknown" } with a readable
+// message so the sub-form can render it without special-casing.
+export interface SubmitMovementBody {
+  canonical_name: string;
+  manufacturer: string;
+  caliber: string;
+  type: "automatic" | "manual" | "quartz" | "spring-drive" | "other";
+  notes?: string;
+}
+
+export type SubmitMovementResult =
+  | { status: "created"; movement: MovementOption }
+  | { status: "exists_pending_own"; movement: MovementOption }
+  | { status: "exists_approved"; movement: MovementOption }
+  | { status: "exists_pending_other"; movement: MovementOption }
+  | { status: "invalid_input"; fieldErrors: Record<string, string> }
+  | { status: "unauthorized" }
+  | { status: "unknown"; message: string };
+
+export async function submitMovement(
+  body: SubmitMovementBody,
+): Promise<SubmitMovementResult> {
+  const response = await fetch("/api/v1/movements", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+
+  if (response.status === 201) {
+    const json = (await response.json()) as { movement: MovementOption };
+    return { status: "created", movement: json.movement };
+  }
+  if (response.status === 200) {
+    const json = (await response.json()) as { movement: MovementOption };
+    return { status: "exists_pending_own", movement: json.movement };
+  }
+  if (response.status === 409) {
+    const json = (await response.json()) as {
+      error: string;
+      movement: MovementOption;
+    };
+    const status =
+      json.error === "movement_exists_approved"
+        ? "exists_approved"
+        : "exists_pending_other";
+    return { status, movement: json.movement };
+  }
+  if (response.status === 400) {
+    const json = (await response.json()) as {
+      error?: string;
+      fieldErrors?: Record<string, string>;
+    };
+    return { status: "invalid_input", fieldErrors: json.fieldErrors ?? {} };
+  }
+  if (response.status === 401) {
+    return { status: "unauthorized" };
+  }
+  return {
+    status: "unknown",
+    message: `Request failed with status ${response.status}`,
+  };
 }

--- a/src/domain/movements/submit.ts
+++ b/src/domain/movements/submit.ts
@@ -1,0 +1,179 @@
+// Movement-submission domain module (slice #10).
+//
+// Input: validated SubmitMovementInput (from src/schemas/movement.ts)
+// + the submitting user's id.
+//
+// Output: a discriminated result that the HTTP layer maps to 201 / 200
+// / 409:
+//
+//   * "created"             → new pending row inserted.
+//   * "exists_approved"     → the generated slug already exists and is
+//                              approved. The route maps this to 409 so
+//                              the SPA can auto-select the approved row
+//                              instead of duplicating the request.
+//   * "exists_pending_own"  → the same user re-submitted (same slug,
+//                              still pending, still theirs). Idempotent
+//                              200 with the existing row.
+//
+// `exists_pending_other` (slug clash with another user's pending row)
+// is an edge case that slice #10 treats the same as "created" for that
+// other user — in practice the slug is deterministic from
+// `<manufacturer>-<caliber>`, and allowing two pending rows with the
+// same slug is forbidden by the PK. We therefore also cover it as
+// "exists_approved" semantics: another user's pending row means the
+// caller should use it by id, so we surface the same 409 shape. Note
+// expanded in mapResult below.
+
+import type { Kysely } from "kysely";
+import type { Database } from "@/db/schema";
+import type { Movement } from "./taxonomy";
+import type { SubmitMovementInput } from "@/schemas/movement";
+
+const MOVEMENT_COLUMNS = [
+  "id",
+  "canonical_name",
+  "manufacturer",
+  "caliber",
+  "type",
+  "status",
+  "notes",
+] as const;
+
+export type SubmitMovementResult =
+  | { status: "created"; movement: Movement }
+  | { status: "exists_approved"; movement: Movement }
+  | { status: "exists_pending_own"; movement: Movement }
+  | { status: "exists_pending_other"; movement: Movement };
+
+/**
+ * Generate a kebab-case slug from `<manufacturer>-<caliber>`. Matches
+ * the pattern used by the seed fixture (`eta-2892-a2`, `seiko-nh35`):
+ *
+ *   * Lower-cased.
+ *   * Spaces + underscores + slashes collapsed into single dashes.
+ *   * Non-[a-z0-9-] characters dropped.
+ *   * Leading/trailing dashes trimmed.
+ *   * Consecutive dashes collapsed.
+ *
+ * Exported (unprefixed) so tests can assert the contract directly
+ * without spinning up the full submit pipeline.
+ */
+export function generateMovementSlug(manufacturer: string, caliber: string): string {
+  const raw = `${manufacturer}-${caliber}`;
+  return raw
+    .toLowerCase()
+    .replace(/[\s_/]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function toMovement(row: {
+  id: string;
+  canonical_name: string;
+  manufacturer: string;
+  caliber: string;
+  type: Movement["type"];
+  status: Movement["status"];
+  notes: string | null;
+}): Movement {
+  return {
+    id: row.id,
+    canonical_name: row.canonical_name,
+    manufacturer: row.manufacturer,
+    caliber: row.caliber,
+    type: row.type,
+    status: row.status,
+    notes: row.notes,
+  };
+}
+
+/**
+ * Submit a user-proposed movement. Idempotent when the same user
+ * re-submits the same slug (returns the existing pending row). When
+ * the slug collides with an approved row, the approved row is
+ * returned — the caller should use it by id rather than duplicating.
+ *
+ * The function does NOT validate input — callers are expected to run
+ * it through `submitMovementSchema` first.
+ */
+export async function submitMovement(
+  db: Kysely<Database>,
+  input: SubmitMovementInput,
+  submittingUserId: string,
+): Promise<SubmitMovementResult> {
+  const id = generateMovementSlug(input.manufacturer, input.caliber);
+
+  // Look up first so the happy path for an idempotent re-submit and
+  // the collision path both stay cheap. D1 is a single-writer SQLite
+  // instance — the race between this SELECT and the INSERT is
+  // vanishingly small, and on conflict the INSERT's PK violation would
+  // surface as an error which we retry-read below.
+  const existing = await db
+    .selectFrom("movements")
+    .select([...MOVEMENT_COLUMNS, "submitted_by_user_id"])
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  if (existing) {
+    const movement = toMovement(existing);
+    if (existing.status === "approved") {
+      return { status: "exists_approved", movement };
+    }
+    // status === "pending"
+    if (existing.submitted_by_user_id === submittingUserId) {
+      return { status: "exists_pending_own", movement };
+    }
+    return { status: "exists_pending_other", movement };
+  }
+
+  try {
+    await db
+      .insertInto("movements")
+      .values({
+        id,
+        canonical_name: input.canonical_name,
+        manufacturer: input.manufacturer,
+        caliber: input.caliber,
+        type: input.type,
+        status: "pending",
+        submitted_by_user_id: submittingUserId,
+        notes: input.notes ?? null,
+        // `MovementsTable.created_at` is `string`, not `Generated<string>`,
+        // even though the SQL column has a DEFAULT. Supply one explicitly
+        // to keep the insert type-check clean without having to mutate
+        // the shared schema module (which is Worker J's lane).
+        created_at: new Date().toISOString(),
+      })
+      .execute();
+  } catch (err) {
+    // Lost the race with another INSERT of the same slug. Re-read and
+    // classify based on the current row state so the caller still
+    // gets a deterministic result.
+    const row = await db
+      .selectFrom("movements")
+      .select([...MOVEMENT_COLUMNS, "submitted_by_user_id"])
+      .where("id", "=", id)
+      .executeTakeFirst();
+    if (!row) {
+      // Truly unexpected — re-throw so it surfaces as a 500.
+      throw err;
+    }
+    const movement = toMovement(row);
+    if (row.status === "approved") {
+      return { status: "exists_approved", movement };
+    }
+    if (row.submitted_by_user_id === submittingUserId) {
+      return { status: "exists_pending_own", movement };
+    }
+    return { status: "exists_pending_other", movement };
+  }
+
+  const created = await db
+    .selectFrom("movements")
+    .select([...MOVEMENT_COLUMNS])
+    .where("id", "=", id)
+    .executeTakeFirstOrThrow();
+
+  return { status: "created", movement: toMovement(created) };
+}

--- a/src/domain/movements/taxonomy.ts
+++ b/src/domain/movements/taxonomy.ts
@@ -31,15 +31,21 @@ export interface MovementSearchOptions {
   limit?: number;
   /** When true, pending rows are included in `approved`. Defaults to false. */
   includePending?: boolean;
+  /**
+   * When set, pending movements submitted by this user id are surfaced
+   * in the `suggestions` array of the result. Used by the authed
+   * typeahead: a user can attach a watch to their own pending caliber
+   * before an admin approves it (slice #10).
+   */
+  suggestionsForUserId?: string;
 }
 
 export interface MovementSearchResult {
   approved: Movement[];
   /**
-   * Reserved for the submission flow in slice #10 — surfaced in the
-   * response shape from day one so the SPA consumer doesn't need a
-   * subsequent breaking change when suggestions start landing. Always
-   * an empty array for now.
+   * Pending movements visible to the caller. Populated only when
+   * `suggestionsForUserId` is passed — other users' pending rows are
+   * never leaked.
    */
   suggestions: Movement[];
 }
@@ -122,9 +128,34 @@ export function createMovementTaxonomy(db: Kysely<Database>) {
         .limit(limit)
         .execute();
 
+      // Slice #10: an authed caller also sees their own pending rows in
+      // the `suggestions` array. We intentionally issue a second query
+      // rather than union them into `approved` so the caller can render
+      // them differently (e.g. a "pending approval" badge).
+      let suggestions: Movement[] = [];
+      if (opts.suggestionsForUserId && !opts.includePending) {
+        const suggestionRows = await db
+          .selectFrom("movements")
+          .select([...MOVEMENT_COLUMNS])
+          .where("status", "=", "pending")
+          .where("submitted_by_user_id", "=", opts.suggestionsForUserId)
+          .where((eb) =>
+            eb.or([
+              sql<boolean>`LOWER(canonical_name) LIKE ${likeNeedle}`,
+              sql<boolean>`LOWER(manufacturer || ' ' || caliber) LIKE ${likeNeedle}`,
+              sql<boolean>`LOWER(REPLACE(REPLACE(canonical_name, '-', ''), ' ', '')) LIKE ${likeNormalized}`,
+            ]),
+          )
+          .orderBy("manufacturer")
+          .orderBy("canonical_name")
+          .limit(limit)
+          .execute();
+        suggestions = suggestionRows.map(toMovement);
+      }
+
       return {
         approved: rows.map(toMovement),
-        suggestions: [],
+        suggestions,
       };
     },
 

--- a/src/schemas/movement.ts
+++ b/src/schemas/movement.ts
@@ -1,0 +1,73 @@
+// Shared Zod schemas for the movement-submission flow (slice #10).
+// Imported by src/server/routes/movements.ts and the SPA's "submit a
+// new movement" inline sub-form in src/app/watches/WatchForm.tsx so the
+// two sides agree on validation + messages.
+//
+// Wire format:
+//   * `canonical_name` is the user-facing display string ("Seiko NH36A").
+//   * `manufacturer` + `caliber` drive the generated slug id on the
+//     server side (kebab-case, matches the curated seed pattern).
+//   * `type` is the movement CHECK-constraint enum from
+//     migrations/0002_movements.sql.
+//   * `notes` is optional, capped at 500 chars so the pending-review
+//     queue stays scannable.
+
+import { z } from "zod";
+
+const CANONICAL_MAX = 100;
+const MANUFACTURER_MAX = 50;
+const CALIBER_MAX = 50;
+const NOTES_MAX = 500;
+
+export const submitMovementSchema = z.object({
+  canonical_name: z
+    .string({ message: "Display name is required" })
+    .trim()
+    .min(2, { message: "Display name must be at least 2 characters" })
+    .max(CANONICAL_MAX, {
+      message: `Display name must be ${CANONICAL_MAX} characters or fewer`,
+    }),
+  manufacturer: z
+    .string({ message: "Manufacturer is required" })
+    .trim()
+    .min(1, { message: "Manufacturer is required" })
+    .max(MANUFACTURER_MAX, {
+      message: `Manufacturer must be ${MANUFACTURER_MAX} characters or fewer`,
+    }),
+  caliber: z
+    .string({ message: "Caliber is required" })
+    .trim()
+    .min(1, { message: "Caliber is required" })
+    .max(CALIBER_MAX, {
+      message: `Caliber must be ${CALIBER_MAX} characters or fewer`,
+    }),
+  type: z.enum(["automatic", "manual", "quartz", "spring-drive", "other"], {
+    message: "Pick a movement type",
+  }),
+  notes: z
+    .string()
+    .trim()
+    .max(NOTES_MAX, { message: `Notes must be ${NOTES_MAX} characters or fewer` })
+    .optional(),
+});
+
+export type SubmitMovementInput = z.infer<typeof submitMovementSchema>;
+
+/**
+ * Flatten a `z.ZodError` from `submitMovementSchema` into a
+ * `{ field: string }` record, keyed by the top-level field name.
+ * Matches the shape used by the watches + profile forms so the SPA
+ * renders inline errors the same way for every mutation.
+ */
+export function formatSubmitMovementErrors(
+  error: z.ZodError<SubmitMovementInput>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !(key in out)) {
+      out[key] = issue.message;
+    }
+  }
+  return out;
+}

--- a/src/server/routes/movements.ts
+++ b/src/server/routes/movements.ts
@@ -1,27 +1,42 @@
 // GET /api/v1/movements?q=<query>&limit=<n>
+// POST /api/v1/movements (authed)
 //
-// Public, unauthenticated endpoint used by:
+// The GET surface is public and consumed by:
 //   * the add-watch typeahead in the SPA (PRD slice 8)
 //   * future public browse pages
 //
-// Always returns `{ approved, suggestions }` — the latter is an empty
-// array until slice #10 wires up user-submitted pending movements.
-// Keeping the envelope stable from day one avoids a breaking shape
-// change when suggestions start landing.
+// The POST surface is authed and lets a user submit a new pending
+// movement when their watch's caliber isn't in the curated list
+// (slice #10). Response envelope is always `{ approved, suggestions }`
+// so the SPA can render both in the same dropdown.
+//
+// Auth detection for GET is best-effort: if a session exists we enrich
+// the response with the caller's own pending rows in `suggestions[]`;
+// if not, we quietly return an empty suggestions array and carry on.
+// Any auth error here (cookie rot, provider config hiccup) is isolated
+// from the anonymous fast path so a broken session never takes the
+// typeahead offline.
 
 import { Hono } from "hono";
 import { z } from "zod";
 import { createDb } from "@/db";
 import { createMovementTaxonomy } from "@/domain/movements/taxonomy";
+import { submitMovement } from "@/domain/movements/submit";
+import { formatSubmitMovementErrors, submitMovementSchema } from "@/schemas/movement";
+import { getAuth, type AuthEnv } from "@/server/auth";
+import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
 
-type Bindings = { DB: D1Database; [key: string]: unknown };
+type Bindings = AuthEnv & { DB: D1Database; [key: string]: unknown };
 
 const movementsQuerySchema = z.object({
   q: z.string().trim().min(1).max(100).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
 });
 
-export const movementsRoute = new Hono<{ Bindings: Bindings }>();
+export const movementsRoute = new Hono<{
+  Bindings: Bindings;
+  Variables: RequireAuthVariables;
+}>();
 
 movementsRoute.get("/", async (c) => {
   const parsed = movementsQuerySchema.safeParse({
@@ -39,8 +54,80 @@ movementsRoute.get("/", async (c) => {
     return c.json({ approved: [], suggestions: [] });
   }
 
+  // Best-effort session read. The GET endpoint is public, but an authed
+  // caller sees their own pending submissions in `suggestions[]`. We
+  // swallow any error here so a broken cookie doesn't take the
+  // anonymous path offline.
+  let submittingUserId: string | undefined;
+  try {
+    const auth = getAuth(c.env);
+    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    submittingUserId = (session?.user as { id: string } | undefined)?.id;
+  } catch {
+    submittingUserId = undefined;
+  }
+
   const db = createDb(c.env);
   const taxonomy = createMovementTaxonomy(db);
-  const result = await taxonomy.search(q, { limit });
+  const result = await taxonomy.search(q, {
+    limit,
+    suggestionsForUserId: submittingUserId,
+  });
   return c.json(result);
+});
+
+// POST is authed. Mounted after GET so the public search stays open.
+movementsRoute.post("/", requireAuth, async (c) => {
+  const user = c.get("user");
+
+  let json: unknown;
+  try {
+    json = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+
+  const parsed = submitMovementSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json(
+      { error: "invalid_input", fieldErrors: formatSubmitMovementErrors(parsed.error) },
+      400,
+    );
+  }
+
+  const db = createDb(c.env);
+  const result = await submitMovement(db, parsed.data, user.id);
+
+  switch (result.status) {
+    case "created":
+      return c.json({ movement: result.movement }, 201);
+    case "exists_pending_own":
+      // Idempotent re-submit — same user, same slug, still pending.
+      return c.json({ movement: result.movement }, 200);
+    case "exists_approved":
+      // The slug already exists as an approved row. Surface it so the
+      // SPA can auto-select it instead of duplicating the submission.
+      return c.json(
+        {
+          error: "movement_exists_approved",
+          id: result.movement.id,
+          canonical_name: result.movement.canonical_name,
+          movement: result.movement,
+        },
+        409,
+      );
+    case "exists_pending_other":
+      // Slug clashes with another user's pending row. Treat the same
+      // as an approved collision from the caller's perspective — they
+      // should use the existing row by id rather than duplicate.
+      return c.json(
+        {
+          error: "movement_exists_pending",
+          id: result.movement.id,
+          canonical_name: result.movement.canonical_name,
+          movement: result.movement,
+        },
+        409,
+      );
+  }
 });

--- a/tests/integration/movements.submit.test.ts
+++ b/tests/integration/movements.submit.test.ts
@@ -1,0 +1,331 @@
+// Integration tests for slice #10 — movement submission flow.
+// Covers:
+//   * POST /api/v1/movements happy path (authed → 201 pending row).
+//   * POST anonymous → 401.
+//   * POST validation (missing fields, bad enum) → 400.
+//   * POST collision with an approved row → 409 + approved row in body.
+//   * POST idempotent re-submit (same user, same slug) → 200.
+//   * GET suggestions visibility:
+//       - submitter sees own pending in `suggestions[]`.
+//       - other users do NOT see it.
+//       - anonymous callers do NOT see it.
+//
+// Kept in a separate file from movements.test.ts to minimize merge
+// surface with parallel workers.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+interface MovementBody {
+  id: string;
+  canonical_name: string;
+  manufacturer: string;
+  caliber: string;
+  type: "automatic" | "manual" | "quartz" | "spring-drive" | "other";
+  status: "approved" | "pending";
+  notes: string | null;
+}
+
+interface SubmitSuccess {
+  movement: MovementBody;
+}
+
+interface SubmitCollision {
+  error: string;
+  id: string;
+  canonical_name: string;
+  movement: MovementBody;
+}
+
+interface SearchBody {
+  approved: MovementBody[];
+  suggestions: MovementBody[];
+}
+
+// --- helpers ---------------------------------------------------------
+
+function makeEmail(prefix = "submovement"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function signUp(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: email.split("@")[0]!, email, password }),
+    }),
+  );
+}
+
+async function signIn(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+}
+
+interface TestUser {
+  cookie: string;
+  userId: string;
+}
+
+async function registerAndGetCookie(): Promise<TestUser> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await signUp(email, password);
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as { user: { id: string } };
+  const loginRes = await signIn(email, password);
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return { cookie, userId: regBody.user.id };
+}
+
+async function submitMovementHttp(body: unknown, cookie?: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/movements", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function searchMovements(q: string, cookie?: string): Promise<Response> {
+  const qs = new URLSearchParams({ q }).toString();
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/movements?${qs}`, {
+      headers: cookie ? { cookie } : {},
+    }),
+  );
+}
+
+// Some tests register two users — miniflare + scrypt makes that
+// expensive, so bump the timeout.
+const TWO_USER_TIMEOUT = 30_000;
+
+// --- tests -----------------------------------------------------------
+
+describe("POST /api/v1/movements — submit", () => {
+  it("creates a pending movement with the submitter attached", async () => {
+    const user = await registerAndGetCookie();
+    const unique = crypto.randomUUID().slice(0, 8);
+    const res = await submitMovementHttp(
+      {
+        canonical_name: `Acme Cal. ${unique}`,
+        manufacturer: "Acme",
+        caliber: `cal-${unique}`,
+        type: "automatic",
+        notes: "User reports excellent timing",
+      },
+      user.cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as SubmitSuccess;
+    expect(body.movement.status).toBe("pending");
+    expect(body.movement.manufacturer).toBe("Acme");
+    expect(body.movement.canonical_name).toBe(`Acme Cal. ${unique}`);
+    expect(body.movement.id).toBe(`acme-cal-${unique}`);
+
+    // Confirm the row landed with submitted_by_user_id = this user.
+    const db = (env as unknown as { DB: D1Database }).DB;
+    const row = await db
+      .prepare("SELECT submitted_by_user_id, status FROM movements WHERE id = ?")
+      .bind(body.movement.id)
+      .first<{ submitted_by_user_id: string | null; status: string }>();
+    expect(row?.submitted_by_user_id).toBe(user.userId);
+    expect(row?.status).toBe("pending");
+  });
+
+  it("rejects an unauthenticated submission (401)", async () => {
+    const unique = crypto.randomUUID().slice(0, 8);
+    const res = await submitMovementHttp({
+      canonical_name: `Anon ${unique}`,
+      manufacturer: "Anon",
+      caliber: `x-${unique}`,
+      type: "quartz",
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("rejects missing manufacturer (400) with a readable message", async () => {
+    const user = await registerAndGetCookie();
+    const res = await submitMovementHttp(
+      {
+        canonical_name: "No manufacturer",
+        caliber: "whatever-1",
+        type: "automatic",
+      },
+      user.cookie,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.error).toBe("invalid_input");
+    expect(body.fieldErrors.manufacturer).toBe("Manufacturer is required");
+  });
+
+  it("rejects a bogus type enum value (400)", async () => {
+    const user = await registerAndGetCookie();
+    const res = await submitMovementHttp(
+      {
+        canonical_name: "Bad type",
+        manufacturer: "X",
+        caliber: "y-1",
+        type: "not-a-type",
+      },
+      user.cookie,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.error).toBe("invalid_input");
+    expect(body.fieldErrors.type).toBeTruthy();
+  });
+
+  it("collides with an approved row and returns 409 with the approved movement", async () => {
+    // Seed an approved row with a slug we'll try to collide against.
+    const unique = crypto.randomUUID().slice(0, 8);
+    const collidingId = `collide-caliber-${unique}`;
+    const db = (env as unknown as { DB: D1Database }).DB;
+    await db
+      .prepare(
+        "INSERT INTO movements (id, canonical_name, manufacturer, caliber, type, status) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        collidingId,
+        `Collide Caliber ${unique}`,
+        "collide",
+        `caliber-${unique}`,
+        "automatic",
+        "approved",
+      )
+      .run();
+
+    const user = await registerAndGetCookie();
+    const res = await submitMovementHttp(
+      {
+        canonical_name: "Collide again",
+        manufacturer: "collide",
+        caliber: `caliber-${unique}`,
+        type: "automatic",
+      },
+      user.cookie,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as SubmitCollision;
+    expect(body.error).toBe("movement_exists_approved");
+    expect(body.id).toBe(collidingId);
+    expect(body.movement.status).toBe("approved");
+    expect(body.movement.canonical_name).toBe(`Collide Caliber ${unique}`);
+  });
+
+  it("is idempotent when the same user re-submits (200 with existing row)", async () => {
+    const user = await registerAndGetCookie();
+    const unique = crypto.randomUUID().slice(0, 8);
+    const payload = {
+      canonical_name: `Dupe Cal ${unique}`,
+      manufacturer: "Dupe",
+      caliber: `x-${unique}`,
+      type: "manual" as const,
+    };
+
+    const first = await submitMovementHttp(payload, user.cookie);
+    expect(first.status).toBe(201);
+    const firstBody = (await first.json()) as SubmitSuccess;
+
+    const second = await submitMovementHttp(payload, user.cookie);
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as SubmitSuccess;
+    expect(secondBody.movement.id).toBe(firstBody.movement.id);
+    expect(secondBody.movement.status).toBe("pending");
+  });
+});
+
+describe("GET /api/v1/movements — suggestions visibility", () => {
+  it("submitter sees their own pending movement in suggestions", async () => {
+    const user = await registerAndGetCookie();
+    const unique = crypto.randomUUID().slice(0, 8);
+    const canonicalName = `SuggVisible ${unique}`;
+    const submit = await submitMovementHttp(
+      {
+        canonical_name: canonicalName,
+        manufacturer: "suggvisible",
+        caliber: `c-${unique}`,
+        type: "automatic",
+      },
+      user.cookie,
+    );
+    expect(submit.status).toBe(201);
+
+    const search = await searchMovements("suggvisible", user.cookie);
+    expect(search.status).toBe(200);
+    const body = (await search.json()) as SearchBody;
+    const suggestionIds = body.suggestions.map((m) => m.id);
+    expect(suggestionIds).toContain(`suggvisible-c-${unique}`);
+    // Never leaks into approved.
+    expect(body.approved.map((m) => m.id)).not.toContain(`suggvisible-c-${unique}`);
+  });
+
+  it(
+    "a different user does not see someone else's pending submission",
+    async () => {
+      const alice = await registerAndGetCookie();
+      const bob = await registerAndGetCookie();
+      const unique = crypto.randomUUID().slice(0, 8);
+      const submit = await submitMovementHttp(
+        {
+          canonical_name: `Alice Only ${unique}`,
+          manufacturer: "aliceonly",
+          caliber: `c-${unique}`,
+          type: "automatic",
+        },
+        alice.cookie,
+      );
+      expect(submit.status).toBe(201);
+
+      const search = await searchMovements("aliceonly", bob.cookie);
+      expect(search.status).toBe(200);
+      const body = (await search.json()) as SearchBody;
+      expect(body.suggestions.map((m) => m.id)).not.toContain(`aliceonly-c-${unique}`);
+      expect(body.approved.map((m) => m.id)).not.toContain(`aliceonly-c-${unique}`);
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it("anonymous callers never see pending submissions", async () => {
+    const user = await registerAndGetCookie();
+    const unique = crypto.randomUUID().slice(0, 8);
+    const submit = await submitMovementHttp(
+      {
+        canonical_name: `Hidden From Anon ${unique}`,
+        manufacturer: "hiddenanon",
+        caliber: `c-${unique}`,
+        type: "automatic",
+      },
+      user.cookie,
+    );
+    expect(submit.status).toBe(201);
+
+    const search = await searchMovements("hiddenanon");
+    expect(search.status).toBe(200);
+    const body = (await search.json()) as SearchBody;
+    expect(body.suggestions).toEqual([]);
+    expect(body.approved.map((m) => m.id)).not.toContain(`hiddenanon-c-${unique}`);
+  });
+});


### PR DESCRIPTION
Closes #10.

## Summary

Lets an authed user submit a new movement when their watch's caliber isn't in the curated list. The row lands as `status='pending'` with `submitted_by_user_id` attached, shows up in their typeahead as a "Pending" suggestion, and can be attached to a watch right away. Other users — and anonymous callers — never see it until an admin approves it via direct SQL (documented in `infra/README.md`).

## API

- **`POST /api/v1/movements`** (authed)
  - 201 `{ movement }` on create
  - 200 `{ movement }` on idempotent re-submit (same user, same slug, still pending)
  - 409 `{ error: "movement_exists_approved"|"movement_exists_pending", id, canonical_name, movement }` on slug collision so the SPA can auto-select the existing row
  - 400 `{ error: "invalid_input", fieldErrors }` for Zod failures
  - 401 `{ error: "unauthorized" }` for anonymous callers
- **`GET /api/v1/movements?q=...`** now surfaces the authed caller's own pending rows in the existing `suggestions[]` field. Anonymous + other-user searches are unchanged. Session read is best-effort, so a broken cookie doesn't take the anonymous path offline.

Slugs are generated deterministically as `<manufacturer>-<caliber>` (kebab, matching the seed pattern) via a pure `generateMovementSlug()` in `src/domain/movements/submit.ts`.

## SPA

- Empty typeahead results now render a **"Can't find it? Submit new movement"** affordance; a footer variant appears when there are matches but the user still wants to propose one.
- `SubmitMovementSubForm` collapses inline, pre-fills the caliber input with the current query, and on success auto-selects the returned movement in the parent form — followed by a small "Submitted for approval" notice (or "We already have this one" on an approved-collision).
- Selected pending movements render a "Pending approval" badge on the selection strip.

## Tests

**9 new integration tests** in `tests/integration/movements.submit.test.ts` (128/128 passing, up from 119):

- Submit happy path → 201, pending row, `submitted_by_user_id` matches caller.
- Anonymous submit → 401.
- Missing manufacturer → 400 with readable error.
- Bad `type` enum → 400.
- Collide with approved → 409 + approved row in body.
- Idempotent re-submit → 200 with existing row.
- Submitter sees own pending in `suggestions[]`.
- Other user does NOT see it.
- Anonymous does NOT see it.

## Moderation

`infra/README.md` (new) documents the phase-1 workflow: list pending rows, approve via `UPDATE movements SET status='approved'`, delete to reject, edit-in-place before approval. Operator invokes via `wrangler d1 execute rated-watch-db --remote --command "..."`.

## Files touched

- `src/schemas/movement.ts` (new)
- `src/domain/movements/submit.ts` (new)
- `src/domain/movements/taxonomy.ts` (extended — `suggestionsForUserId` option)
- `src/server/routes/movements.ts` (extended — `POST`, authed suggestions)
- `src/app/watches/api.ts` (extended — `submitMovement()`, return full `suggestions[]`)
- `src/app/watches/SubmitMovementSubForm.tsx` (new)
- `src/app/watches/MovementTypeahead.tsx` (extended — "Can't find it?" link, pending suggestions, notice)
- `tests/integration/movements.submit.test.ts` (new)
- `infra/README.md` (new)

No migration. `src/db/schema.ts` untouched (Worker J's lane). `src/worker/index.tsx` untouched (existing mount already covers `POST /api/v1/movements`).

## Verification

- `npm run typecheck` → clean
- `npm run build` → clean
- `npm run test` → **128 passed (128)**, 15 test files
- Pre-commit hooks (lint-staged + `vitest related`) ran on both commits and passed.

## Deviations / followups

- The spec originally proposed extending the existing `movements.test.ts`; per the dispatch's explicit "do NOT pile onto existing `movements.test.ts`" instruction I put the new suite in a separate file to minimize merge surface with parallel workers.
- `MovementsTable.created_at` is typed as `string` rather than `Generated<string>` in `src/db/schema.ts`, so the submit insert explicitly supplies an ISO timestamp rather than relying on the SQL DEFAULT. This stays within my lane — Worker J owns `src/db/schema.ts`. A followup could flip it to `Generated<>` to match the pattern used for `watches.created_at`.