### PR TITLE
Slice 11: Watch visibility toggle

### DIFF
--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -13,7 +13,7 @@ import { LogReadingForm } from "../watches/LogReadingForm";
 import { ReadingList } from "../watches/ReadingList";
 import { SessionStatsPanel } from "../watches/SessionStatsPanel";
 import { WatchPhotoPanel } from "../watches/WatchPhotoPanel";
-import { deleteWatch, getWatch, type Watch } from "../watches/api";
+import { deleteWatch, getWatch, updateWatch, type Watch } from "../watches/api";
 import { listReadings, type Reading, type SessionStats } from "../watches/readings";
 
 type LoadState =
@@ -41,6 +41,10 @@ export function WatchDetailPage() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [readings, setReadings] = useState<ReadingsState>(EMPTY_READINGS_STATE);
   const [deleting, setDeleting] = useState(false);
+  // Visibility toggle (slice #11). Kept local so we can show an inline
+  // saving/error state without re-fetching the whole watch record.
+  const [togglingVisibility, setTogglingVisibility] = useState(false);
+  const [visibilityError, setVisibilityError] = useState<string | null>(null);
 
   const reloadReadings = useCallback(async () => {
     if (!id) return;
@@ -110,6 +114,20 @@ export function WatchDetailPage() {
     navigate("/app/dashboard", { replace: true });
   }
 
+  async function handleToggleVisibility() {
+    if (!id || state.kind !== "loaded") return;
+    const next = !state.watch.is_public;
+    setTogglingVisibility(true);
+    setVisibilityError(null);
+    const result = await updateWatch(id, { is_public: next });
+    setTogglingVisibility(false);
+    if (!result.ok) {
+      setVisibilityError(result.error.message);
+      return;
+    }
+    setState({ kind: "loaded", watch: result.watch });
+  }
+
   if (state.kind === "loading") {
     return (
       <section className="mx-auto max-w-2xl">
@@ -156,15 +174,40 @@ export function WatchDetailPage() {
               : "No brand/model set"}
           </p>
         </div>
-        <span
-          className={
-            watch.is_public
-              ? "rounded-full border border-cf-border bg-cf-bg-200 px-3 py-1 text-xs font-medium text-cf-text-muted"
-              : "rounded-full border border-cf-orange/40 bg-cf-orange/10 px-3 py-1 text-xs font-medium text-cf-orange"
-          }
-        >
-          {watch.is_public ? "Public" : "Private"}
-        </span>
+        <div className="flex flex-col items-end gap-1">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={watch.is_public}
+            aria-label="Public on leaderboards"
+            onClick={handleToggleVisibility}
+            disabled={togglingVisibility}
+            className={
+              watch.is_public
+                ? "inline-flex items-center gap-2 rounded-full border border-cf-border bg-cf-bg-200 px-3 py-1 text-xs font-medium text-cf-text-muted transition-colors hover:border-cf-orange hover:text-cf-orange disabled:opacity-60"
+                : "inline-flex items-center gap-2 rounded-full border border-cf-orange/40 bg-cf-orange/10 px-3 py-1 text-xs font-medium text-cf-orange transition-colors hover:bg-cf-orange/20 disabled:opacity-60"
+            }
+          >
+            <span
+              aria-hidden="true"
+              className={
+                watch.is_public
+                  ? "inline-block h-2 w-2 rounded-full bg-cf-text-muted"
+                  : "inline-block h-2 w-2 rounded-full bg-cf-orange"
+              }
+            />
+            {togglingVisibility
+              ? "Saving…"
+              : watch.is_public
+                ? "Public on leaderboards"
+                : "Private"}
+          </button>
+          {visibilityError ? (
+            <p role="alert" className="text-xs text-cf-orange">
+              {visibilityError}
+            </p>
+          ) : null}
+        </div>
       </div>
 
       <dl className="mb-8 grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-[140px_1fr]">

--- a/src/server/routes/watches.ts
+++ b/src/server/routes/watches.ts
@@ -27,6 +27,7 @@ import {
 } from "@/schemas/watch";
 import { assertWatchOwnership, type Watch } from "@/domain/watches/ownership";
 import { getAuth, type AuthEnv } from "@/server/auth";
+import { purgeLeaderboardUrls } from "@/server/lib/purge-cache";
 import { requireAuth, type RequireAuthVariables } from "@/server/middleware/require-auth";
 
 type Bindings = AuthEnv & {
@@ -320,6 +321,30 @@ watchesRoute.patch("/:id", async (c) => {
     .where("id", "=", id)
     .executeTakeFirstOrThrow();
   const movementName = await resolveMovementName(db, updated.movement_id);
+
+  // Cache purge: when is_public flips, the public HTML pages
+  // (/leaderboard, /m/:id, /u/:username, home hero) may now show —
+  // or must stop showing — this watch. Same best-effort pattern as
+  // the readings route (see src/server/routes/readings.ts). Purge only
+  // when the value actually changed; a no-op PATCH shouldn't thrash
+  // the CDN cache.
+  if (
+    input.is_public !== undefined &&
+    (input.is_public ? 1 : 0) !== ownership.watch.is_public
+  ) {
+    const ownerRow = await db
+      .selectFrom("user")
+      .select(["username"])
+      .where("id", "=", user.id)
+      .executeTakeFirst();
+    await purgeLeaderboardUrls({
+      requestUrl: new URL(c.req.url),
+      movementId: updated.movement_id,
+      username: ownerRow?.username ?? null,
+      watchId: id,
+    });
+  }
+
   return c.json(toResponse(updated, movementName));
 });
 

--- a/tests/integration/watches.visibility.test.ts
+++ b/tests/integration/watches.visibility.test.ts
@@ -1,0 +1,243 @@
+// Slice 11 (issue #12). End-to-end behaviour of the per-watch
+// `is_public` toggle. The PATCH endpoint itself already accepts the
+// field (slice #9); this file exercises the user-visible consequence:
+//
+//   * Private watches are hidden from /api/v1/leaderboard (and the
+//     public HTML page that composes the same query).
+//   * Flipping back to public restores the watch.
+//   * Non-owners still get 403 on PATCH (sanity check — keeps us
+//     honest when refactoring the handler).
+//
+// We seed a watch via the real POST endpoint and readings directly
+// into D1 (same pattern as tests/integration/leaderboard.test.ts)
+// because the leaderboard query needs a 7-day, 3-reading session —
+// easier to fabricate with fixed timestamps than to work around the
+// API's reading cadence rules.
+//
+// NOTE: the "private watch → /w/:id returns 404" assertion from the
+// issue body is deferred to slice #15 (the public watch page doesn't
+// exist on main yet). Once that page lands, add the assertion here.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { beforeAll, describe, it, expect } from "vitest";
+
+const approvedMovementId = "test-vis-mov";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeAll(async () => {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      approvedMovementId,
+      "Test ETA (visibility)",
+      "ETA",
+      "2824-vis",
+      "automatic",
+      "approved",
+      null,
+    )
+    .run();
+});
+
+// ---- Auth / fetch helpers (same shape as watches.test.ts) ---------
+
+function makeEmail(): string {
+  return `vis-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function signUp(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: email.split("@")[0]!, email, password }),
+    }),
+  );
+}
+
+async function signIn(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+}
+
+interface TestUser {
+  cookie: string;
+  userId: string;
+  username: string;
+}
+
+async function registerAndGetCookie(): Promise<TestUser> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await signUp(email, password);
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as {
+    user: { id: string; username: string };
+  };
+  const loginRes = await signIn(email, password);
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return { cookie, userId: regBody.user.id, username: regBody.user.username };
+}
+
+async function createWatch(body: unknown, cookie: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/watches", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function patchWatch(id: string, body: unknown, cookie: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/watches/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function getLeaderboardIds(verifiedOnly = false): Promise<string[]> {
+  const qs = verifiedOnly ? "?verified_only=1&limit=200" : "?limit=200";
+  const res = await exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/leaderboard${qs}`),
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { watches: Array<{ watch_id: string }> };
+  return body.watches.map((w) => w.watch_id);
+}
+
+/**
+ * Seed 3 readings across 14 days so the watch clears the leaderboard
+ * eligibility gate (≥ 7 days session, ≥ 3 readings). Written directly
+ * to D1 because the readings API enforces cadence rules that would
+ * make a multi-day session tedious to construct.
+ */
+async function seedEligibleReadings(watchId: string, userId: string): Promise<void> {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  const now = Date.now();
+  const readings: Array<{ t: number; dev: number; baseline: 0 | 1 }> = [
+    { t: 0, dev: 0, baseline: 1 },
+    { t: 7, dev: 3.5, baseline: 0 },
+    { t: 14, dev: 7, baseline: 0 },
+  ];
+  for (const r of readings) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO readings (id, watch_id, user_id, reference_timestamp, deviation_seconds, is_baseline, verified) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        `vis-r-${watchId}-${r.t}`,
+        watchId,
+        userId,
+        now + r.t * DAY_MS,
+        r.dev,
+        r.baseline,
+        0,
+      )
+      .run();
+  }
+}
+
+interface WatchBody {
+  id: string;
+  is_public: boolean;
+}
+
+const TWO_USER_TIMEOUT = 30_000;
+
+// ---- Tests ---------------------------------------------------------
+
+describe("Watch visibility toggle (slice #11)", () => {
+  it("flipping a public watch to private removes it from the leaderboard", async () => {
+    const owner = await registerAndGetCookie();
+    const create = await createWatch(
+      {
+        name: "Flip to Private",
+        brand: "VisTest",
+        model: "Priv-001",
+        movement_id: approvedMovementId,
+        is_public: true,
+      },
+      owner.cookie,
+    );
+    expect(create.status).toBe(201);
+    const { id } = (await create.json()) as WatchBody;
+    await seedEligibleReadings(id, owner.userId);
+
+    // Sanity: public + eligible → visible.
+    expect(await getLeaderboardIds()).toContain(id);
+
+    // Flip to private via PATCH.
+    const patch = await patchWatch(id, { is_public: false }, owner.cookie);
+    expect(patch.status).toBe(200);
+    const patchBody = (await patch.json()) as WatchBody;
+    expect(patchBody.is_public).toBe(false);
+
+    // No longer ranked.
+    expect(await getLeaderboardIds()).not.toContain(id);
+  });
+
+  it("flipping a private watch back to public restores leaderboard presence", async () => {
+    const owner = await registerAndGetCookie();
+    const create = await createWatch(
+      {
+        name: "Toggle to Public",
+        brand: "VisTest",
+        model: "Pub-002",
+        movement_id: approvedMovementId,
+        is_public: false,
+      },
+      owner.cookie,
+    );
+    expect(create.status).toBe(201);
+    const { id } = (await create.json()) as WatchBody;
+    await seedEligibleReadings(id, owner.userId);
+
+    // Sanity: private → hidden.
+    expect(await getLeaderboardIds()).not.toContain(id);
+
+    // Flip to public.
+    const patch = await patchWatch(id, { is_public: true }, owner.cookie);
+    expect(patch.status).toBe(200);
+
+    // Now ranked.
+    expect(await getLeaderboardIds()).toContain(id);
+  });
+
+  it(
+    "non-owner cannot flip is_public (403)",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const other = await registerAndGetCookie();
+      const create = await createWatch(
+        {
+          name: "Hands off",
+          movement_id: approvedMovementId,
+          is_public: true,
+        },
+        owner.cookie,
+      );
+      const { id } = (await create.json()) as WatchBody;
+
+      const res = await patchWatch(id, { is_public: false }, other.cookie);
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("forbidden");
+    },
+    TWO_USER_TIMEOUT,
+  );
+});


### PR DESCRIPTION
Closes #12

## Changes

- `src/app/pages/WatchDetailPage.tsx` — replace the static Public/Private badge with a `role="switch"` button labelled **"Public on leaderboards"**. Clicking calls `updateWatch({ is_public })` and updates local state on success; errors render inline without knocking the page into its error fallback.
- `src/server/routes/watches.ts` — on `PATCH /api/v1/watches/:id`, when `is_public` actually flips, call `purgeLeaderboardUrls({...})` so the public HTML pages (`/leaderboard`, `/`, `/m/:id`, `/u/:username`, `/w/:id`) don't serve the stale state for the full 5-minute `s-maxage` window. No-op PATCHes skip the purge.
- `tests/integration/watches.visibility.test.ts` (new) — seeds a public+eligible watch via the real POST + direct-D1 readings, flips `is_public` via PATCH, asserts the watch disappears from `/api/v1/leaderboard`; reverse-direction test for private → public; plus a non-owner 403 sanity check.

## Deferred

The acceptance criterion "toggling private makes `/w/:id` return 404" is blocked on slice #15 (public watch page). `/w/:id` doesn't exist on main yet. Once slice #15 lands, extend `watches.visibility.test.ts` with a `GET /w/:id` assertion — the server already emits a 404 for non-owner reads of private watches, so it's a one-liner.

## Tests

- 241 → 244 integration tests (+3 in the new file).
- No migration. No changes to the PATCH request schema (already accepted `is_public` from slice #9).

## Files touched

```
M src/app/pages/WatchDetailPage.tsx
M src/server/routes/watches.ts
A tests/integration/watches.visibility.test.ts
```

Hard-rule compliance: `src/public/**`, `src/app/watches/CameraCapture*` untouched.