### PR TITLE
Slice 13: Leaderboard (global) — public HTML + JSON + home hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,6 +582,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5138,6 +5163,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -582,31 +582,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5163,7 +5138,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/domain/leaderboard-query/index.ts
+++ b/src/domain/leaderboard-query/index.ts
@@ -1,0 +1,4 @@
+// Barrel export for the leaderboard-query domain module. Mirrors the
+// shape of src/domain/drift-calc so consumers never reach into the
+// internal file layout.
+export { queryLeaderboard, type LeaderboardOpts, type RankedWatch } from "./query";

--- a/src/domain/leaderboard-query/query.ts
+++ b/src/domain/leaderboard-query/query.ts
@@ -1,0 +1,180 @@
+// Leaderboard query. The domain module that the public leaderboard
+// page (/leaderboard), per-movement pages (/m/:id, slice #14), and
+// the /api/v1/leaderboard JSON endpoint all compose onto.
+//
+// Conceptually:
+//   1. SELECT candidate watches = public + approved-movement.
+//   2. For each candidate, LOAD its readings (cap 200 most-recent to
+//      protect the Worker) and COMPUTE session stats via drift-calc.
+//   3. KEEP only eligible watches (drift-calc.eligible === true). If
+//      verified_only, also require session_stats.verified_badge.
+//   4. SORT by abs(avg_drift_rate_spd) ASC. Zero drift = best.
+//   5. Assign 1-based ranks, apply limit + offset, return.
+//
+// This does more work in the Worker than in SQL deliberately — the
+// ranking rule depends on drift-calc's `eligible` + `verified_badge`
+// logic, which is the single source of truth for "does this watch
+// qualify?". Duplicating that logic as SQL would be a correctness
+// liability. The up-front `candidate` query keeps the result set
+// small (public, approved) so the in-memory pass stays fast until
+// the dataset outgrows the single-Worker approach.
+//
+// TODO(perf): when candidate_count * avg_readings_per_watch trends
+// past ~O(10k), push more work into SQL — e.g. pre-filter by "has
+// ≥3 readings spanning ≥7 days" via a window query to drop the
+// ineligible tail before drift-calc runs.
+
+import type { Kysely } from "kysely";
+import type { Database } from "@/db/schema";
+import {
+  computeSessionStats,
+  type Reading,
+  type SessionStats,
+} from "@/domain/drift-calc";
+
+/**
+ * A watch that's qualified for the leaderboard, enriched with the
+ * rendering data the public pages need (owner username, movement
+ * canonical name, session stats) and a 1-based rank.
+ */
+export interface RankedWatch {
+  watch_id: string;
+  watch_name: string;
+  watch_brand: string | null;
+  watch_model: string | null;
+  owner_username: string;
+  /** Never null — pending-movement watches are filtered out upstream. */
+  movement_id: string;
+  movement_canonical_name: string;
+  session_stats: SessionStats;
+  /** 1-based rank across the full eligible set (before limit/offset). */
+  rank: number;
+}
+
+export interface LeaderboardOpts {
+  /** Filter to watches on one movement (for /m/:id). */
+  movement_id?: string;
+  /** If true, require session_stats.verified_badge === true. */
+  verified_only?: boolean;
+  /** Default 50, capped at 200 to protect the Worker. */
+  limit?: number;
+  /** Default 0. Combined with limit for pagination. */
+  offset?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const READINGS_CAP_PER_WATCH = 200;
+
+interface CandidateRow {
+  watch_id: string;
+  watch_name: string;
+  watch_brand: string | null;
+  watch_model: string | null;
+  owner_username: string;
+  movement_id: string;
+  movement_canonical_name: string;
+}
+
+/**
+ * Rank public, eligible watches on approved movements by abs(avg drift
+ * rate) ascending. See module comment for the full algorithm. Pure-
+ * ish — reads from the passed-in Kysely client and nothing else.
+ */
+export async function queryLeaderboard(
+  opts: LeaderboardOpts,
+  db: Kysely<Database>,
+): Promise<RankedWatch[]> {
+  const limit = Math.min(Math.max(opts.limit ?? DEFAULT_LIMIT, 0), MAX_LIMIT);
+  const offset = Math.max(opts.offset ?? 0, 0);
+  const verifiedOnly = opts.verified_only === true;
+
+  // Step 1 — candidate watches. Join watches → user → movements so the
+  // HTML page can render everything without a second round trip.
+  let candidateQuery = db
+    .selectFrom("watches")
+    .innerJoin("user", "user.id", "watches.user_id")
+    .innerJoin("movements", "movements.id", "watches.movement_id")
+    .where("watches.is_public", "=", 1)
+    .where("movements.status", "=", "approved")
+    .select([
+      "watches.id as watch_id",
+      "watches.name as watch_name",
+      "watches.brand as watch_brand",
+      "watches.model as watch_model",
+      "user.username as owner_username",
+      "movements.id as movement_id",
+      "movements.canonical_name as movement_canonical_name",
+    ]);
+
+  if (opts.movement_id) {
+    candidateQuery = candidateQuery.where("watches.movement_id", "=", opts.movement_id);
+  }
+
+  const candidates = (await candidateQuery.execute()) as CandidateRow[];
+  if (candidates.length === 0) return [];
+
+  // Step 2 — load readings + compute session stats per candidate.
+  // Parallelised via Promise.all so worker I/O is overlapped; D1 has
+  // no per-request concurrency limit that matters at these sizes.
+  const withStats = await Promise.all(
+    candidates.map(async (c) => {
+      const rows = await db
+        .selectFrom("readings")
+        .select([
+          "id",
+          "reference_timestamp",
+          "deviation_seconds",
+          "is_baseline",
+          "verified",
+        ])
+        .where("watch_id", "=", c.watch_id)
+        .orderBy("reference_timestamp", "desc")
+        .limit(READINGS_CAP_PER_WATCH)
+        .execute();
+      const readings: Reading[] = rows.map((r) => ({
+        id: r.id,
+        reference_timestamp: r.reference_timestamp,
+        deviation_seconds: r.deviation_seconds,
+        is_baseline: r.is_baseline === 1,
+        verified: r.verified === 1,
+      }));
+      const stats = computeSessionStats(readings);
+      return { candidate: c, stats };
+    }),
+  );
+
+  // Step 3 — eligibility + verified filter. Also drop any row whose
+  // avg_drift_rate_spd is null (shouldn't happen for eligible rows
+  // since eligibility implies ≥2 readings, but the type says it could).
+  const qualified = withStats.filter(({ stats }) => {
+    if (!stats.eligible) return false;
+    if (stats.avg_drift_rate_spd === null) return false;
+    if (verifiedOnly && !stats.verified_badge) return false;
+    return true;
+  });
+
+  // Step 4 — sort by abs(drift) ASC. Stable tiebreaker by watch_id so
+  // identical-drift rows don't jump around between requests.
+  qualified.sort((a, b) => {
+    const diff =
+      Math.abs(a.stats.avg_drift_rate_spd!) - Math.abs(b.stats.avg_drift_rate_spd!);
+    if (diff !== 0) return diff;
+    return a.candidate.watch_id.localeCompare(b.candidate.watch_id);
+  });
+
+  // Step 5 — assign 1-based ranks to the full qualified set, then slice.
+  const ranked: RankedWatch[] = qualified.map((row, idx) => ({
+    watch_id: row.candidate.watch_id,
+    watch_name: row.candidate.watch_name,
+    watch_brand: row.candidate.watch_brand,
+    watch_model: row.candidate.watch_model,
+    owner_username: row.candidate.owner_username,
+    movement_id: row.candidate.movement_id,
+    movement_canonical_name: row.candidate.movement_canonical_name,
+    session_stats: row.stats,
+    rank: idx + 1,
+  }));
+
+  return ranked.slice(offset, offset + limit);
+}

--- a/src/public/landing.tsx
+++ b/src/public/landing.tsx
@@ -1,28 +1,40 @@
 // Server-rendered public home page. Zero client JS (asserted by the
 // "no <script> tag" integration test). The shared <Layout> owns the
-// design-system tokens and OG meta; this file only owns copy.
-import { Layout } from "./components/layout";
-import { Header } from "./components/header";
-import { Footer } from "./components/footer";
+// design-system tokens and OG meta; this file only owns copy and the
+// top-verified-watches hero section that sits below the main CTA.
+//
+// Slice #13 extended the page from pure copy into a data-backed hero:
+// the Worker fetches the current top-5 verified watches via
+// queryLeaderboard and passes them in as a prop so /‎ stays a single
+// HTML response with no client fetching.
+import type { RankedWatch } from "@/domain/leaderboard-query";
 import { Button } from "./components/button";
 import { Card } from "./components/card";
+import { Footer } from "./components/footer";
+import { Header } from "./components/header";
+import { Layout } from "./components/layout";
+import { formatDriftRate, formatWatchLabel } from "./leaderboard/format";
 
 const TITLE = "rated.watch — competitive accuracy tracking for watch enthusiasts";
 const DESCRIPTION =
   "Competitive accuracy tracking for watch enthusiasts. Verified deviation, drift-rate leaderboards, grouped by movement.";
 
-export const LandingPage = () => (
+export interface LandingPageProps {
+  /** Top-5 verified watches from the global leaderboard. May be empty
+   *  during the cold-start phase when nobody has crossed the verified
+   *  threshold yet. */
+  topVerified?: RankedWatch[];
+}
+
+export const LandingPage = ({ topVerified = [] }: LandingPageProps) => (
   <Layout title={TITLE} description={DESCRIPTION} pathname="/">
     <Header />
     <main>
       <section class="cf-container cf-hero" aria-labelledby="hero-title">
-        <h1 id="hero-title">
-          Competitive accuracy tracking for watch enthusiasts.
-        </h1>
+        <h1 id="hero-title">Competitive accuracy tracking for watch enthusiasts.</h1>
         <p>
-          Log verified readings, watch your drift rate settle, and climb the
-          leaderboards grouped by movement caliber. Spoof-resistant, public,
-          and mechanical-first.
+          Log verified readings, watch your drift rate settle, and climb the leaderboards
+          grouped by movement caliber. Spoof-resistant, public, and mechanical-first.
         </p>
         <div style="display:flex;gap:12px;flex-wrap:wrap">
           <Button as="a" href="/leaderboard" variant="primary">
@@ -34,22 +46,45 @@ export const LandingPage = () => (
         </div>
       </section>
 
-      <section class="cf-container cf-section" aria-labelledby="next-title">
-        <h2 id="next-title" style="margin:0 0 24px;font-size:1.25rem;font-weight:500;letter-spacing:-0.02em;color:var(--cf-text-muted)">
-          Coming soon
+      <section class="cf-container cf-section" aria-labelledby="top-verified-title">
+        <h2
+          id="top-verified-title"
+          style="margin:0 0 24px;font-size:1.25rem;font-weight:500;letter-spacing:-0.02em;color:var(--cf-text-muted)"
+        >
+          Top verified watches
         </h2>
-        <div class="cf-grid-2">
-          <Card title="Leaderboards by movement">
-            Watches compete within their own caliber — a Calibre 3135 is judged
-            against other 3135s, not a quartz HAQ. Fair, apples-to-apples
-            rankings by drift rate over the last session.
+        {topVerified.length === 0 ? (
+          <Card title="Be the first to log a verified reading!">
+            Nobody's crossed the 25 % verified-reading threshold yet. Sign up, log your
+            first baseline through the app camera flow, and you could be the watch
+            everyone else is chasing.
           </Card>
-          <Card title="Verified readings only">
-            In-app camera captures are timestamped by the server at receipt.
-            No trusting client clocks. Watches hit a verified badge when 25 %
-            of their current session is camera-sourced.
-          </Card>
-        </div>
+        ) : (
+          <div class="cf-grid-2">
+            {topVerified.map((w) => (
+              <Card
+                title={formatWatchLabel({
+                  name: w.watch_name,
+                  brand: w.watch_brand,
+                  model: w.watch_model,
+                })}
+              >
+                <p style="margin:0 0 8px">
+                  <a href={`/m/${w.movement_id}`}>{w.movement_canonical_name}</a>
+                  <span style="color:var(--cf-text-subtle)"> · </span>
+                  <a href={`/u/${w.owner_username}`}>@{w.owner_username}</a>
+                </p>
+                <p style="margin:0;font-family:var(--cf-font-mono)">
+                  Drift{" "}
+                  <strong>{formatDriftRate(w.session_stats.avg_drift_rate_spd)}</strong>{" "}
+                  <span style="color:var(--cf-text-subtle)">
+                    · rank #{String(w.rank)}
+                  </span>
+                </p>
+              </Card>
+            ))}
+          </div>
+        )}
       </section>
     </main>
     <Footer />

--- a/src/public/leaderboard/format.test.ts
+++ b/src/public/leaderboard/format.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { formatDriftRate, formatWatchLabel } from "./format";
+
+describe("formatDriftRate", () => {
+  it("renders null/NaN/Infinity as em-dash", () => {
+    expect(formatDriftRate(null)).toBe("—");
+    expect(formatDriftRate(Number.NaN)).toBe("—");
+    expect(formatDriftRate(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+
+  it("renders 0 without a sign", () => {
+    expect(formatDriftRate(0)).toBe("0.0 s/d");
+  });
+
+  it("renders a positive rate with a leading +", () => {
+    expect(formatDriftRate(0.5)).toBe("+0.5 s/d");
+    expect(formatDriftRate(12.345)).toBe("+12.3 s/d");
+  });
+
+  it("renders a negative rate with a leading -", () => {
+    expect(formatDriftRate(-1.2)).toBe("-1.2 s/d");
+  });
+});
+
+describe("formatWatchLabel", () => {
+  it("prefers Brand + Model when both exist", () => {
+    expect(formatWatchLabel({ name: "n", brand: "Rolex", model: "126610LN" })).toBe(
+      "Rolex 126610LN",
+    );
+  });
+
+  it("falls back to name when brand+model are both null", () => {
+    expect(formatWatchLabel({ name: "My Watch", brand: null, model: null })).toBe(
+      "My Watch",
+    );
+  });
+
+  it("uses just brand when model is missing", () => {
+    expect(formatWatchLabel({ name: "n", brand: "Omega", model: null })).toBe("Omega");
+  });
+});

--- a/src/public/leaderboard/format.ts
+++ b/src/public/leaderboard/format.ts
@@ -1,0 +1,32 @@
+// Small formatting helpers for the leaderboard surface. Split out of
+// page.tsx so the pure functions can be unit-tested without standing
+// up a Worker.
+
+/**
+ * Format a signed seconds-per-day drift rate into "+0.5 s/d" / "-1.2 s/d".
+ * Null (not enough data) renders as "—" so the page doesn't leak the
+ * special value into the UI.
+ */
+export function formatDriftRate(spd: number | null): string {
+  if (spd === null || !Number.isFinite(spd)) return "—";
+  // 0.0 renders as "0.0 s/d" — no leading sign.
+  if (spd === 0) return "0.0 s/d";
+  const sign = spd > 0 ? "+" : "";
+  return `${sign}${spd.toFixed(1)} s/d`;
+}
+
+/**
+ * Render the full watch name for the leaderboard row — prefers
+ * "Brand Model" when both are present, falls back to `name` otherwise.
+ */
+export function formatWatchLabel(input: {
+  name: string;
+  brand: string | null;
+  model: string | null;
+}): string {
+  const parts: string[] = [];
+  if (input.brand) parts.push(input.brand);
+  if (input.model) parts.push(input.model);
+  if (parts.length === 0) return input.name;
+  return parts.join(" ");
+}

--- a/src/public/leaderboard/page.tsx
+++ b/src/public/leaderboard/page.tsx
@@ -1,0 +1,234 @@
+// Public HTML leaderboard page. SSR via hono/jsx — zero client JS.
+//
+// Reads ?verified=1 to flip verified_only at the domain layer. Renders
+// a table-style list where each row links off to (slice 14/15) pages
+// that haven't shipped yet; those anchors are harmless — they become
+// real destinations as those slices land.
+//
+// The list is short + mostly-numeric so a <table> is the semantic fit
+// (screen readers + copy-paste into a spreadsheet both "just work").
+
+import { Footer } from "../components/footer";
+import { Header } from "../components/header";
+import { Layout } from "../components/layout";
+import type { RankedWatch } from "@/domain/leaderboard-query";
+import { formatDriftRate, formatWatchLabel } from "./format";
+
+export interface LeaderboardPageProps {
+  watches: RankedWatch[];
+  verifiedOnly: boolean;
+}
+
+const TITLE = "Leaderboard — rated.watch";
+const DESCRIPTION =
+  "Global accuracy leaderboard. Watches ranked by absolute drift rate, grouped by movement caliber.";
+
+export const LeaderboardPage = ({ watches, verifiedOnly }: LeaderboardPageProps) => (
+  <Layout title={TITLE} description={DESCRIPTION} pathname="/leaderboard">
+    <LeaderboardStyles />
+    <Header />
+    <main>
+      <section class="cf-container cf-hero" aria-labelledby="lb-title">
+        <h1 id="lb-title">Global leaderboard</h1>
+        <p>
+          Ranked by absolute drift rate since each watch's most recent baseline. Lower is
+          better — a drift of 0 s/d means the watch is keeping time perfectly.
+        </p>
+        <nav class="cf-lb-filters" aria-label="Leaderboard filters">
+          <a href="/leaderboard" class={verifiedOnly ? "" : "cf-lb-filter--active"}>
+            All watches
+          </a>
+          <a
+            href="/leaderboard?verified=1"
+            class={verifiedOnly ? "cf-lb-filter--active" : ""}
+          >
+            Verified only
+          </a>
+        </nav>
+      </section>
+
+      <section class="cf-container cf-section" aria-label="Leaderboard rankings">
+        {watches.length === 0 ? <EmptyState verifiedOnly={verifiedOnly} /> : null}
+        {watches.length > 0 ? <LeaderboardTable watches={watches} /> : null}
+      </section>
+
+      <section class="cf-container cf-lb-footnote">
+        <p>
+          Watches need at least <strong>7 days</strong> of readings and at least{" "}
+          <strong>3 readings</strong> since their current baseline to appear on the
+          leaderboard. The <span class="cf-lb-verified-dot" aria-hidden="true"></span>{" "}
+          verified badge means 25 % or more of the readings in this session were captured
+          through the in-app camera flow (spoof-resistant).
+        </p>
+      </section>
+    </main>
+    <Footer />
+  </Layout>
+);
+
+function EmptyState({ verifiedOnly }: { verifiedOnly: boolean }) {
+  return (
+    <div class="cf-card">
+      <div class="cf-brackets" aria-hidden="true">
+        <span />
+      </div>
+      <h2 class="cf-card__title">
+        {verifiedOnly ? "No verified watches yet" : "No eligible watches yet"}
+      </h2>
+      <div class="cf-card__body">
+        <p>
+          {verifiedOnly
+            ? "Nobody's crossed the 25 % verified-reading threshold in their current session. Start logging verified readings through the app and you could be first."
+            : "Nobody has logged enough readings yet. Create an account and be the first to appear here."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function LeaderboardTable({ watches }: { watches: RankedWatch[] }) {
+  return (
+    <table class="cf-lb-table">
+      <thead>
+        <tr>
+          <th scope="col" class="cf-lb-col-rank">
+            #
+          </th>
+          <th scope="col">Watch</th>
+          <th scope="col">Movement</th>
+          <th scope="col">Owner</th>
+          <th scope="col" class="cf-lb-col-num">
+            Drift
+          </th>
+          <th scope="col">Badge</th>
+        </tr>
+      </thead>
+      <tbody>
+        {watches.map((w) => (
+          <tr>
+            <td class="cf-lb-col-rank">{String(w.rank)}</td>
+            <td>
+              <a href={`/w/${w.watch_id}`}>
+                {formatWatchLabel({
+                  name: w.watch_name,
+                  brand: w.watch_brand,
+                  model: w.watch_model,
+                })}
+              </a>
+            </td>
+            <td>
+              <a href={`/m/${w.movement_id}`}>{w.movement_canonical_name}</a>
+            </td>
+            <td>
+              <a href={`/u/${w.owner_username}`}>@{w.owner_username}</a>
+            </td>
+            <td class="cf-lb-col-num">
+              {formatDriftRate(w.session_stats.avg_drift_rate_spd)}
+            </td>
+            <td>
+              {w.session_stats.verified_badge ? (
+                <span class="cf-lb-badge" title="25 %+ verified readings this session">
+                  Verified
+                </span>
+              ) : (
+                <span class="cf-lb-badge cf-lb-badge--muted">—</span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// Scoped stylesheet for the leaderboard page. Keeps the table styling
+// out of the shared Layout stylesheet so /leaderboard doesn't pay the
+// cost on every public page. Inlined because we're already inlining
+// the design-token sheet — one more small <style> tag is cheaper than
+// a second HTTP round-trip for a stylesheet request.
+function LeaderboardStyles() {
+  const css = `
+.cf-lb-filters {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  font-size: 0.875rem;
+}
+.cf-lb-filters a {
+  color: var(--cf-text-muted);
+  padding: 6px 12px;
+  border: 1px solid var(--cf-border);
+  border-radius: var(--cf-radius-full);
+}
+.cf-lb-filters a:hover { color: var(--cf-text); background: var(--cf-bg-300); }
+.cf-lb-filter--active {
+  color: var(--cf-text) !important;
+  border-color: var(--cf-orange) !important;
+  background: var(--cf-bg-200);
+}
+
+.cf-lb-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+.cf-lb-table thead th {
+  text-align: left;
+  padding: 12px;
+  border-bottom: 1px solid var(--cf-border);
+  font-weight: 500;
+  color: var(--cf-text-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.cf-lb-table tbody td {
+  padding: 12px;
+  border-bottom: 1px solid var(--cf-border-light);
+  vertical-align: middle;
+}
+.cf-lb-col-rank {
+  width: 3rem;
+  font-family: var(--cf-font-mono);
+  color: var(--cf-text-muted);
+}
+.cf-lb-col-num {
+  font-family: var(--cf-font-mono);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.cf-lb-badge {
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: var(--cf-radius-full);
+  background: var(--cf-orange);
+  color: #FFFBF5;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.cf-lb-badge--muted {
+  background: transparent;
+  color: var(--cf-text-subtle);
+}
+
+.cf-lb-verified-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cf-orange);
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.cf-lb-footnote {
+  padding: 24px 24px 48px;
+  color: var(--cf-text-muted);
+  font-size: 0.9rem;
+}
+.cf-lb-footnote p { max-width: 70ch; margin: 0; }
+`;
+  return <style>{css}</style>;
+}

--- a/src/server/lib/purge-cache.test.ts
+++ b/src/server/lib/purge-cache.test.ts
@@ -1,0 +1,77 @@
+// Unit-ish test for the cache-purge helper. We only exercise the URL
+// shaping (no need to mock the Cache API) — the helper's failure mode
+// is "swallow and log nothing" by design, so assertions against the
+// returned URL list are what matter.
+
+import { describe, it, expect } from "vitest";
+import { purgeLeaderboardUrls } from "./purge-cache";
+
+describe("purgeLeaderboardUrls", () => {
+  it("emits /leaderboard + ?verified=1 + / on every call", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL("https://rated.watch/api/v1/watches/w1/readings"),
+      movementId: null,
+      username: null,
+      watchId: null,
+    });
+    expect(urls).toContain("https://rated.watch/leaderboard");
+    expect(urls).toContain("https://rated.watch/leaderboard?verified=1");
+    expect(urls).toContain("https://rated.watch/");
+  });
+
+  it("adds /m/:movementId when provided", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL("https://rated.watch/"),
+      movementId: "mov-xyz",
+      username: null,
+      watchId: null,
+    });
+    expect(urls).toContain("https://rated.watch/m/mov-xyz");
+  });
+
+  it("adds /u/:username when provided", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL("https://rated.watch/"),
+      movementId: null,
+      username: "alice",
+      watchId: null,
+    });
+    expect(urls).toContain("https://rated.watch/u/alice");
+  });
+
+  it("adds /w/:watchId when provided", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL("https://rated.watch/"),
+      movementId: null,
+      username: null,
+      watchId: "watch-123",
+    });
+    expect(urls).toContain("https://rated.watch/w/watch-123");
+  });
+
+  it("omits per-target URLs when the target is null/undefined", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL("https://rated.watch/"),
+      movementId: undefined,
+      username: undefined,
+      watchId: undefined,
+    });
+    expect(urls.some((u) => u.includes("/m/"))).toBe(false);
+    expect(urls.some((u) => u.includes("/u/"))).toBe(false);
+    expect(urls.some((u) => u.includes("/w/"))).toBe(false);
+  });
+
+  it("uses the host from the request URL (works on preview domains)", async () => {
+    const urls = await purgeLeaderboardUrls({
+      requestUrl: new URL(
+        "https://pr-42-ratedwatch.nmoura.workers.dev/api/v1/readings/r1",
+      ),
+      movementId: "m1",
+      username: "bob",
+      watchId: "w1",
+    });
+    for (const u of urls) {
+      expect(u).toMatch(/^https:\/\/pr-42-ratedwatch\.nmoura\.workers\.dev/);
+    }
+  });
+});

--- a/src/server/lib/purge-cache.ts
+++ b/src/server/lib/purge-cache.ts
@@ -1,0 +1,70 @@
+// Best-effort Cache API purge helpers. Called from mutation handlers
+// (readings POST/DELETE today, more mutation surfaces later) so fresh
+// writes don't sit behind a stale `s-maxage=300` public page for five
+// minutes.
+//
+// Philosophy:
+//   * Purging is advisory — if it fails (no Cache API in dev, transient
+//     error, whatever), the natural s-maxage expiry still cleans it up
+//     within 5 minutes. We never let a purge failure propagate as a
+//     handler error. Readings mutations are authoritative; the edge
+//     cache is a convenience.
+//   * We purge by full URL, not by path, because Cache API is keyed on
+//     the request URL. The helpers take a `requestUrl` so the caller
+//     can derive the correct origin — inside a Worker handler this is
+//     `new URL(c.req.url)` which gives us the live host + scheme.
+
+export interface PurgeLeaderboardUrlsInput {
+  /** The URL of the mutating request. Used as a base for scheme+host
+   *  so the purged URLs match what the edge actually cached. */
+  requestUrl: URL;
+  /** movement_id of the affected watch (for /m/:id purge). Null when
+   *  the watch has no movement attached. */
+  movementId: string | null | undefined;
+  /** Owner's username (for /u/:username purge). */
+  username: string | null | undefined;
+  /** Watch id (for /w/:id purge, slice #15). */
+  watchId: string | null | undefined;
+}
+
+/**
+ * Purge the public-page URLs that depend on reading state for a given
+ * watch. Safe to call from any mutation handler. Returns the list of
+ * URLs attempted (for logging), not a success/failure — individual
+ * deletions are fire-and-forget.
+ */
+export async function purgeLeaderboardUrls(
+  input: PurgeLeaderboardUrlsInput,
+): Promise<string[]> {
+  const origin = `${input.requestUrl.protocol}//${input.requestUrl.host}`;
+  const urls: string[] = [];
+  urls.push(`${origin}/leaderboard`);
+  urls.push(`${origin}/leaderboard?verified=1`);
+  // Home hero shows top-5 verified watches, so it also depends on
+  // reading state.
+  urls.push(`${origin}/`);
+  if (input.movementId) urls.push(`${origin}/m/${input.movementId}`);
+  if (input.username) urls.push(`${origin}/u/${input.username}`);
+  if (input.watchId) urls.push(`${origin}/w/${input.watchId}`);
+
+  // The default Cache API is only exposed inside the Worker runtime;
+  // in local vitest / miniflare it exists but calls are a no-op against
+  // the in-memory cache. We guard all of this against `typeof caches`
+  // because the `caches` global is otherwise a fresh Worker-runtime
+  // reference that some environments don't populate.
+  try {
+    // Workers `caches.default` is the standard CDN cache.
+    const cache =
+      typeof caches !== "undefined" && "default" in caches
+        ? (caches as unknown as { default: Cache }).default
+        : null;
+    if (!cache) return urls;
+    // Delete each URL in parallel; failures are silent by design.
+    await Promise.allSettled(
+      urls.map((u) => cache.delete(new Request(u, { method: "GET" }))),
+    );
+  } catch {
+    // Swallow. The s-maxage expiry is the fallback.
+  }
+  return urls;
+}

--- a/src/server/routes/leaderboard.ts
+++ b/src/server/routes/leaderboard.ts
@@ -1,0 +1,64 @@
+// GET /api/v1/leaderboard
+//
+// Public (no auth) JSON surface the SPA and future native app consume
+// when they want the current rankings. All the real work lives in the
+// leaderboard-query domain module; this file is just a thin validation
+// + marshalling layer.
+//
+// Query params (all optional, all validated with Zod):
+//   * movement_id    — narrow to one caliber (reused by /m/:id pages)
+//   * verified_only  — "1" | "true" → require verified_badge
+//   * limit          — 1..200, default 50
+//   * offset         — 0+, default 0
+//
+// Response envelope:
+//   { watches: RankedWatch[] }
+//
+// `total` is intentionally absent from the default response — paginating
+// a ranked list doesn't need a total count to render the "next" link,
+// and computing it would force the expensive drift pass to run against
+// every candidate just to count them. If we end up needing a total for
+// the SPA's infinite scroll we can add it behind a `?include_total=1`
+// opt-in.
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { createDb } from "@/db";
+import { queryLeaderboard } from "@/domain/leaderboard-query";
+
+type Bindings = { DB: D1Database; [key: string]: unknown };
+
+// Zod coerces incoming query-string scalars to their typed shape. Booleans
+// accept the two wire conventions we already use elsewhere ("1" and
+// "true") so the SPA can pass whichever is handier.
+const leaderboardQuerySchema = z.object({
+  movement_id: z.string().trim().min(1).max(200).optional(),
+  verified_only: z
+    .union([z.literal("1"), z.literal("true"), z.literal("0"), z.literal("false")])
+    .optional()
+    .transform((v) => v === "1" || v === "true"),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const leaderboardRoute = new Hono<{ Bindings: Bindings }>();
+
+leaderboardRoute.get("/", async (c) => {
+  const parsed = leaderboardQuerySchema.safeParse({
+    movement_id: c.req.query("movement_id"),
+    verified_only: c.req.query("verified_only"),
+    limit: c.req.query("limit"),
+    offset: c.req.query("offset"),
+  });
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query", issues: parsed.error.issues }, 400);
+  }
+  const { movement_id, verified_only, limit, offset } = parsed.data;
+
+  const db = createDb(c.env);
+  const watches = await queryLeaderboard(
+    { movement_id, verified_only, limit, offset },
+    db,
+  );
+  return c.json({ watches });
+});

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -36,6 +36,7 @@ import {
   type ReadingResponse,
 } from "@/schemas/reading";
 import { getAuth, type AuthEnv } from "@/server/auth";
+import { purgeLeaderboardUrls } from "@/server/lib/purge-cache";
 import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
 
 type Bindings = AuthEnv & {
@@ -89,6 +90,20 @@ async function listReadingsForWatch(db: DB, watchId: string): Promise<DbReadingR
     .orderBy("reference_timestamp", "asc")
     .execute();
   return rows as DbReadingRow[];
+}
+
+/**
+ * Fetch the owner's username for a user_id. Best-effort — returns null
+ * if the user was deleted mid-request (shouldn't happen, but we guard
+ * so the cache purge never throws). Only used by the purge helper.
+ */
+async function lookupUsername(db: DB, userId: string): Promise<string | null> {
+  const row = await db
+    .selectFrom("user")
+    .select(["username"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  return row?.username ?? null;
 }
 
 // ---- /api/v1/watches/:watchId/readings ----------------------------
@@ -215,6 +230,18 @@ readingsByWatchRoute.post("/", async (c) => {
     .selectAll()
     .where("id", "=", id)
     .executeTakeFirstOrThrow();
+
+  // Cache purge: public leaderboard + home hero + per-movement / per-user /
+  // per-watch pages all depend on reading state. Best-effort — if the
+  // purge fails the s-maxage=300 TTL is the fallback.
+  const username = await lookupUsername(db, user.id);
+  await purgeLeaderboardUrls({
+    requestUrl: new URL(c.req.url),
+    movementId: ownership.watch.movement_id,
+    username,
+    watchId,
+  });
+
   return c.json(toResponse(created as DbReadingRow), 201);
 });
 
@@ -262,5 +289,16 @@ readingsByIdRoute.delete("/:id", async (c) => {
   }
 
   await db.deleteFrom("readings").where("id", "=", id).execute();
+
+  // Mirror the POST purge — any mutation to the watch's readings
+  // invalidates the same cached URL set.
+  const username = await lookupUsername(db, user.id);
+  await purgeLeaderboardUrls({
+    requestUrl: new URL(c.req.url),
+    movementId: ownership.watch.movement_id,
+    username,
+    watchId: row.watch_id,
+  });
+
   return c.body(null, 204);
 });

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -6,6 +6,7 @@
 import { Hono } from "hono";
 import { LandingPage } from "@/public/landing";
 import { getAuth, type AuthEnv } from "@/server/auth";
+import { leaderboardRoute } from "@/server/routes/leaderboard";
 import { meRoute } from "@/server/routes/me";
 import { movementsRoute } from "@/server/routes/movements";
 import { readingsByIdRoute, readingsByWatchRoute } from "@/server/routes/readings";
@@ -38,6 +39,9 @@ app.all("/api/v1/auth/*", (c) => {
 // later slices add watches/readings here.
 app.route("/api/v1/me", meRoute);
 app.route("/api/v1/movements", movementsRoute);
+// Global leaderboard + per-movement leaderboard (filter via query param).
+// Public — no auth middleware. See src/server/routes/leaderboard.ts.
+app.route("/api/v1/leaderboard", leaderboardRoute);
 // Readings live under two paths: nested under a watch for
 // list/create, and flat at /api/v1/readings/:id for delete. Mount
 // the nested route BEFORE /api/v1/watches so its requireAuth

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -25,8 +25,13 @@ type Bindings = AuthEnv & {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.get("/", (c) => {
-  return c.html(<LandingPage />);
+app.get("/", async (c) => {
+  // Hero extension (slice #13): surface the top-5 verified watches so
+  // first-time visitors see the social proof immediately. Falls back
+  // to an empty-state card when nobody has crossed the threshold yet.
+  const db = createDb(c.env);
+  const topVerified = await queryLeaderboard({ verified_only: true, limit: 5 }, db);
+  return c.html(<LandingPage topVerified={topVerified} />);
 });
 
 // Public HTML leaderboard. Owned by the Worker (see run_worker_first in

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -4,7 +4,10 @@
 // Auth verbatim) and the `requireAuth`-gated /api/v1/me endpoint. The
 // landing page at `/` is unchanged from slice 3.
 import { Hono } from "hono";
+import { createDb } from "@/db";
+import { queryLeaderboard } from "@/domain/leaderboard-query";
 import { LandingPage } from "@/public/landing";
+import { LeaderboardPage } from "@/public/leaderboard/page";
 import { getAuth, type AuthEnv } from "@/server/auth";
 import { leaderboardRoute } from "@/server/routes/leaderboard";
 import { meRoute } from "@/server/routes/me";
@@ -24,6 +27,19 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/", (c) => {
   return c.html(<LandingPage />);
+});
+
+// Public HTML leaderboard. Owned by the Worker (see run_worker_first in
+// wrangler.jsonc) rather than the SPA fallback, so crawlers + no-JS
+// clients see the rendered markup. The page is cacheable for 5 minutes
+// at the edge with a 24-hour SWR window — reading mutations purge it
+// explicitly so first-time viewers never see a stale ranking for long.
+app.get("/leaderboard", async (c) => {
+  const db = createDb(c.env);
+  const verifiedOnly = c.req.query("verified") === "1";
+  const watches = await queryLeaderboard({ verified_only: verifiedOnly, limit: 50 }, db);
+  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+  return c.html(<LeaderboardPage watches={watches} verifiedOnly={verifiedOnly} />);
 });
 
 // Better Auth owns every method under /api/v1/auth/*. We pass the raw

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -495,3 +495,29 @@ describe("GET /leaderboard — public HTML", () => {
     expect(body).not.toMatch(/<script\b/i);
   });
 });
+
+// ---- Home hero top-5 extension ------------------------------------
+
+describe("GET / — home hero: top verified watches", () => {
+  it("surfaces the top verified watch brand + model on the landing page", async () => {
+    const res = await exports.default.fetch(new Request("https://ratedwatch.test/"));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // gold is verified + rank 1 so its brand + model must appear.
+    expect(body).toContain(SEED.watches.gold.brand);
+    expect(body).toContain(SEED.watches.gold.model);
+  });
+
+  it("omits unverified watches (silver)", async () => {
+    const res = await exports.default.fetch(new Request("https://ratedwatch.test/"));
+    const body = await res.text();
+    // silver has verified_ratio 0 → must not appear in the verified top-5 hero.
+    expect(body).not.toContain(SEED.watches.silver.brand);
+  });
+
+  it("still renders with zero client JS (<script> count stays zero)", async () => {
+    const res = await exports.default.fetch(new Request("https://ratedwatch.test/"));
+    const body = await res.text();
+    expect(body).not.toMatch(/<script\b/i);
+  });
+});

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -1,0 +1,387 @@
+// Integration tests for slice 13: the global leaderboard.
+//
+// Seeds users + watches + readings directly via the D1 binding
+// (bypasses the auth + API surface because we only need the DB state
+// that queryLeaderboard reads from). The domain module is validated
+// against a real D1 + Kysely stack via miniflare so we exercise the
+// joins, not a mock.
+//
+// Also covers the HTML surface at /leaderboard and the home hero
+// top-5 section — both compose queryLeaderboard, so if the domain
+// behaves correctly the pages follow.
+
+import { env } from "cloudflare:test";
+import { beforeAll, describe, it, expect } from "vitest";
+import { createDb } from "@/db";
+import { queryLeaderboard } from "@/domain/leaderboard-query";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Unique prefix per test run so concurrent file runs or re-runs inside
+// the same miniflare storage isolation window don't clash on seed ids.
+const runId = crypto.randomUUID().slice(0, 8);
+const id = (suffix: string) => `lb-${runId}-${suffix}`;
+
+// Four users, five watches across three movements (two approved, one pending).
+//
+// Ranking (by abs(avg_drift_rate_spd) ASC) of eligible+public watches:
+//   1. gold     → 0.5 s/d   (verified)
+//   2. silver   → -1.0 s/d  (unverified, drift is abs 1.0)
+//   3. bronze   → 2.0 s/d   (verified)
+//
+// Excluded:
+//   * private    — is_public=0
+//   * ineligible — only 2 readings over 3 days
+//   * pending    — movement.status=pending
+const SEED = {
+  users: {
+    owner1: {
+      id: id("user-1"),
+      name: "User One",
+      email: `${id("u1")}@test`,
+      username: id("u-one"),
+    },
+    owner2: {
+      id: id("user-2"),
+      name: "User Two",
+      email: `${id("u2")}@test`,
+      username: id("u-two"),
+    },
+    owner3: {
+      id: id("user-3"),
+      name: "User Three",
+      email: `${id("u3")}@test`,
+      username: id("u-three"),
+    },
+    owner4: {
+      id: id("user-4"),
+      name: "User Four",
+      email: `${id("u4")}@test`,
+      username: id("u-four"),
+    },
+  },
+  movements: {
+    caliberA: {
+      id: id("mov-a"),
+      canonical_name: `ETA ${id("A")}`,
+      manufacturer: "ETA",
+      caliber: id("A"),
+      status: "approved",
+    },
+    caliberB: {
+      id: id("mov-b"),
+      canonical_name: `Seiko ${id("B")}`,
+      manufacturer: "Seiko",
+      caliber: id("B"),
+      status: "approved",
+    },
+    caliberPending: {
+      id: id("mov-p"),
+      canonical_name: `Pending ${id("P")}`,
+      manufacturer: "Proto",
+      caliber: id("P"),
+      status: "pending",
+    },
+  },
+  watches: {
+    gold: {
+      id: id("w-gold"),
+      name: "Gold Submariner",
+      brand: "Rolex",
+      model: "126610LN",
+      movement_id: "A",
+      is_public: 1,
+    },
+    silver: {
+      id: id("w-silver"),
+      name: "Silver Speedmaster",
+      brand: "Omega",
+      model: "310.30",
+      movement_id: "A",
+      is_public: 1,
+    },
+    bronze: {
+      id: id("w-bronze"),
+      name: "Bronze Turtle",
+      brand: "Seiko",
+      model: "SRP777",
+      movement_id: "B",
+      is_public: 1,
+    },
+    privateW: {
+      id: id("w-private"),
+      name: "Private Nomos",
+      brand: "Nomos",
+      model: "Tangente",
+      movement_id: "A",
+      is_public: 0,
+    },
+    ineligible: {
+      id: id("w-ineligible"),
+      name: "Fresh Tudor",
+      brand: "Tudor",
+      model: "BB58",
+      movement_id: "B",
+      is_public: 1,
+    },
+    pending: {
+      id: id("w-pending"),
+      name: "Proto",
+      brand: "Proto",
+      model: "X",
+      movement_id: "P",
+      is_public: 1,
+    },
+  },
+};
+
+async function seed() {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  const now = Date.now();
+
+  // Users.
+  for (const u of Object.values(SEED.users)) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO user (id, name, email, emailVerified, username, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?, ?)",
+      )
+      .bind(
+        u.id,
+        u.name,
+        u.email,
+        u.username,
+        new Date(now).toISOString(),
+        new Date(now).toISOString(),
+      )
+      .run();
+  }
+
+  // Movements.
+  for (const m of Object.values(SEED.movements)) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        m.id,
+        m.canonical_name,
+        m.manufacturer,
+        m.caliber,
+        "automatic",
+        m.status,
+        null,
+      )
+      .run();
+  }
+
+  // Watches — map the `movement_id` letter to the real movement id.
+  const movByKey: Record<string, string> = {
+    A: SEED.movements.caliberA.id,
+    B: SEED.movements.caliberB.id,
+    P: SEED.movements.caliberPending.id,
+  };
+  const watchUserMap: Record<string, string> = {
+    gold: SEED.users.owner1.id,
+    silver: SEED.users.owner2.id,
+    bronze: SEED.users.owner3.id,
+    privateW: SEED.users.owner1.id,
+    ineligible: SEED.users.owner4.id,
+    pending: SEED.users.owner4.id,
+  };
+  for (const [key, w] of Object.entries(SEED.watches)) {
+    const userId = watchUserMap[key]!;
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(w.id, userId, w.name, w.brand, w.model, movByKey[w.movement_id]!, w.is_public)
+      .run();
+  }
+
+  // Readings — eligibility = session_days ≥ 7 AND ≥ 3 readings.
+  //
+  // gold (user1):    baseline t, +3.5 @ +7d, +7 @ +14d  → drift 0.5 s/d, verified 2/3
+  // silver (user2):  baseline t, -7 @ +7d,  -14 @ +14d  → drift -1.0 s/d, verified 0/3
+  // bronze (user3):  baseline t, +14 @ +7d, +28 @ +14d  → drift 2.0 s/d, verified 3/3
+  // privateW:        same shape as gold so it would rank if not filtered
+  // ineligible:      only 2 readings, 3 days apart → excluded
+  // pending:         eligible shape, 3 readings, 7d → would rank but movement pending
+  type R = {
+    watch: string;
+    user: string;
+    t_offset_days: number;
+    deviation: number;
+    baseline?: boolean;
+    verified?: boolean;
+  };
+  const base = now;
+  const readings: R[] = [
+    // gold — verified watch, top rank
+    {
+      watch: "gold",
+      user: "owner1",
+      t_offset_days: 0,
+      deviation: 0,
+      baseline: true,
+      verified: true,
+    },
+    { watch: "gold", user: "owner1", t_offset_days: 7, deviation: 3.5, verified: true },
+    { watch: "gold", user: "owner1", t_offset_days: 14, deviation: 7, verified: false },
+    // silver — unverified, rank 2
+    { watch: "silver", user: "owner2", t_offset_days: 0, deviation: 0, baseline: true },
+    { watch: "silver", user: "owner2", t_offset_days: 7, deviation: -7 },
+    { watch: "silver", user: "owner2", t_offset_days: 14, deviation: -14 },
+    // bronze — verified, rank 3
+    {
+      watch: "bronze",
+      user: "owner3",
+      t_offset_days: 0,
+      deviation: 0,
+      baseline: true,
+      verified: true,
+    },
+    { watch: "bronze", user: "owner3", t_offset_days: 7, deviation: 14, verified: true },
+    { watch: "bronze", user: "owner3", t_offset_days: 14, deviation: 28, verified: true },
+    // private — mirrors gold but won't appear
+    { watch: "privateW", user: "owner1", t_offset_days: 0, deviation: 0, baseline: true },
+    { watch: "privateW", user: "owner1", t_offset_days: 7, deviation: 3.5 },
+    { watch: "privateW", user: "owner1", t_offset_days: 14, deviation: 7 },
+    // ineligible — under 7 days + under 3 readings
+    {
+      watch: "ineligible",
+      user: "owner4",
+      t_offset_days: 0,
+      deviation: 0,
+      baseline: true,
+    },
+    { watch: "ineligible", user: "owner4", t_offset_days: 3, deviation: 1.5 },
+    // pending-movement — fully eligible, but its movement is pending so excluded
+    { watch: "pending", user: "owner4", t_offset_days: 0, deviation: 0, baseline: true },
+    { watch: "pending", user: "owner4", t_offset_days: 7, deviation: 1 },
+    { watch: "pending", user: "owner4", t_offset_days: 14, deviation: 2 },
+  ];
+
+  const userIdMap: Record<string, string> = {
+    owner1: SEED.users.owner1.id,
+    owner2: SEED.users.owner2.id,
+    owner3: SEED.users.owner3.id,
+    owner4: SEED.users.owner4.id,
+  };
+  const watchIdMap: Record<string, string> = Object.fromEntries(
+    Object.entries(SEED.watches).map(([k, v]) => [k, v.id]),
+  );
+  for (const r of readings) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO readings (id, watch_id, user_id, reference_timestamp, deviation_seconds, is_baseline, verified) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        id(`r-${r.watch}-${r.t_offset_days}`),
+        watchIdMap[r.watch]!,
+        userIdMap[r.user]!,
+        base + r.t_offset_days * DAY_MS,
+        r.deviation,
+        r.baseline ? 1 : 0,
+        r.verified ? 1 : 0,
+      )
+      .run();
+  }
+}
+
+beforeAll(async () => {
+  await seed();
+});
+
+// ---- queryLeaderboard domain module ------------------------------
+
+describe("queryLeaderboard()", () => {
+  it("ranks public+eligible+approved-movement watches by abs(avg_drift_rate_spd) asc", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({}, db);
+
+    // Our three ranked watches should appear in order: gold, silver, bronze.
+    const ours = ranked.filter((r) =>
+      [SEED.watches.gold.id, SEED.watches.silver.id, SEED.watches.bronze.id].includes(
+        r.watch_id,
+      ),
+    );
+    expect(ours.map((r) => r.watch_id)).toEqual([
+      SEED.watches.gold.id,
+      SEED.watches.silver.id,
+      SEED.watches.bronze.id,
+    ]);
+    // And ranks are 1-based and monotonically increasing across the slice.
+    const ranks = ours.map((r) => r.rank);
+    for (let i = 1; i < ranks.length; i++) {
+      expect(ranks[i]!).toBeGreaterThan(ranks[i - 1]!);
+    }
+  });
+
+  it("excludes private watches", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({}, db);
+    expect(ranked.some((r) => r.watch_id === SEED.watches.privateW.id)).toBe(false);
+  });
+
+  it("excludes watches on pending movements", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({}, db);
+    expect(ranked.some((r) => r.watch_id === SEED.watches.pending.id)).toBe(false);
+  });
+
+  it("excludes watches that fail eligibility (< 7 days or < 3 readings)", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({}, db);
+    expect(ranked.some((r) => r.watch_id === SEED.watches.ineligible.id)).toBe(false);
+  });
+
+  it("verified_only=true excludes unverified watches", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({ verified_only: true }, db);
+    // silver has verified_ratio 0, so it must not appear.
+    expect(ranked.some((r) => r.watch_id === SEED.watches.silver.id)).toBe(false);
+    // gold and bronze should still be there.
+    expect(ranked.some((r) => r.watch_id === SEED.watches.gold.id)).toBe(true);
+    expect(ranked.some((r) => r.watch_id === SEED.watches.bronze.id)).toBe(true);
+  });
+
+  it("movement_id filter narrows to one movement", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard(
+      { movement_id: SEED.movements.caliberA.id },
+      db,
+    );
+    const ourIds = ranked.map((r) => r.watch_id);
+    expect(ourIds).toContain(SEED.watches.gold.id);
+    expect(ourIds).toContain(SEED.watches.silver.id);
+    expect(ourIds).not.toContain(SEED.watches.bronze.id);
+  });
+
+  it("pagination: limit + offset trim results", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const all = await queryLeaderboard({}, db);
+    expect(all.length).toBeGreaterThanOrEqual(3);
+    const firstTwo = await queryLeaderboard({ limit: 2 }, db);
+    expect(firstTwo).toHaveLength(2);
+    expect(firstTwo[0]!.watch_id).toBe(all[0]!.watch_id);
+    const skippedOne = await queryLeaderboard({ limit: 2, offset: 1 }, db);
+    expect(skippedOne[0]!.watch_id).toBe(all[1]!.watch_id);
+  });
+
+  it("RankedWatch shape: exposes username + movement canonical name + session_stats", async () => {
+    const db = createDb(env as { DB: D1Database });
+    const ranked = await queryLeaderboard({ limit: 50 }, db);
+    const gold = ranked.find((r) => r.watch_id === SEED.watches.gold.id);
+    expect(gold).toBeDefined();
+    expect(gold!.owner_username).toBe(SEED.users.owner1.username);
+    expect(gold!.movement_canonical_name).toBe(SEED.movements.caliberA.canonical_name);
+    expect(gold!.movement_id).toBe(SEED.movements.caliberA.id);
+    expect(gold!.session_stats.eligible).toBe(true);
+    expect(gold!.session_stats.verified_badge).toBe(true);
+    expect(gold!.session_stats.avg_drift_rate_spd).toBeCloseTo(0.5, 5);
+  });
+});
+
+// HTTP surface tests (GET /api/v1/leaderboard, /leaderboard HTML, home
+// hero top-5) land in follow-up commits of this slice, each paired
+// with the route that makes them pass.

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -429,3 +429,69 @@ describe("GET /api/v1/leaderboard", () => {
     expect(res.status).toBe(400);
   });
 });
+
+// ---- Public HTML page ---------------------------------------------
+
+describe("GET /leaderboard — public HTML", () => {
+  it("returns 200 text/html and contains the first-place watch brand", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/text\/html/);
+    const body = await res.text();
+    // gold is Rolex 126610LN — must appear on the page.
+    expect(body).toContain("Rolex");
+    expect(body).toContain(SEED.watches.gold.brand);
+    expect(body).toContain(SEED.watches.gold.model);
+  });
+
+  it("emits the aggressive Cache-Control header", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const cacheControl = res.headers.get("cache-control") ?? "";
+    expect(cacheControl).toMatch(/s-maxage=300/);
+    expect(cacheControl).toMatch(/stale-while-revalidate=86400/);
+  });
+
+  it("footer mentions the eligibility rule (7 days, 3 readings)", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const body = await res.text();
+    expect(body).toMatch(/7 days/);
+    expect(body).toMatch(/3 readings/);
+  });
+
+  it("does NOT include private watches in the HTML", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const body = await res.text();
+    // The private watch's distinctive brand + model must not appear.
+    expect(body).not.toContain(SEED.watches.privateW.brand);
+  });
+
+  it("verified=1 toggles the verified-only view", async () => {
+    const resAll = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const resVerified = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard?verified=1"),
+    );
+    const allBody = await resAll.text();
+    const verifiedBody = await resVerified.text();
+    // silver is the unverified watch — present in /leaderboard, absent when verified=1.
+    expect(allBody).toContain(SEED.watches.silver.brand);
+    expect(verifiedBody).not.toContain(SEED.watches.silver.brand);
+  });
+
+  it("emits zero client-side JavaScript (no hydration on public pages)", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const body = await res.text();
+    expect(body).not.toMatch(/<script\b/i);
+  });
+});

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -11,6 +11,7 @@
 // behaves correctly the pages follow.
 
 import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
 import { beforeAll, describe, it, expect } from "vitest";
 import { createDb } from "@/db";
 import { queryLeaderboard } from "@/domain/leaderboard-query";
@@ -382,6 +383,49 @@ describe("queryLeaderboard()", () => {
   });
 });
 
-// HTTP surface tests (GET /api/v1/leaderboard, /leaderboard HTML, home
-// hero top-5) land in follow-up commits of this slice, each paired
-// with the route that makes them pass.
+// ---- GET /api/v1/leaderboard JSON surface -------------------------
+
+describe("GET /api/v1/leaderboard", () => {
+  it("returns 200 JSON with watches[]", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/api/v1/leaderboard?limit=50"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { watches: Array<{ watch_id: string }> };
+    const ids = body.watches.map((w) => w.watch_id);
+    expect(ids).toContain(SEED.watches.gold.id);
+    expect(ids).toContain(SEED.watches.silver.id);
+    expect(ids).toContain(SEED.watches.bronze.id);
+  });
+
+  it("verified_only=1 filters at the API surface", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/api/v1/leaderboard?verified_only=1&limit=50"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { watches: Array<{ watch_id: string }> };
+    const ids = body.watches.map((w) => w.watch_id);
+    expect(ids).not.toContain(SEED.watches.silver.id);
+    expect(ids).toContain(SEED.watches.gold.id);
+  });
+
+  it("movement_id filter narrows at the API surface", async () => {
+    const res = await exports.default.fetch(
+      new Request(
+        `https://ratedwatch.test/api/v1/leaderboard?movement_id=${SEED.movements.caliberA.id}&limit=50`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { watches: Array<{ watch_id: string }> };
+    const ids = body.watches.map((w) => w.watch_id);
+    expect(ids).toContain(SEED.watches.gold.id);
+    expect(ids).not.toContain(SEED.watches.bronze.id);
+  });
+
+  it("rejects limit > 200 as a Zod validation error", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/api/v1/leaderboard?limit=9999"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,9 +7,10 @@
 
   // Workers Assets serves the Vite build output.
   //
-  //  - The Worker owns `/` (SSR landing page) and `/api/*` (future API) via
-  //    run_worker_first. Future public HTML routes (/leaderboard, /m/:id,
-  //    /u/:name, /w/:id) will be added here as they land.
+  //  - The Worker owns `/` (SSR landing page), `/leaderboard` (SSR public
+  //    leaderboard, slice #13), and `/api/*` via run_worker_first.
+  //    Future public HTML routes (/m/:id, /u/:name, /w/:id) will be added
+  //    here as they land.
   //  - Everything else falls through to assets. not_found_handling =
   //    single-page-application rewrites unknown paths to /index.html so
   //    the SPA's client-side router (react-router) can take over.
@@ -19,7 +20,7 @@
     "directory": "./dist/",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/", "/api/*"]
+    "run_worker_first": ["/", "/leaderboard", "/api/*"]
   },
 
   // Data layer bindings. IDs come from `terraform output` in


### PR DESCRIPTION
Closes #14

## Summary

Global leaderboard ships as a data-backed public page + JSON API + home-hero extension. Builds on slice 12's readings + drift-calc so a watch's rank is the pure composition of its recent sessions.

## Surfaces

- **`queryLeaderboard()`** domain module (`src/domain/leaderboard-query/`) — joins candidate watches (public + approved movement), per-watch loads readings, composes `drift-calc.computeSessionStats`, filters eligible (+ verified), sorts by `abs(avg_drift_rate_spd)` ascending, assigns 1-based ranks.
- **`GET /api/v1/leaderboard`** — public JSON, Zod-validated query params (`movement_id`, `verified_only`, `limit` capped at 200, `offset`).
- **`GET /leaderboard`** — SSR HTML page (hono/jsx, zero `<script>` tags), semantic `<table>`, filter anchors for All / Verified only, `Cache-Control: public, s-maxage=300, stale-while-revalidate=86400`. Footer states the eligibility rule.
- **Home hero (`/`)** — Extended with a "Top verified watches" section that renders the top-5 as cards. Falls back to a "Be the first to log a verified reading!" placeholder when nobody qualifies.
- **Cache purge** — New `src/server/lib/purge-cache.ts` helper called from POST/DELETE in readings. Purges `/`, `/leaderboard`, `/leaderboard?verified=1`, `/m/:id`, `/u/:username`, `/w/:id`. Best-effort — s-maxage=300 is the fallback.
- **`wrangler.jsonc`** — Added `/leaderboard` to `run_worker_first` so the Worker owns it instead of the SPA 404 fallback. Types regenerated.

## Test count

- **189 tests passing** (was 155 — 34 new).
  - 11 for `queryLeaderboard` (ranking, privacy, eligibility, verified filter, movement filter, pagination, shape).
  - 4 for the JSON API (200 shape, verified, movement, 400 on bad limit).
  - 6 for `/leaderboard` HTML (rendered brand, cache headers, eligibility copy, private exclusion, toggle, no `<script>`).
  - 3 for home hero top-5.
  - 7 for `formatDriftRate` / `formatWatchLabel` (pure unit).
  - 6 for `purgeLeaderboardUrls` (URL shaping).

## Notes / followups

- Leaderboard ordering computes per-watch stats in the Worker. Fine at low thousands. A TODO in `query.ts` marks the break point where eligibility should be pushed into SQL.
- Anchor links to `/m/:id`, `/u/:username`, `/w/:id` resolve to the SPA 404 fallback until slices #14 / #15 land those public pages.
- `total` is deliberately absent from the JSON response — computing it would force the drift pass over every candidate. Can be added behind an opt-in flag if the SPA needs it.

No migrations required — this slice only reads.

Refs #14