### PR TITLE
Slice 12: Manual readings + drift-calc + session stats UI

### DIFF
--- a/migrations/0004_readings.sql
+++ b/migrations/0004_readings.sql
@@ -1,0 +1,47 @@
+-- Slice 12 (issue #13): readings table.
+--
+-- A "reading" is one recorded observation of a watch's displayed time
+-- against an authoritative reference time. The `deviation_seconds`
+-- is the signed difference at that moment (positive = watch ahead).
+-- Readings anchor sessions and drift calculations (see
+-- src/domain/drift-calc/).
+--
+-- Design notes:
+--   * `user_id` is denormalised from `watches.user_id` so per-user
+--     queries (e.g. "all my readings this week") stay a single-table
+--     scan. Integrity is maintained by always setting it on INSERT
+--     from the authed session and by the `watches` ownership check
+--     at the API layer.
+--   * `reference_timestamp` is unix milliseconds INTEGER — easier to
+--     arithmetic on than ISO strings, and matches Date.now() on the
+--     client side without conversion. `created_at` stays ISO for
+--     consistency with the rest of the schema.
+--   * SQLite has no native boolean, so `is_baseline` / `verified`
+--     are INTEGER 0/1 with CHECK constraints. The Kysely schema
+--     surfaces them as `number` and the API layer flips them to
+--     boolean at the wire boundary.
+--   * `deviation_seconds` is REAL so sub-second precision from the
+--     verified-capture flow (slice #16) survives the DB round-trip.
+--   * ON DELETE CASCADE on watch_id so removing a watch cleans up
+--     its readings. Same for user_id so account deletion is clean.
+
+CREATE TABLE IF NOT EXISTS readings (
+  id TEXT PRIMARY KEY NOT NULL,
+  watch_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  reference_timestamp INTEGER NOT NULL,
+  deviation_seconds REAL NOT NULL,
+  is_baseline INTEGER NOT NULL DEFAULT 0 CHECK (is_baseline IN (0, 1)),
+  verified INTEGER NOT NULL DEFAULT 0 CHECK (verified IN (0, 1)),
+  notes TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY (watch_id) REFERENCES watches(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+
+-- The two hot lookup paths:
+--   1. "list readings for a watch in chronological order" (session stats)
+--   2. "list readings for a user" (per-user summaries in later slices)
+CREATE INDEX IF NOT EXISTS idx_readings_watch_id_ref_ts
+  ON readings(watch_id, reference_timestamp);
+CREATE INDEX IF NOT EXISTS idx_readings_user_id ON readings(user_id);

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -1,21 +1,66 @@
-// Read-only view of a single watch with Edit + Delete affordances.
-// Readings / drift charts land in a later slice; the layout here
-// leaves room for that section beneath the metadata.
+// Detail view of a single watch. Read-only metadata at the top,
+// then — slice #13 — session stats, a "log a reading" form, and the
+// reading log itself. Delete-watch still lives at the bottom.
+//
+// The readings section fetches in parallel with the watch lookup so
+// the page doesn't need two sequential round-trips to render. Every
+// mutation (log, delete) calls `reloadReadings()` to re-pull both
+// the list and the server-computed session stats.
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
+import { LogReadingForm } from "../watches/LogReadingForm";
+import { ReadingList } from "../watches/ReadingList";
+import { SessionStatsPanel } from "../watches/SessionStatsPanel";
 import { deleteWatch, getWatch, type Watch } from "../watches/api";
+import { listReadings, type Reading, type SessionStats } from "../watches/readings";
 
 type LoadState =
   | { kind: "loading" }
   | { kind: "loaded"; watch: Watch }
   | { kind: "error"; message: string };
 
+interface ReadingsState {
+  readings: Reading[];
+  session_stats: SessionStats | null;
+  error: string | null;
+  loading: boolean;
+}
+
+const EMPTY_READINGS_STATE: ReadingsState = {
+  readings: [],
+  session_stats: null,
+  error: null,
+  loading: true,
+};
+
 export function WatchDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [readings, setReadings] = useState<ReadingsState>(EMPTY_READINGS_STATE);
   const [deleting, setDeleting] = useState(false);
+
+  const reloadReadings = useCallback(async () => {
+    if (!id) return;
+    setReadings((prev) => ({ ...prev, loading: true }));
+    const result = await listReadings(id);
+    if (result.ok) {
+      setReadings({
+        readings: result.readings,
+        session_stats: result.session_stats,
+        error: null,
+        loading: false,
+      });
+    } else {
+      setReadings({
+        readings: [],
+        session_stats: null,
+        error: result.error.message,
+        loading: false,
+      });
+    }
+  }, [id]);
 
   useEffect(() => {
     if (!id) return;
@@ -33,6 +78,13 @@ export function WatchDetailPage() {
       cancelled = true;
     };
   }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    // Don't wait on the watch lookup — fetch readings in parallel.
+    // Errors are stored in-panel, not propagated to the whole page.
+    void reloadReadings();
+  }, [id, reloadReadings]);
 
   async function handleDelete() {
     if (!id) return;
@@ -81,7 +133,7 @@ export function WatchDetailPage() {
       : "—";
 
   return (
-    <section className="mx-auto max-w-2xl">
+    <section className="mx-auto max-w-3xl">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
           <h1 className="mb-1 text-4xl font-medium tracking-tight text-cf-text">
@@ -121,11 +173,24 @@ export function WatchDetailPage() {
         </dd>
       </dl>
 
-      <div className="mb-10 rounded-md border border-cf-border bg-cf-bg-200 px-4 py-3 text-sm text-cf-text-muted">
-        Readings, drift charts, and session stats ship in a later slice.
-      </div>
+      {readings.error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+        >
+          {readings.error}
+        </p>
+      ) : null}
 
-      <div className="flex flex-wrap items-center gap-3">
+      <SessionStatsPanel stats={readings.session_stats} />
+      <LogReadingForm watchId={watch.id} onLogged={reloadReadings} />
+      <ReadingList
+        readings={readings.readings}
+        perInterval={readings.session_stats?.per_interval ?? []}
+        onDeleted={reloadReadings}
+      />
+
+      <div className="mt-10 flex flex-wrap items-center gap-3">
         <Link
           to={`/app/watches/${watch.id}/edit`}
           className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"

--- a/src/app/watches/LogReadingForm.tsx
+++ b/src/app/watches/LogReadingForm.tsx
@@ -1,0 +1,191 @@
+// "Log a manual reading" form. Lives below the session stats panel
+// on the watch detail page. Submits to POST /api/v1/watches/:id/readings
+// via the readings API client.
+//
+// UX notes:
+//   * "This is a baseline" checkbox — when checked, disables the
+//     deviation input and forces its visual state to 0. The server
+//     enforces the same rule defensively.
+//   * Reference time defaults to "now" (Date.now()), editable via a
+//     standard datetime-local input. The server stores unix ms;
+//     conversion happens here.
+//   * Success/failure are reported back to the parent via `onLogged`
+//     (the parent reloads the list + stats).
+
+import { useState, type FormEvent } from "react";
+import { createReading } from "./readings";
+
+interface Props {
+  watchId: string;
+  onLogged: () => void;
+}
+
+/**
+ * Turn a <input type="datetime-local"> value into unix ms. The input
+ * emits local-TZ strings like "2025-01-15T14:30"; Date() parses them
+ * in the browser's local timezone which is what the user expects.
+ */
+function localInputToMs(value: string): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Format a unix ms timestamp as a local-TZ datetime-local value so
+ * the input populates correctly on mount. `Date.toISOString()` uses
+ * UTC — we need the local equivalent, trimmed to minute precision.
+ */
+function msToLocalInput(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function LogReadingForm({ watchId, onLogged }: Props) {
+  const [deviationInput, setDeviationInput] = useState("");
+  const [isBaseline, setIsBaseline] = useState(false);
+  const [refInput, setRefInput] = useState(() => msToLocalInput(Date.now()));
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setFieldErrors({});
+
+    const referenceMs = localInputToMs(refInput);
+    if (referenceMs === null) {
+      setError("Reference time is required");
+      return;
+    }
+
+    const deviation = isBaseline ? 0 : Number.parseFloat(deviationInput);
+    if (!isBaseline && !Number.isFinite(deviation)) {
+      setFieldErrors({ deviation_seconds: "Deviation is required" });
+      return;
+    }
+
+    setSubmitting(true);
+    const result = await createReading(watchId, {
+      reference_timestamp: referenceMs,
+      deviation_seconds: deviation,
+      is_baseline: isBaseline,
+      notes: notes.trim() || undefined,
+    });
+    setSubmitting(false);
+
+    if (!result.ok) {
+      setError(result.error.message);
+      setFieldErrors(result.error.fieldErrors ?? {});
+      return;
+    }
+
+    // Reset the form for the next entry, keep the reference time at
+    // "now" so rapid-fire logging works without edits.
+    setDeviationInput("");
+    setIsBaseline(false);
+    setRefInput(msToLocalInput(Date.now()));
+    setNotes("");
+    onLogged();
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5"
+    >
+      <h2 className="mb-4 text-sm font-medium text-cf-text">Log a reading</h2>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mb-4 grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm">
+          <span className="mb-1 block text-cf-text-muted">
+            Deviation (seconds){" "}
+            <span
+              className="text-cf-text-subtle"
+              title="Positive if watch is AHEAD of reference time; negative if behind"
+            >
+              ⓘ
+            </span>
+          </span>
+          <input
+            type="number"
+            step="0.1"
+            inputMode="decimal"
+            value={isBaseline ? "0" : deviationInput}
+            onChange={(e) => setDeviationInput(e.target.value)}
+            disabled={isBaseline || submitting}
+            placeholder="e.g. 2.5 or -1.3"
+            aria-invalid={!!fieldErrors.deviation_seconds}
+            className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-mono text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-orange focus:outline-none disabled:opacity-60"
+          />
+          {fieldErrors.deviation_seconds ? (
+            <span className="mt-1 block text-xs text-cf-orange">
+              {fieldErrors.deviation_seconds}
+            </span>
+          ) : null}
+        </label>
+
+        <label className="block text-sm">
+          <span className="mb-1 block text-cf-text-muted">Reference time</span>
+          <input
+            type="datetime-local"
+            value={refInput}
+            onChange={(e) => setRefInput(e.target.value)}
+            disabled={submitting}
+            className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-mono text-sm text-cf-text focus:border-cf-orange focus:outline-none disabled:opacity-60"
+          />
+        </label>
+      </div>
+
+      <label className="mb-4 flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={isBaseline}
+          onChange={(e) => setIsBaseline(e.target.checked)}
+          disabled={submitting}
+          className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-orange focus:ring-cf-orange"
+        />
+        <span>
+          <span className="text-cf-text">This is a baseline</span>
+          <span className="ml-1 text-cf-text-muted">
+            — watch just set to the exact time; deviation = 0
+          </span>
+        </span>
+      </label>
+
+      <label className="mb-4 block text-sm">
+        <span className="mb-1 block text-cf-text-muted">Notes (optional)</span>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={submitting}
+          rows={2}
+          maxLength={500}
+          className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-orange focus:outline-none disabled:opacity-60"
+          placeholder="e.g. worn overnight face-up, 20ºC"
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="inline-flex items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-2.5 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90 disabled:opacity-60"
+      >
+        {submitting ? "Logging…" : "Log reading"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/watches/ReadingList.tsx
+++ b/src/app/watches/ReadingList.tsx
@@ -1,0 +1,130 @@
+// Reading log table. Shows every reading in reverse-chronological
+// order with its deviation, reference time, the drift rate since the
+// previous reading (if computable), a verified tick, notes, and a
+// delete button.
+//
+// Drift per row is pulled from the `session_stats.per_interval` array
+// so we reuse the pure drift-calc result rather than recomputing on
+// the client. Readings outside the current session (i.e. before the
+// last baseline) render "—" for drift.
+
+import { useState } from "react";
+import { deleteReading, type PerIntervalDrift, type Reading } from "./readings";
+
+interface Props {
+  readings: Reading[];
+  perInterval: PerIntervalDrift[];
+  onDeleted: () => void;
+}
+
+function formatDeviation(secs: number): string {
+  const rounded = Math.round(secs * 100) / 100;
+  const sign = rounded > 0 ? "+" : rounded < 0 ? "" : "";
+  return `${sign}${rounded.toFixed(2)} s`;
+}
+
+function formatDrift(spd: number): string {
+  const rounded = Math.round(spd * 100) / 100;
+  const sign = rounded > 0 ? "+" : rounded < 0 ? "" : "";
+  return `${sign}${rounded.toFixed(2)} s/d`;
+}
+
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+export function ReadingList({ readings, perInterval, onDeleted }: Props) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  if (readings.length === 0) {
+    return null;
+  }
+
+  // Build a lookup: to_reading_id -> drift rate. The array is session-
+  // scoped, so readings outside the current session legitimately have
+  // no entry and render "—".
+  const driftByToId = new Map<string, number>();
+  for (const iv of perInterval) {
+    driftByToId.set(iv.to_reading_id, iv.drift_rate_spd);
+  }
+
+  // Display newest-first — the API returns oldest-first so per-interval
+  // math is stable. We copy + reverse so we don't mutate the prop.
+  const displayReadings = [...readings].reverse();
+
+  async function handleDelete(id: string) {
+    if (!window.confirm("Delete this reading? This cannot be undone.")) return;
+    setDeletingId(id);
+    const res = await deleteReading(id);
+    setDeletingId(null);
+    if (!res.ok) {
+      window.alert(res.error.message);
+      return;
+    }
+    onDeleted();
+  }
+
+  return (
+    <div className="mb-6 overflow-hidden rounded-lg border border-cf-border bg-cf-bg-200">
+      <div className="border-b border-cf-border px-5 py-3 text-sm font-medium text-cf-text">
+        Reading log
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-cf-bg-100 text-left text-xs uppercase tracking-wide text-cf-text-subtle">
+            <tr>
+              <th className="px-4 py-2">Reference time</th>
+              <th className="px-4 py-2">Deviation</th>
+              <th className="px-4 py-2">Drift since prev</th>
+              <th className="px-4 py-2">Verified</th>
+              <th className="px-4 py-2">Notes</th>
+              <th className="px-4 py-2" aria-label="actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {displayReadings.map((r) => {
+              const drift = driftByToId.get(r.id);
+              return (
+                <tr
+                  key={r.id}
+                  className="border-t border-cf-border align-top first:border-t-0"
+                >
+                  <td className="px-4 py-3 font-mono text-xs text-cf-text">
+                    {formatTime(r.reference_timestamp)}
+                    {r.is_baseline ? (
+                      <span className="ml-2 rounded-full border border-cf-orange/40 bg-cf-orange/10 px-1.5 py-0.5 text-[10px] font-medium text-cf-orange">
+                        baseline
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-cf-text">
+                    {formatDeviation(r.deviation_seconds)}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-cf-text-muted">
+                    {drift === undefined ? "—" : formatDrift(drift)}
+                  </td>
+                  <td className="px-4 py-3 text-cf-text-muted">
+                    {r.verified ? "✓" : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-cf-text-muted">
+                    {r.notes ? r.notes : ""}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(r.id)}
+                      disabled={deletingId === r.id}
+                      className="text-xs text-cf-text-muted transition-colors hover:text-cf-orange disabled:opacity-60"
+                    >
+                      {deletingId === r.id ? "Deleting…" : "Delete"}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/watches/SessionStatsPanel.tsx
+++ b/src/app/watches/SessionStatsPanel.tsx
@@ -1,0 +1,117 @@
+// Read-only session stats panel that lives above the reading log on
+// the watch detail page. Derives every display label from the raw
+// SessionStats so there's no client-side drift math duplication.
+//
+// Design rules (AGENTS.md):
+//   * Hide avg_drift when reading_count < 2 (no drift computable yet).
+//   * Show eligibility + verified-badge as chips. Tone stays neutral
+//     while the watch is ineligible; warm CF orange when a milestone
+//     is hit.
+
+import type { SessionStats } from "./readings";
+
+interface Props {
+  stats: SessionStats | null;
+}
+
+function formatDays(days: number): string {
+  const rounded = Math.round(days * 10) / 10;
+  if (rounded === 1) return "1 day";
+  return `${rounded} days`;
+}
+
+function formatDrift(spd: number): string {
+  // Preserve the sign; round to 2 decimals so panel numbers stay
+  // calm at read time. Sub-decimal precision is overkill for UI.
+  const rounded = Math.round(spd * 100) / 100;
+  const sign = rounded > 0 ? "+" : rounded < 0 ? "" : "";
+  return `${sign}${rounded.toFixed(2)} s/d`;
+}
+
+function formatDeviation(secs: number): string {
+  const rounded = Math.round(secs * 10) / 10;
+  const sign = rounded > 0 ? "+" : rounded < 0 ? "" : "";
+  return `${sign}${rounded.toFixed(1)} s`;
+}
+
+export function SessionStatsPanel({ stats }: Props) {
+  if (!stats || stats.reading_count === 0) {
+    return (
+      <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 px-5 py-4 text-sm text-cf-text-muted">
+        <p className="mb-1 font-medium text-cf-text">No readings yet</p>
+        <p>
+          Log your first reading below. Mark it as a baseline to start a tracking session.
+        </p>
+      </div>
+    );
+  }
+
+  // No baseline in the input → the API still returns reading_count >0
+  // but session_days=0. Surface that state specifically.
+  const hasSession = stats.baseline_reference_timestamp > 0;
+  const showAvgDrift = stats.reading_count >= 2 && stats.avg_drift_rate_spd !== null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <h2 className="mr-2 text-sm font-medium text-cf-text">
+          {hasSession ? "Current session" : "Readings logged"}
+        </h2>
+        {hasSession && stats.eligible ? (
+          <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2.5 py-0.5 text-xs font-medium text-cf-orange">
+            Eligible
+          </span>
+        ) : hasSession ? (
+          <span
+            className="rounded-full border border-cf-border bg-cf-bg-100 px-2.5 py-0.5 text-xs font-medium text-cf-text-muted"
+            title="Eligible for ranking after 7 days and 3 readings"
+          >
+            Not eligible yet
+          </span>
+        ) : null}
+        {stats.verified_badge ? (
+          <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2.5 py-0.5 text-xs font-medium text-cf-orange">
+            Verified
+          </span>
+        ) : null}
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-4">
+        <div>
+          <dt className="text-cf-text-muted">Session length</dt>
+          <dd className="mt-0.5 font-mono text-base text-cf-text">
+            {hasSession ? formatDays(stats.session_days) : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-cf-text-muted">Readings</dt>
+          <dd className="mt-0.5 font-mono text-base text-cf-text">
+            {stats.reading_count}
+          </dd>
+        </div>
+        {showAvgDrift ? (
+          <div>
+            <dt className="text-cf-text-muted">Average drift</dt>
+            <dd className="mt-0.5 font-mono text-base text-cf-text">
+              {formatDrift(stats.avg_drift_rate_spd!)}
+            </dd>
+          </div>
+        ) : null}
+        <div>
+          <dt className="text-cf-text-muted">Verified ratio</dt>
+          <dd className="mt-0.5 font-mono text-base text-cf-text">
+            {Math.round(stats.verified_ratio * 100)}%
+          </dd>
+        </div>
+        {hasSession ? (
+          <div>
+            <dt className="text-cf-text-muted">Latest deviation</dt>
+            <dd className="mt-0.5 font-mono text-base text-cf-text">
+              {formatDeviation(stats.latest_deviation_seconds)}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  );
+}

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -1,0 +1,128 @@
+// HTTP client for /api/v1/watches/:id/readings + /api/v1/readings/:id.
+// Mirrors the shape conventions in src/app/watches/api.ts: every call
+// returns a discriminated union so the pages don't leak raw Response
+// objects into render code.
+//
+// The Reading / SessionStats wire shapes are kept lightweight here;
+// the shared Zod schemas on the server side are the contract source
+// of truth, these interfaces mirror them.
+
+export interface Reading {
+  id: string;
+  watch_id: string;
+  user_id: string;
+  /** Unix ms. */
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline: boolean;
+  verified: boolean;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface PerIntervalDrift {
+  from_reading_id: string;
+  to_reading_id: string;
+  interval_days: number;
+  drift_rate_spd: number;
+}
+
+export interface SessionStats {
+  session_days: number;
+  reading_count: number;
+  verified_ratio: number;
+  avg_drift_rate_spd: number | null;
+  per_interval: PerIntervalDrift[];
+  eligible: boolean;
+  verified_badge: boolean;
+  latest_deviation_seconds: number;
+  baseline_reference_timestamp: number;
+}
+
+export interface ReadingsError {
+  code: "invalid_input" | "unauthorized" | "forbidden" | "not_found" | "unknown";
+  message: string;
+  fieldErrors?: Record<string, string>;
+}
+
+async function readError(response: Response): Promise<ReadingsError> {
+  let parsed: { error?: string; fieldErrors?: Record<string, string> } = {};
+  try {
+    parsed = (await response.json()) as typeof parsed;
+  } catch {
+    /* non-JSON body */
+  }
+  if (response.status === 400 && parsed.error === "invalid_input") {
+    const fieldErrors = parsed.fieldErrors ?? {};
+    const firstMsg =
+      Object.values(fieldErrors)[0] ?? "Please check the form and try again";
+    return { code: "invalid_input", message: firstMsg, fieldErrors };
+  }
+  if (response.status === 401) {
+    return { code: "unauthorized", message: "Your session has expired" };
+  }
+  if (response.status === 403) {
+    return { code: "forbidden", message: "You do not own this reading" };
+  }
+  if (response.status === 404) {
+    return { code: "not_found", message: "Not found" };
+  }
+  return {
+    code: "unknown",
+    message: `Request failed with status ${response.status}`,
+  };
+}
+
+export async function listReadings(
+  watchId: string,
+): Promise<
+  | { ok: true; readings: Reading[]; session_stats: SessionStats | null }
+  | { ok: false; error: ReadingsError }
+> {
+  const response = await fetch(
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings`,
+    { credentials: "include" },
+  );
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  const body = (await response.json()) as {
+    readings: Reading[];
+    session_stats: SessionStats | null;
+  };
+  return { ok: true, readings: body.readings, session_stats: body.session_stats };
+}
+
+export interface CreateReadingBody {
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline?: boolean;
+  notes?: string;
+}
+
+export async function createReading(
+  watchId: string,
+  body: CreateReadingBody,
+): Promise<{ ok: true; reading: Reading } | { ok: false; error: ReadingsError }> {
+  const response = await fetch(
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(body),
+    },
+  );
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  const reading = (await response.json()) as Reading;
+  return { ok: true, reading };
+}
+
+export async function deleteReading(
+  id: string,
+): Promise<{ ok: true } | { ok: false; error: ReadingsError }> {
+  const response = await fetch(`/api/v1/readings/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  return { ok: true };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -99,6 +99,25 @@ export interface WatchesTable {
   created_at: Generated<string>; // ISO 8601, populated by DEFAULT
 }
 
+// Slice 12 (issue #13): readings. Columns mirror
+// migrations/0004_readings.sql. Booleans are stored as INTEGER 0/1
+// and converted to `boolean` at the API boundary. `reference_timestamp`
+// is unix milliseconds (not ISO) so drift math works directly on the
+// stored value.
+export interface ReadingsTable {
+  id: string;
+  watch_id: string;
+  // Denormalised from watches.user_id for per-user queries — always
+  // set from the authed session at INSERT time; never trust client.
+  user_id: string;
+  reference_timestamp: number; // unix ms
+  deviation_seconds: number; // signed REAL
+  is_baseline: Generated<number>; // 0 | 1, default 0
+  verified: Generated<number>; // 0 | 1, default 0 (slice #16 flips this)
+  notes: string | null;
+  created_at: Generated<string>; // ISO 8601, populated by DEFAULT
+}
+
 export interface Database {
   user: UserTable;
   session: SessionTable;
@@ -106,4 +125,5 @@ export interface Database {
   verification: VerificationTable;
   movements: MovementsTable;
   watches: WatchesTable;
+  readings: ReadingsTable;
 }

--- a/src/domain/drift-calc/compute-session-stats.test.ts
+++ b/src/domain/drift-calc/compute-session-stats.test.ts
@@ -1,0 +1,227 @@
+// Unit tests for the pure drift-calc module. These run under the
+// default vitest pool (node/workerd) and MUST stay import-free of any
+// IO — the point of a pure module is that a product engineer can
+// reason about drift math without standing up a database.
+//
+// Ubiquitous language (see AGENTS.md):
+//   * Reading — a record of displayed time vs reference time
+//   * Deviation — signed seconds the watch is ahead (+) or behind (-)
+//   * Drift rate — change in deviation per day (s/d)
+//   * Baseline — reading with is_baseline=true, deviation = 0
+//   * Session — readings since and including the most recent baseline
+
+import { describe, it, expect } from "vitest";
+import { computeSessionStats, type Reading } from "./compute-session-stats";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Fixture helper — builds a Reading with sane defaults. */
+function r(partial: Partial<Reading> & { reference_timestamp: number }): Reading {
+  return {
+    id: partial.id ?? crypto.randomUUID(),
+    reference_timestamp: partial.reference_timestamp,
+    deviation_seconds: partial.deviation_seconds ?? 0,
+    is_baseline: partial.is_baseline ?? false,
+    verified: partial.verified ?? false,
+  };
+}
+
+describe("computeSessionStats — empty / degenerate inputs", () => {
+  it("returns safe zeros for an empty reading list", () => {
+    const stats = computeSessionStats([]);
+    expect(stats.reading_count).toBe(0);
+    expect(stats.session_days).toBe(0);
+    expect(stats.avg_drift_rate_spd).toBeNull();
+    expect(stats.per_interval).toEqual([]);
+    expect(stats.eligible).toBe(false);
+    expect(stats.verified_badge).toBe(false);
+    expect(stats.verified_ratio).toBe(0);
+    expect(stats.latest_deviation_seconds).toBe(0);
+    expect(stats.baseline_reference_timestamp).toBe(0);
+  });
+
+  it("handles a session with only a baseline (1 reading)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "a", reference_timestamp: t, is_baseline: true }),
+    ]);
+    expect(stats.reading_count).toBe(1);
+    expect(stats.session_days).toBe(0);
+    expect(stats.avg_drift_rate_spd).toBeNull();
+    expect(stats.per_interval).toEqual([]);
+    expect(stats.eligible).toBe(false);
+    expect(stats.latest_deviation_seconds).toBe(0);
+    expect(stats.baseline_reference_timestamp).toBe(t);
+  });
+
+  it("no baseline in input — falls back to counting all readings but flags as ineligible", () => {
+    // Useful for UI: the user logged readings without ever marking one
+    // as baseline. We still want to show the list count.
+    const t = Date.UTC(2025, 0, 1);
+    const readings = [
+      r({ id: "a", reference_timestamp: t, deviation_seconds: 1 }),
+      r({ id: "b", reference_timestamp: t + DAY_MS, deviation_seconds: 2 }),
+    ];
+    const stats = computeSessionStats(readings);
+    expect(stats.reading_count).toBe(2);
+    expect(stats.session_days).toBe(0);
+    expect(stats.avg_drift_rate_spd).toBeNull();
+    expect(stats.eligible).toBe(false);
+    expect(stats.baseline_reference_timestamp).toBe(0);
+    expect(stats.per_interval).toEqual([]);
+  });
+});
+
+describe("computeSessionStats — drift math edges", () => {
+  it("two readings at 0 days apart → drift_rate_spd = 0 (no divide-by-zero)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "a", reference_timestamp: t, is_baseline: true }),
+      r({ id: "b", reference_timestamp: t, deviation_seconds: 5 }),
+    ]);
+    expect(stats.per_interval).toHaveLength(1);
+    expect(stats.per_interval[0]!.drift_rate_spd).toBe(0);
+    expect(Number.isFinite(stats.per_interval[0]!.drift_rate_spd)).toBe(true);
+    expect(stats.avg_drift_rate_spd).toBe(0);
+  });
+});
+
+describe("computeSessionStats — ordering + session reset", () => {
+  it("sorts input chronologically before computing", () => {
+    const t = Date.UTC(2025, 0, 1);
+    // Provide intentionally out-of-order input
+    const stats = computeSessionStats([
+      r({ id: "c", reference_timestamp: t + 2 * DAY_MS, deviation_seconds: 4 }),
+      r({ id: "a", reference_timestamp: t, is_baseline: true }),
+      r({ id: "b", reference_timestamp: t + DAY_MS, deviation_seconds: 2 }),
+    ]);
+    expect(stats.per_interval).toHaveLength(2);
+    expect(stats.per_interval[0]!.from_reading_id).toBe("a");
+    expect(stats.per_interval[0]!.to_reading_id).toBe("b");
+    expect(stats.per_interval[1]!.from_reading_id).toBe("b");
+    expect(stats.per_interval[1]!.to_reading_id).toBe("c");
+  });
+
+  it("a new baseline mid-series restarts the session — earlier readings are dropped", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "old-1", reference_timestamp: t, is_baseline: true }),
+      r({ id: "old-2", reference_timestamp: t + DAY_MS, deviation_seconds: 5 }),
+      r({ id: "old-3", reference_timestamp: t + 2 * DAY_MS, deviation_seconds: 10 }),
+      // User resets the watch to true time here:
+      r({
+        id: "new-baseline",
+        reference_timestamp: t + 10 * DAY_MS,
+        is_baseline: true,
+      }),
+      r({
+        id: "latest",
+        reference_timestamp: t + 14 * DAY_MS,
+        deviation_seconds: 3,
+      }),
+    ]);
+    expect(stats.reading_count).toBe(2); // only the last 2
+    expect(stats.baseline_reference_timestamp).toBe(t + 10 * DAY_MS);
+    expect(stats.session_days).toBe(4);
+    expect(stats.per_interval).toHaveLength(1);
+    expect(stats.per_interval[0]!.from_reading_id).toBe("new-baseline");
+    expect(stats.per_interval[0]!.to_reading_id).toBe("latest");
+    expect(stats.per_interval[0]!.drift_rate_spd).toBeCloseTo(0.75, 5);
+  });
+});
+
+describe("computeSessionStats — eligibility thresholds", () => {
+  it("7-day session with 3 readings (inclusive of baseline) → eligible, avg_drift correct", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "b0", reference_timestamp: t, is_baseline: true }),
+      // Day 3: watch is +6s.  interval 0→3 days, drift 2 s/d.
+      r({ id: "r1", reference_timestamp: t + 3 * DAY_MS, deviation_seconds: 6 }),
+      // Day 7: watch is +14s. interval 3→7 days = 4d, Δ deviation = 8, drift 2 s/d.
+      r({ id: "r2", reference_timestamp: t + 7 * DAY_MS, deviation_seconds: 14 }),
+    ]);
+    expect(stats.reading_count).toBe(3);
+    expect(stats.session_days).toBe(7);
+    expect(stats.per_interval).toHaveLength(2);
+    expect(stats.per_interval[0]!.interval_days).toBeCloseTo(3, 5);
+    expect(stats.per_interval[0]!.drift_rate_spd).toBeCloseTo(2, 5);
+    expect(stats.per_interval[1]!.drift_rate_spd).toBeCloseTo(2, 5);
+    expect(stats.avg_drift_rate_spd).toBeCloseTo(2, 5);
+    expect(stats.eligible).toBe(true);
+    expect(stats.latest_deviation_seconds).toBe(14);
+  });
+
+  it("6-day session with 3 readings → not eligible (fails session_days >= 7)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "b0", reference_timestamp: t, is_baseline: true }),
+      r({ id: "r1", reference_timestamp: t + 3 * DAY_MS, deviation_seconds: 3 }),
+      r({ id: "r2", reference_timestamp: t + 6 * DAY_MS, deviation_seconds: 6 }),
+    ]);
+    expect(stats.reading_count).toBe(3);
+    expect(stats.session_days).toBe(6);
+    expect(stats.eligible).toBe(false);
+  });
+
+  it("7-day session with only 2 readings → not eligible (fails reading_count >= 3)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "b0", reference_timestamp: t, is_baseline: true }),
+      r({ id: "r1", reference_timestamp: t + 7 * DAY_MS, deviation_seconds: 7 }),
+    ]);
+    expect(stats.reading_count).toBe(2);
+    expect(stats.session_days).toBe(7);
+    expect(stats.eligible).toBe(false);
+    expect(stats.avg_drift_rate_spd).toBeCloseTo(1, 5);
+  });
+
+  it("14-day, 5 readings → per-interval drifts are each correct and avg is the mean over intervals", () => {
+    const t = Date.UTC(2025, 0, 1);
+    // Irregular sampling with a deliberately uneven last interval.
+    // deviations: 0, +3 @d3, +5 @d7, +8 @d10, +14 @d14
+    // intervals: 3d (+3/3=1), 4d (+2/4=.5), 3d (+3/3=1), 4d (+6/4=1.5)
+    // avg = (1 + .5 + 1 + 1.5)/4 = 1
+    const stats = computeSessionStats([
+      r({ id: "a", reference_timestamp: t, is_baseline: true }),
+      r({ id: "b", reference_timestamp: t + 3 * DAY_MS, deviation_seconds: 3 }),
+      r({ id: "c", reference_timestamp: t + 7 * DAY_MS, deviation_seconds: 5 }),
+      r({ id: "d", reference_timestamp: t + 10 * DAY_MS, deviation_seconds: 8 }),
+      r({ id: "e", reference_timestamp: t + 14 * DAY_MS, deviation_seconds: 14 }),
+    ]);
+    expect(stats.per_interval).toHaveLength(4);
+    expect(stats.per_interval[0]!.drift_rate_spd).toBeCloseTo(1, 5);
+    expect(stats.per_interval[1]!.drift_rate_spd).toBeCloseTo(0.5, 5);
+    expect(stats.per_interval[2]!.drift_rate_spd).toBeCloseTo(1, 5);
+    expect(stats.per_interval[3]!.drift_rate_spd).toBeCloseTo(1.5, 5);
+    expect(stats.avg_drift_rate_spd).toBeCloseTo(1, 5);
+    expect(stats.session_days).toBe(14);
+    expect(stats.eligible).toBe(true);
+  });
+});
+
+describe("computeSessionStats — verified ratio / badge", () => {
+  it("1 verified of 4 = 0.25 → verified_badge = true (at the boundary)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "a", reference_timestamp: t, is_baseline: true, verified: true }),
+      r({ id: "b", reference_timestamp: t + DAY_MS, deviation_seconds: 1 }),
+      r({ id: "c", reference_timestamp: t + 2 * DAY_MS, deviation_seconds: 2 }),
+      r({ id: "d", reference_timestamp: t + 3 * DAY_MS, deviation_seconds: 3 }),
+    ]);
+    expect(stats.verified_ratio).toBeCloseTo(0.25, 5);
+    expect(stats.verified_badge).toBe(true);
+  });
+
+  it("1 verified of 5 = 0.2 → verified_badge = false (below boundary)", () => {
+    const t = Date.UTC(2025, 0, 1);
+    const stats = computeSessionStats([
+      r({ id: "a", reference_timestamp: t, is_baseline: true, verified: true }),
+      r({ id: "b", reference_timestamp: t + DAY_MS, deviation_seconds: 1 }),
+      r({ id: "c", reference_timestamp: t + 2 * DAY_MS, deviation_seconds: 2 }),
+      r({ id: "d", reference_timestamp: t + 3 * DAY_MS, deviation_seconds: 3 }),
+      r({ id: "e", reference_timestamp: t + 4 * DAY_MS, deviation_seconds: 4 }),
+    ]);
+    expect(stats.verified_ratio).toBeCloseTo(0.2, 5);
+    expect(stats.verified_badge).toBe(false);
+  });
+});

--- a/src/domain/drift-calc/compute-session-stats.ts
+++ b/src/domain/drift-calc/compute-session-stats.ts
@@ -1,0 +1,165 @@
+// Pure drift-calc domain module.
+//
+// Given a list of Readings for a single watch, compute the session
+// stats that the SPA (slice #13), the public watch page (slice #15)
+// and the leaderboard ranker (slice #17) all need. A "session" starts
+// at the most recent `is_baseline=true` reading and runs up to the
+// latest reading.
+//
+// MUST stay pure: no imports from hono, kysely, workerd, or anything
+// IO-bound. Everything here is plain arithmetic so it can be unit-
+// tested without standing up a Worker.
+//
+// See AGENTS.md glossary for the vocabulary (Reading, Deviation, Drift
+// rate, Baseline, Session, Verified reading, Verified watch).
+
+export interface Reading {
+  id: string;
+  /** Unix ms. The authoritative time the watch was read against. */
+  reference_timestamp: number;
+  /** Signed seconds. Positive = watch ahead of reference. */
+  deviation_seconds: number;
+  /** true if this reading marks the start of a new session (deviation = 0 by definition). */
+  is_baseline: boolean;
+  /** true if derived from a camera capture (slice #16). */
+  verified: boolean;
+}
+
+export interface PerIntervalDrift {
+  from_reading_id: string;
+  to_reading_id: string;
+  /** Float days between the two readings' reference_timestamps. */
+  interval_days: number;
+  /** Seconds per day, signed. 0 when interval_days is 0 (no divide-by-zero). */
+  drift_rate_spd: number;
+}
+
+export interface SessionStats {
+  /** Days from the session baseline to the latest reading. 0 if no baseline exists. */
+  session_days: number;
+  /** Readings in the current session (inclusive of baseline). */
+  reading_count: number;
+  /** Fraction of session readings that are verified. 0..1. */
+  verified_ratio: number;
+  /** Null when there's nothing to average (< 2 readings in session). */
+  avg_drift_rate_spd: number | null;
+  /** One entry per pair of consecutive readings in the session. */
+  per_interval: PerIntervalDrift[];
+  /** True when the session qualifies for ranking (session_days >= 7 && reading_count >= 3). */
+  eligible: boolean;
+  /** True when verified_ratio >= 0.25. */
+  verified_badge: boolean;
+  /** Deviation on the most-recent reading in the session; 0 when empty. */
+  latest_deviation_seconds: number;
+  /** reference_timestamp of the session baseline; 0 when no baseline exists. */
+  baseline_reference_timestamp: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute session stats from an unsorted list of readings.
+ *
+ * Session rules:
+ *   * Session = readings since (and including) the LAST `is_baseline=true`.
+ *   * No baseline in input → session_days=0, avg_drift=null, eligible=false,
+ *     but reading_count is still total input so the UI can show *something*.
+ *   * 0-day interval between two readings → drift_rate_spd=0 (not NaN/Infinity).
+ *
+ * Thresholds:
+ *   * eligible ⇔ session_days ≥ 7 AND reading_count ≥ 3.
+ *   * verified_badge ⇔ verified_ratio ≥ 0.25.
+ */
+export function computeSessionStats(readings: readonly Reading[]): SessionStats {
+  if (readings.length === 0) {
+    return emptyStats();
+  }
+
+  // Sort chronologically so we never assume the caller did.
+  const sorted = [...readings].sort(
+    (a, b) => a.reference_timestamp - b.reference_timestamp,
+  );
+
+  // Find the LAST baseline. If none, we degrade gracefully.
+  let lastBaselineIdx = -1;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (sorted[i]!.is_baseline) {
+      lastBaselineIdx = i;
+      break;
+    }
+  }
+
+  if (lastBaselineIdx === -1) {
+    // No baseline — can't compute a drift session. Report total
+    // reading count so the UI shows a "log a baseline to start" state.
+    const latest = sorted[sorted.length - 1]!;
+    const verifiedCount = sorted.filter((r) => r.verified).length;
+    return {
+      session_days: 0,
+      reading_count: sorted.length,
+      verified_ratio: sorted.length === 0 ? 0 : verifiedCount / sorted.length,
+      avg_drift_rate_spd: null,
+      per_interval: [],
+      eligible: false,
+      verified_badge: sorted.length > 0 && verifiedCount / sorted.length >= 0.25,
+      latest_deviation_seconds: latest.deviation_seconds,
+      baseline_reference_timestamp: 0,
+    };
+  }
+
+  const sessionReadings = sorted.slice(lastBaselineIdx);
+  const baseline = sessionReadings[0]!;
+  const latest = sessionReadings[sessionReadings.length - 1]!;
+
+  const perInterval: PerIntervalDrift[] = [];
+  for (let i = 1; i < sessionReadings.length; i++) {
+    const prev = sessionReadings[i - 1]!;
+    const curr = sessionReadings[i]!;
+    const intervalMs = curr.reference_timestamp - prev.reference_timestamp;
+    const intervalDays = intervalMs / MS_PER_DAY;
+    const deltaDev = curr.deviation_seconds - prev.deviation_seconds;
+    const drift = intervalDays === 0 ? 0 : deltaDev / intervalDays;
+    perInterval.push({
+      from_reading_id: prev.id,
+      to_reading_id: curr.id,
+      interval_days: intervalDays,
+      drift_rate_spd: drift,
+    });
+  }
+
+  const avgDrift =
+    sessionReadings.length < 2
+      ? null
+      : perInterval.reduce((sum, iv) => sum + iv.drift_rate_spd, 0) / perInterval.length;
+
+  const sessionDays =
+    (latest.reference_timestamp - baseline.reference_timestamp) / MS_PER_DAY;
+  const verifiedCount = sessionReadings.filter((r) => r.verified).length;
+  const verifiedRatio = verifiedCount / sessionReadings.length;
+
+  return {
+    session_days: sessionDays,
+    reading_count: sessionReadings.length,
+    verified_ratio: verifiedRatio,
+    avg_drift_rate_spd: avgDrift,
+    per_interval: perInterval,
+    eligible: sessionDays >= 7 && sessionReadings.length >= 3,
+    verified_badge: verifiedRatio >= 0.25,
+    latest_deviation_seconds: latest.deviation_seconds,
+    baseline_reference_timestamp: baseline.reference_timestamp,
+  };
+}
+
+function emptyStats(): SessionStats {
+  return {
+    session_days: 0,
+    reading_count: 0,
+    verified_ratio: 0,
+    avg_drift_rate_spd: null,
+    per_interval: [],
+    eligible: false,
+    verified_badge: false,
+    latest_deviation_seconds: 0,
+    baseline_reference_timestamp: 0,
+  };
+}

--- a/src/domain/drift-calc/index.ts
+++ b/src/domain/drift-calc/index.ts
@@ -1,0 +1,8 @@
+// Barrel export for the drift-calc domain module. Keeps consumers
+// (routes, SPA) from reaching into the internal file layout.
+export {
+  computeSessionStats,
+  type Reading,
+  type PerIntervalDrift,
+  type SessionStats,
+} from "./compute-session-stats";

--- a/src/schemas/reading.ts
+++ b/src/schemas/reading.ts
@@ -1,0 +1,72 @@
+// Shared Zod schemas for the readings surface. Imported by the API
+// route (src/server/routes/readings.ts) and (later) by the SPA form
+// that logs manual readings so the two sides agree on the wire
+// contract.
+//
+// Ubiquitous language (AGENTS.md):
+//   * `reference_timestamp` — unix milliseconds the watch was read
+//     against.
+//   * `deviation_seconds` — signed seconds the watch is ahead (+) or
+//     behind (−). Forced to 0 server-side when is_baseline=true.
+//   * `is_baseline` — marks the start of a new tracking session.
+//
+// The route is responsible for the `is_baseline ⇒ deviation = 0`
+// rule so a client that sends a stale deviation on a baseline reading
+// gets corrected rather than rejected.
+
+import { z } from "zod";
+
+const NOTES_MAX = 500;
+
+export const createReadingSchema = z.object({
+  reference_timestamp: z
+    .number({ message: "reference_timestamp is required" })
+    .int({ message: "reference_timestamp must be an integer" })
+    .positive({ message: "reference_timestamp must be positive (unix ms)" }),
+  deviation_seconds: z
+    .number({ message: "deviation_seconds is required" })
+    .finite({ message: "deviation_seconds must be a finite number" }),
+  is_baseline: z.boolean().default(false),
+  notes: z
+    .string()
+    .trim()
+    .max(NOTES_MAX, { message: `Notes must be ${NOTES_MAX} characters or fewer` })
+    .optional(),
+});
+
+export type CreateReadingInput = z.infer<typeof createReadingSchema>;
+
+// Wire shape returned by the readings API. Flattens the DB row's
+// 0/1 booleans to real booleans and leaves everything else as-is.
+export const readingResponseSchema = z.object({
+  id: z.string(),
+  watch_id: z.string(),
+  user_id: z.string(),
+  reference_timestamp: z.number(),
+  deviation_seconds: z.number(),
+  is_baseline: z.boolean(),
+  verified: z.boolean(),
+  notes: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export type ReadingResponse = z.infer<typeof readingResponseSchema>;
+
+/**
+ * Flatten a Zod error from `createReadingSchema` into a compact
+ * `{ field: message }` record for inline form errors. Mirrors the
+ * formatWatchErrors helper so the SPA can render failures the same
+ * way everywhere.
+ */
+export function formatReadingErrors(
+  error: z.ZodError<CreateReadingInput>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !(key in out)) {
+      out[key] = issue.message;
+    }
+  }
+  return out;
+}

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -1,0 +1,266 @@
+// Readings CRUD. Two Hono sub-apps exported from this module:
+//
+//   * `readingsByWatchRoute` — mounted at /api/v1/watches/:watchId/readings
+//     Handles POST (log) and GET (list + session stats). Anonymous
+//     GET is allowed when the parent watch is_public, matching the
+//     pattern already set by src/server/routes/watches.ts.
+//
+//   * `readingsByIdRoute` — mounted at /api/v1/readings
+//     Handles DELETE /:id. Ownership is resolved via a join back to
+//     the owning watch.
+//
+// Shape conventions mirror watches.ts:
+//   * 400 `{ error: "invalid_input", fieldErrors }` on Zod failure.
+//   * 401 `{ error: "unauthorized" }` from requireAuth.
+//   * 403 `{ error: "forbidden" }` when the caller isn't the owner.
+//   * 404 `{ error: "not_found" }` for unknown id / private watch
+//     accessed by anon / non-owner (we don't leak existence).
+//
+// The `is_baseline ⇒ deviation_seconds = 0` rule (AGENTS.md: "the
+// watch just set to the exact time; deviation is 0") is enforced here
+// so a stale client can't corrupt the math by sending a non-zero
+// deviation with the baseline flag.
+
+import { Hono } from "hono";
+import { createDb } from "@/db";
+import type { DB } from "@/db";
+import {
+  computeSessionStats,
+  type Reading,
+  type SessionStats,
+} from "@/domain/drift-calc";
+import { assertWatchOwnership } from "@/domain/watches/ownership";
+import {
+  createReadingSchema,
+  formatReadingErrors,
+  type ReadingResponse,
+} from "@/schemas/reading";
+import { getAuth, type AuthEnv } from "@/server/auth";
+import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
+
+type Bindings = AuthEnv & {
+  DB: D1Database;
+  [key: string]: unknown;
+};
+
+// ---- Shared mappers ------------------------------------------------
+
+interface DbReadingRow {
+  id: string;
+  watch_id: string;
+  user_id: string;
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline: number;
+  verified: number;
+  notes: string | null;
+  created_at: string;
+}
+
+function toResponse(row: DbReadingRow): ReadingResponse {
+  return {
+    id: row.id,
+    watch_id: row.watch_id,
+    user_id: row.user_id,
+    reference_timestamp: row.reference_timestamp,
+    deviation_seconds: row.deviation_seconds,
+    is_baseline: row.is_baseline === 1,
+    verified: row.verified === 1,
+    notes: row.notes,
+    created_at: row.created_at,
+  };
+}
+
+function toDomain(row: DbReadingRow): Reading {
+  return {
+    id: row.id,
+    reference_timestamp: row.reference_timestamp,
+    deviation_seconds: row.deviation_seconds,
+    is_baseline: row.is_baseline === 1,
+    verified: row.verified === 1,
+  };
+}
+
+async function listReadingsForWatch(db: DB, watchId: string): Promise<DbReadingRow[]> {
+  const rows = await db
+    .selectFrom("readings")
+    .selectAll()
+    .where("watch_id", "=", watchId)
+    .orderBy("reference_timestamp", "asc")
+    .execute();
+  return rows as DbReadingRow[];
+}
+
+// ---- /api/v1/watches/:watchId/readings ----------------------------
+
+export const readingsByWatchRoute = new Hono<{
+  Bindings: Bindings;
+  Variables: RequireAuthVariables;
+}>();
+
+// Hono can't infer outer-mount params in a sub-app's type system, so
+// we read them as unknown and narrow with a runtime guard. The mount
+// path in src/worker/index.tsx guarantees :watchId is present at
+// request time, but the compiler doesn't know that.
+function getWatchIdParam(c: {
+  req: { param: (name: string) => string | undefined };
+}): string | null {
+  const raw = c.req.param("watchId");
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+/**
+ * GET — list readings + session stats.
+ *
+ * Public-watch rule: anonymous callers can read when the parent
+ * watch's `is_public` is true. Otherwise we return 404 so the route
+ * doesn't leak existence of private watches.
+ *
+ * Registered BEFORE the blanket requireAuth middleware so anon
+ * callers can hit it without a 401.
+ */
+readingsByWatchRoute.get("/", async (c) => {
+  const watchId = getWatchIdParam(c);
+  if (!watchId) return c.json({ error: "not_found" }, 404);
+  const db = createDb(c.env);
+
+  const auth = getAuth(c.env);
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const callerId = (session?.user as { id: string } | undefined)?.id ?? null;
+
+  const watch = await db
+    .selectFrom("watches")
+    .select(["id", "user_id", "is_public"])
+    .where("id", "=", watchId)
+    .executeTakeFirst();
+  if (!watch) {
+    return c.json({ error: "not_found" }, 404);
+  }
+  const isOwner = callerId !== null && watch.user_id === callerId;
+  const isPublic = watch.is_public === 1;
+  if (!isPublic && !isOwner) {
+    return c.json({ error: "not_found" }, 404);
+  }
+
+  const rows = await listReadingsForWatch(db, watchId);
+  const readings = rows.map(toResponse);
+  const session_stats: SessionStats | null =
+    rows.length === 0 ? null : computeSessionStats(rows.map(toDomain));
+
+  return c.json({ readings, session_stats });
+});
+
+// Mutating routes below require a session.
+readingsByWatchRoute.use("*", requireAuth);
+
+/**
+ * POST — log a manual reading against an owned watch.
+ *
+ * Baseline rule: when `is_baseline=true`, `deviation_seconds` is
+ * forced to 0 server-side no matter what the client sent. Rejecting
+ * a stale client outright would be user-hostile — correcting the
+ * value is the safer, lower-surprise behaviour.
+ */
+readingsByWatchRoute.post("/", async (c) => {
+  const user = c.get("user");
+  const watchId = getWatchIdParam(c);
+  if (!watchId) return c.json({ error: "not_found" }, 404);
+  const db = createDb(c.env);
+
+  let json: unknown;
+  try {
+    json = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+  const parsed = createReadingSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json(
+      { error: "invalid_input", fieldErrors: formatReadingErrors(parsed.error) },
+      400,
+    );
+  }
+  const input = parsed.data;
+
+  const ownership = await assertWatchOwnership(db, watchId, user.id);
+  if (ownership.status === "not_found") {
+    return c.json({ error: "not_found" }, 404);
+  }
+  if (ownership.status === "forbidden") {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
+  // Baseline readings are, by definition, "watch just set to true
+  // time" — deviation is 0. See AGENTS.md glossary.
+  const deviation = input.is_baseline ? 0 : input.deviation_seconds;
+
+  const id = crypto.randomUUID();
+  await db
+    .insertInto("readings")
+    .values({
+      id,
+      watch_id: watchId,
+      user_id: user.id,
+      reference_timestamp: input.reference_timestamp,
+      deviation_seconds: deviation,
+      is_baseline: input.is_baseline ? 1 : 0,
+      // verified stays at default 0 — slice #16 flips it via the
+      // in-app camera capture flow.
+      notes: input.notes ?? null,
+    })
+    .execute();
+
+  const created = await db
+    .selectFrom("readings")
+    .selectAll()
+    .where("id", "=", id)
+    .executeTakeFirstOrThrow();
+  return c.json(toResponse(created as DbReadingRow), 201);
+});
+
+// ---- /api/v1/readings/:id -----------------------------------------
+
+export const readingsByIdRoute = new Hono<{
+  Bindings: Bindings;
+  Variables: RequireAuthVariables;
+}>();
+
+readingsByIdRoute.use("*", requireAuth);
+
+/**
+ * DELETE /api/v1/readings/:id — destroy a reading you own.
+ *
+ * We resolve ownership via the parent watch: a reading is "owned" by
+ * the same user that owns its watch. The `user_id` column on readings
+ * is denormalised for per-user queries but we still cross-check via
+ * the watches table so an inconsistent denorm (should never happen,
+ * but defensive programming) doesn't let someone bypass the check.
+ */
+readingsByIdRoute.delete("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+  if (!id) return c.json({ error: "not_found" }, 404);
+  const db = createDb(c.env);
+
+  const row = await db
+    .selectFrom("readings")
+    .select(["id", "watch_id"])
+    .where("id", "=", id)
+    .executeTakeFirst();
+  if (!row) {
+    return c.json({ error: "not_found" }, 404);
+  }
+
+  const ownership = await assertWatchOwnership(db, row.watch_id, user.id);
+  if (ownership.status === "not_found") {
+    // The parent watch vanished (should be impossible with FK cascade,
+    // but if it happens we surface 404 rather than crash).
+    return c.json({ error: "not_found" }, 404);
+  }
+  if (ownership.status === "forbidden") {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
+  await db.deleteFrom("readings").where("id", "=", id).execute();
+  return c.body(null, 204);
+});

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -8,6 +8,7 @@ import { LandingPage } from "@/public/landing";
 import { getAuth, type AuthEnv } from "@/server/auth";
 import { meRoute } from "@/server/routes/me";
 import { movementsRoute } from "@/server/routes/movements";
+import { readingsByIdRoute, readingsByWatchRoute } from "@/server/routes/readings";
 import { watchesRoute } from "@/server/routes/watches";
 
 // The Worker's full env extends the narrower AuthEnv used by getAuth.
@@ -37,6 +38,12 @@ app.all("/api/v1/auth/*", (c) => {
 // later slices add watches/readings here.
 app.route("/api/v1/me", meRoute);
 app.route("/api/v1/movements", movementsRoute);
+// Readings live under two paths: nested under a watch for
+// list/create, and flat at /api/v1/readings/:id for delete. Mount
+// the nested route BEFORE /api/v1/watches so its requireAuth
+// middleware doesn't catch anonymous GETs on public-watch readings.
+app.route("/api/v1/watches/:watchId/readings", readingsByWatchRoute);
+app.route("/api/v1/readings", readingsByIdRoute);
 app.route("/api/v1/watches", watchesRoute);
 
 export default app;

--- a/tests/integration/readings.test.ts
+++ b/tests/integration/readings.test.ts
@@ -1,0 +1,471 @@
+// Integration tests for /api/v1/watches/:id/readings and
+// /api/v1/readings/:id. Follows the same fixture + helper pattern as
+// tests/integration/watches.test.ts so the expensive Better Auth
+// sign-up path is reused across tests.
+//
+// Covers:
+//   * POST happy path + baseline-forces-deviation-0 rule
+//   * POST non-owner → 403
+//   * GET with session stats + anonymous public / private distinctions
+//   * DELETE owner / non-owner
+//   * FK cascade when the parent watch is deleted
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { beforeAll, describe, it, expect } from "vitest";
+import type { SessionStats } from "@/domain/drift-calc";
+
+// ---- Test fixture ---------------------------------------------------
+
+const movementId = "test-readings-eta-2824";
+
+beforeAll(async () => {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      movementId,
+      "Test ETA 2824 (readings)",
+      "ETA",
+      "2824 (readings)",
+      "automatic",
+      "approved",
+      null,
+    )
+    .run();
+});
+
+// ---- Auth helpers (mirror watches.test.ts) -------------------------
+
+function makeEmail(prefix = "readings"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function signUp(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: email.split("@")[0]!, email, password }),
+    }),
+  );
+}
+
+async function signIn(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+}
+
+interface TestUser {
+  cookie: string;
+  userId: string;
+}
+
+async function registerAndGetCookie(): Promise<TestUser> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await signUp(email, password);
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as { user: { id: string } };
+  const loginRes = await signIn(email, password);
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return { cookie, userId: regBody.user.id };
+}
+
+// ---- Request helpers -----------------------------------------------
+
+async function createWatch(
+  body: {
+    name: string;
+    movement_id: string;
+    is_public?: boolean;
+  },
+  cookie: string,
+): Promise<{ id: string }> {
+  const res = await exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/watches", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+  expect(res.status).toBe(201);
+  return (await res.json()) as { id: string };
+}
+
+async function deleteWatch(id: string, cookie: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/watches/${id}`, {
+      method: "DELETE",
+      headers: { cookie },
+    }),
+  );
+}
+
+interface CreateReadingBody {
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline?: boolean;
+  notes?: string;
+}
+
+async function postReading(
+  watchId: string,
+  body: CreateReadingBody,
+  cookie?: string,
+): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/watches/${watchId}/readings`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function getReadings(watchId: string, cookie?: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/watches/${watchId}/readings`, {
+      headers: cookie ? { cookie } : {},
+    }),
+  );
+}
+
+async function deleteReading(id: string, cookie?: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/readings/${id}`, {
+      method: "DELETE",
+      headers: cookie ? { cookie } : {},
+    }),
+  );
+}
+
+interface ReadingBody {
+  id: string;
+  watch_id: string;
+  user_id: string;
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline: boolean;
+  verified: boolean;
+  notes: string | null;
+  created_at: string;
+}
+
+interface GetReadingsBody {
+  readings: ReadingBody[];
+  session_stats: SessionStats | null;
+}
+
+const TWO_USER_TIMEOUT = 30_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ---- POST /api/v1/watches/:id/readings -----------------------------
+
+describe("POST /api/v1/watches/:id/readings", () => {
+  it("creates a reading and returns the full shape (201)", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Test", movement_id: movementId },
+      owner.cookie,
+    );
+    const now = Date.now();
+    const res = await postReading(
+      watchId,
+      {
+        reference_timestamp: now,
+        deviation_seconds: 2.5,
+        is_baseline: false,
+        notes: "first log",
+      },
+      owner.cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.watch_id).toBe(watchId);
+    expect(body.user_id).toBe(owner.userId);
+    expect(body.reference_timestamp).toBe(now);
+    expect(body.deviation_seconds).toBe(2.5);
+    expect(body.is_baseline).toBe(false);
+    expect(body.verified).toBe(false);
+    expect(body.notes).toBe("first log");
+    expect(typeof body.id).toBe("string");
+    expect(body.id.length).toBeGreaterThan(10);
+  });
+
+  it("forces deviation_seconds to 0 when is_baseline=true, even if client sent 42", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Baseline watch", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postReading(
+      watchId,
+      {
+        reference_timestamp: Date.now(),
+        deviation_seconds: 42,
+        is_baseline: true,
+      },
+      owner.cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.is_baseline).toBe(true);
+    expect(body.deviation_seconds).toBe(0);
+  });
+
+  it(
+    "rejects a non-owner (403)",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const other = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Theirs", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postReading(
+        watchId,
+        { reference_timestamp: Date.now(), deviation_seconds: 1 },
+        other.cookie,
+      );
+      expect(res.status).toBe(403);
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it("rejects an unauthenticated request (401)", async () => {
+    // Use an obviously fake id — requireAuth triggers before we even
+    // look up the watch, so the 401 comes out before any DB access.
+    const res = await postReading("whatever", {
+      reference_timestamp: Date.now(),
+      deviation_seconds: 1,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid input (400)", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "x", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postReading(
+      watchId,
+      // missing deviation_seconds, negative timestamp
+      { reference_timestamp: -1 } as unknown as CreateReadingBody,
+      owner.cookie,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_input");
+  });
+});
+
+// ---- GET /api/v1/watches/:id/readings ------------------------------
+
+describe("GET /api/v1/watches/:id/readings", () => {
+  it("returns readings + computed session_stats for the owner", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Drift test", movement_id: movementId },
+      owner.cookie,
+    );
+    const t = Date.now();
+    // Post three readings across 7 days with drift = 1 s/d.
+    await postReading(
+      watchId,
+      {
+        reference_timestamp: t,
+        deviation_seconds: 999, // forced to 0 because baseline
+        is_baseline: true,
+      },
+      owner.cookie,
+    );
+    await postReading(
+      watchId,
+      {
+        reference_timestamp: t + 3 * DAY_MS,
+        deviation_seconds: 3,
+      },
+      owner.cookie,
+    );
+    await postReading(
+      watchId,
+      {
+        reference_timestamp: t + 7 * DAY_MS,
+        deviation_seconds: 7,
+      },
+      owner.cookie,
+    );
+
+    const res = await getReadings(watchId, owner.cookie);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GetReadingsBody;
+    expect(body.readings).toHaveLength(3);
+    expect(body.session_stats).not.toBeNull();
+    expect(body.session_stats!.reading_count).toBe(3);
+    expect(body.session_stats!.session_days).toBeCloseTo(7, 5);
+    expect(body.session_stats!.avg_drift_rate_spd).toBeCloseTo(1, 5);
+    expect(body.session_stats!.eligible).toBe(true);
+  });
+
+  it("empty watch returns session_stats=null", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Empty", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await getReadings(watchId, owner.cookie);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GetReadingsBody;
+    expect(body.readings).toEqual([]);
+    expect(body.session_stats).toBeNull();
+  });
+
+  it("anonymous can read readings on a public watch (200)", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Public watch", movement_id: movementId, is_public: true },
+      owner.cookie,
+    );
+    await postReading(
+      watchId,
+      { reference_timestamp: Date.now(), deviation_seconds: 0, is_baseline: true },
+      owner.cookie,
+    );
+    const res = await getReadings(watchId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GetReadingsBody;
+    expect(body.readings).toHaveLength(1);
+  });
+
+  it("anonymous gets 404 for a private watch", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Private watch", movement_id: movementId, is_public: false },
+      owner.cookie,
+    );
+    const res = await getReadings(watchId);
+    expect(res.status).toBe(404);
+  });
+
+  it("unknown watch id returns 404", async () => {
+    const res = await getReadings("no-such-watch");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---- DELETE /api/v1/readings/:id -----------------------------------
+
+describe("DELETE /api/v1/readings/:id", () => {
+  it("owner deletes a reading (204) and subsequent GET omits it", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Delete test", movement_id: movementId },
+      owner.cookie,
+    );
+    const post = await postReading(
+      watchId,
+      {
+        reference_timestamp: Date.now(),
+        deviation_seconds: 0,
+        is_baseline: true,
+      },
+      owner.cookie,
+    );
+    const reading = (await post.json()) as ReadingBody;
+
+    const del = await deleteReading(reading.id, owner.cookie);
+    expect(del.status).toBe(204);
+
+    const list = await getReadings(watchId, owner.cookie);
+    const body = (await list.json()) as GetReadingsBody;
+    expect(body.readings.find((r) => r.id === reading.id)).toBeUndefined();
+  });
+
+  it(
+    "non-owner gets 403",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const other = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Not yours", movement_id: movementId, is_public: true },
+        owner.cookie,
+      );
+      const post = await postReading(
+        watchId,
+        {
+          reference_timestamp: Date.now(),
+          deviation_seconds: 0,
+          is_baseline: true,
+        },
+        owner.cookie,
+      );
+      const reading = (await post.json()) as ReadingBody;
+
+      const del = await deleteReading(reading.id, other.cookie);
+      expect(del.status).toBe(403);
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it("unknown reading id returns 404 for authed caller", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await deleteReading("not-a-real-reading", cookie);
+    expect(res.status).toBe(404);
+  });
+
+  it("unauthenticated DELETE is 401", async () => {
+    const res = await deleteReading("anything");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---- FK cascade ----------------------------------------------------
+
+describe("cascade: deleting a watch deletes its readings", () => {
+  it("GET on a deleted watch returns 404; row count is 0", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Cascade", movement_id: movementId },
+      owner.cookie,
+    );
+    await postReading(
+      watchId,
+      {
+        reference_timestamp: Date.now(),
+        deviation_seconds: 0,
+        is_baseline: true,
+      },
+      owner.cookie,
+    );
+
+    const del = await deleteWatch(watchId, owner.cookie);
+    expect(del.status).toBe(204);
+
+    // After the parent watch is gone, GET readings returns 404
+    // (because the watch lookup fails first).
+    const list = await getReadings(watchId, owner.cookie);
+    expect(list.status).toBe(404);
+
+    // Also verify at the SQL layer that the readings row is gone.
+    const db = (env as unknown as { DB: D1Database }).DB;
+    const row = await db
+      .prepare("SELECT COUNT(*) as n FROM readings WHERE watch_id = ?")
+      .bind(watchId)
+      .first<{ n: number }>();
+    expect(row?.n).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #13.

## What ships

### Pure domain
- `src/domain/drift-calc/` — `computeSessionStats(readings)` returns `session_days`, `reading_count`, `verified_ratio`, `avg_drift_rate_spd`, `per_interval[]`, `eligible`, `verified_badge`, `latest_deviation_seconds`, `baseline_reference_timestamp`.
- Session = readings since (and including) the most recent `is_baseline=true`. Gracefully degrades when no baseline exists. 0-day intervals return `drift_rate_spd=0` instead of `NaN`/`Infinity`.
- Eligibility: `session_days ≥ 7 && reading_count ≥ 3`. Verified badge: `verified_ratio ≥ 0.25`.
- **Pure** — no imports from hono/kysely/workerd/cloudflare. 12 unit tests covering empty input, baseline-only, zero-interval, out-of-order input, mid-series baseline reset, 7/14-day sessions, threshold boundaries, and verified-ratio edges (1/4 = badge; 1/5 = no badge).

### DB
- `migrations/0004_readings.sql` — `readings` table with `watch_id`, denormalised `user_id`, `reference_timestamp` (unix ms INTEGER), `deviation_seconds` REAL, `is_baseline` / `verified` 0/1, `notes`, `created_at` ISO. Indexes on `(watch_id, reference_timestamp)` and `user_id`. `ON DELETE CASCADE` on both FKs.
- `src/db/schema.ts` — `ReadingsTable` interface, follows the existing `Generated<>` pattern.

### API
- `POST /api/v1/watches/:watchId/readings` — authed + owner. Validates via `createReadingSchema`. **Server forces `deviation_seconds = 0` when `is_baseline=true`** no matter what the client sent.
- `GET /api/v1/watches/:watchId/readings` — anonymous on public watches, owner-only on private (returns 404 for non-owner on private to avoid leaking existence). Returns `{ readings, session_stats }` with the server-computed session stats.
- `DELETE /api/v1/readings/:id` — authed + owner (via join to parent watch).
- Routes live in `src/server/routes/readings.ts`. Mounted in `src/worker/index.tsx` **before** `/api/v1/watches` so the nested route sees anonymous GETs before the watches `requireAuth` middleware would 401 them.

### SPA
- `src/app/watches/readings.ts` — HTTP client mirroring the existing `src/app/watches/api.ts` shape.
- `SessionStatsPanel.tsx` — session length, reading count, avg drift (hidden when `reading_count < 2` per the acceptance criterion), verified ratio, latest deviation, eligibility + verified badge chips.
- `LogReadingForm.tsx` — signed-decimal deviation input (with AHEAD/BEHIND tooltip), datetime-local ref time (defaults to now), "This is a baseline" checkbox (disables + zeroes the deviation input; server enforces the rule defensively), 500-char notes.
- `ReadingList.tsx` — reverse-chronological table with deviation, reference time, drift-since-prev (pulled from `session_stats.per_interval` — no client-side recompute), verified tick, notes, per-row delete.
- `WatchDetailPage.tsx` extended: readings fetch in parallel with the watch lookup; every mutation calls `reloadReadings()` to re-pull list + stats.

## Tests

- 12 unit tests in `src/domain/drift-calc/compute-session-stats.test.ts`.
- 15 integration tests in `tests/integration/readings.test.ts` — POST happy / baseline-forces-0 / non-owner 403 / unauth 401 / invalid 400, GET stats / empty / anon public / anon private / unknown, DELETE owner / non-owner / unknown / unauth, and FK cascade (deleting the watch removes its readings, verified at the SQL layer).
- **146 tests passing (was 119).**
- Typecheck + `vite build` green.
- E2E smoke skipped per the issue note ("optional; integration tests do the heavy lifting"). The existing `tests/e2e/watches.smoke.test.ts` still covers the broader flow.

## Acceptance criteria from #13

- [x] Logging `is_baseline=true` forces `deviation_seconds=0` server-side (integration test `forces deviation_seconds to 0 when is_baseline=true`).
- [x] Session stats show the right average across at least two real scenarios (unit tests: 7-day/3-reading and 14-day/5-reading irregular-sampling cases).
- [x] Deleting a reading recomputes stats on next fetch (integration test + SPA `reloadReadings()` on delete).
- [x] `drift-calc` is pure (no hono/kysely/workerd imports; runs in the default vitest pool with plain arrays).
- [x] Session panel hides avg drift when `reading_count < 2` (`SessionStatsPanel` branch + unit-test coverage).

## Post-merge operator step

A new D1 migration lands in this PR. Before the `main` → prod deploy picks it up, run:

```bash
npx wrangler d1 migrations apply rated-watch-db --remote
```

(Per `AGENTS.md` — the vitest integration setup auto-applies locally; prod/preview D1 needs this explicit apply.)

## Coordination note

Worker K (issue #10) is running in parallel on the submit-unknown-movement flow. Lanes kept clean:
- I only modified `src/worker/index.tsx` (mount 2 lines) and `src/db/schema.ts` (add `ReadingsTable`).
- No changes to `WatchForm.tsx`, `MovementTypeahead.tsx`, `NewWatchPage.tsx`, `movements.ts` routes, `src/domain/movements/`, or `src/schemas/movement.ts`.
- `src/app/watches/api.ts` unchanged (I added a separate `readings.ts` client beside it).
- Expect a trivial conflict in `package-lock.json` / `src/worker/index.tsx` at most.

## Followups (out of scope)

- Slice #16 flips `verified` on the reading insert path when a camera capture is submitted.
- Slice #17 consumes `SessionStats.eligible` + `.avg_drift_rate_spd` for the movement leaderboard ranker.
- No per-interval drift chart yet — the per-interval data is already in the response, a chart can be added when the UX is nailed down.