### PR TITLE
Slice 14: Per-movement leaderboard + Chrono24 CTA

### DIFF
--- a/src/domain/chrono24-link/chrono24-link.test.ts
+++ b/src/domain/chrono24-link/chrono24-link.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for the chrono24-link domain module.
+//
+// The module is the single place where Chrono24 URLs are constructed.
+// Phase 1 returns a plain search URL; a later slice will wrap it with
+// an affiliate ID. Callers MUST go through this function so the
+// affiliate migration is a one-line change.
+
+import { describe, it, expect } from "vitest";
+import { buildChrono24Url } from "./index";
+
+describe("buildChrono24Url", () => {
+  it("returns a URL pointing at chrono24.com search", () => {
+    const url = buildChrono24Url({
+      canonical_name: "ETA 2892-A2",
+      manufacturer: "ETA",
+      caliber: "2892-A2",
+    });
+    expect(url).toBeInstanceOf(URL);
+    expect(url.origin).toBe("https://www.chrono24.com");
+    expect(url.pathname).toBe("/search/index.htm");
+  });
+
+  it("encodes the canonical name as the `query` search parameter", () => {
+    const url = buildChrono24Url({
+      canonical_name: "ETA 2892-A2",
+      manufacturer: "ETA",
+      caliber: "2892-A2",
+    });
+    expect(url.searchParams.get("query")).toBe("ETA 2892-A2");
+    // URL serialization turns the space into a + (form encoding).
+    expect(url.toString()).toBe(
+      "https://www.chrono24.com/search/index.htm?query=ETA+2892-A2",
+    );
+  });
+
+  it("url-encodes reserved characters (ampersand, slash, spaces)", () => {
+    const url = buildChrono24Url({
+      canonical_name: "Brand & Co / Caliber 42",
+      manufacturer: "Brand & Co",
+      caliber: "42",
+    });
+    // The raw query param should still read back as the original string.
+    expect(url.searchParams.get("query")).toBe("Brand & Co / Caliber 42");
+    // And the serialized URL must have encoded the ampersand so it
+    // doesn't introduce a new query parameter.
+    const serialized = url.toString();
+    expect(serialized).not.toMatch(/[?&]query=Brand &/);
+    expect(serialized).toMatch(/%26/); // encoded ampersand
+    expect(serialized).toMatch(/%2F/); // encoded forward slash
+  });
+
+  it("handles unicode in the canonical name", () => {
+    const url = buildChrono24Url({
+      canonical_name: "Omega Cøaxial 8800 — ∞",
+      manufacturer: "Omega",
+      caliber: "8800",
+    });
+    expect(url.searchParams.get("query")).toBe("Omega Cøaxial 8800 — ∞");
+    // Non-ASCII must be percent-encoded in the serialized form.
+    expect(url.toString()).toMatch(/%C3%B8/i); // ø encoded as UTF-8
+  });
+
+  it("still builds a URL when manufacturer and caliber are empty strings", () => {
+    // A pending movement could have sparse fields — the function must
+    // never throw. It uses canonical_name only in phase 1 so empty
+    // ancillary fields have no effect on the output.
+    const url = buildChrono24Url({
+      canonical_name: "Unknown Movement",
+      manufacturer: "",
+      caliber: "",
+    });
+    expect(url.searchParams.get("query")).toBe("Unknown Movement");
+  });
+
+  it("trims whitespace from the canonical name before encoding", () => {
+    const url = buildChrono24Url({
+      canonical_name: "  Seiko 6R35  ",
+      manufacturer: "Seiko",
+      caliber: "6R35",
+    });
+    expect(url.searchParams.get("query")).toBe("Seiko 6R35");
+  });
+});

--- a/src/domain/chrono24-link/index.ts
+++ b/src/domain/chrono24-link/index.ts
@@ -1,0 +1,30 @@
+// Chrono24 link builder — the single place that constructs a URL
+// pointing at Chrono24. Every caller (public movement page, future
+// SPA CTA, future emails) MUST go through this function so the
+// affiliate-ID wrapping planned for a later slice is a one-line
+// change here rather than a grep-and-replace across the repo.
+//
+// Phase 1 behaviour: return a plain search URL — no affiliate wrapper
+// yet. The function accepts the movement's full shape (canonical_name
+// + manufacturer + caliber) even though phase 1 only consumes
+// `canonical_name`, so the signature is stable when the affiliate
+// rewrite starts keying off the other fields.
+
+export interface Chrono24LinkInput {
+  canonical_name: string;
+  manufacturer: string;
+  caliber: string;
+}
+
+/**
+ * Build a URL pointing at a Chrono24 search for the given movement.
+ *
+ * The returned `URL` uses the canonical name as the `query` search
+ * parameter. `URL.searchParams.set` handles all percent-encoding so
+ * callers never need to worry about special characters.
+ */
+export function buildChrono24Url(movement: Chrono24LinkInput): URL {
+  const url = new URL("https://www.chrono24.com/search/index.htm");
+  url.searchParams.set("query", movement.canonical_name.trim());
+  return url;
+}

--- a/src/public/leaderboard/page.tsx
+++ b/src/public/leaderboard/page.tsx
@@ -1,18 +1,15 @@
 // Public HTML leaderboard page. SSR via hono/jsx — zero client JS.
 //
 // Reads ?verified=1 to flip verified_only at the domain layer. Renders
-// a table-style list where each row links off to (slice 14/15) pages
-// that haven't shipped yet; those anchors are harmless — they become
-// real destinations as those slices land.
-//
-// The list is short + mostly-numeric so a <table> is the semantic fit
-// (screen readers + copy-paste into a spreadsheet both "just work").
+// the shared <LeaderboardTable> component, which also exports the
+// stylesheet so the per-movement page (slice #14) picks up the same
+// table styling for free.
 
 import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
 import type { RankedWatch } from "@/domain/leaderboard-query";
-import { formatDriftRate, formatWatchLabel } from "./format";
+import { LeaderboardStyles, LeaderboardTable } from "./table";
 
 export interface LeaderboardPageProps {
   watches: RankedWatch[];
@@ -48,8 +45,17 @@ export const LeaderboardPage = ({ watches, verifiedOnly }: LeaderboardPageProps)
       </section>
 
       <section class="cf-container cf-section" aria-label="Leaderboard rankings">
-        {watches.length === 0 ? <EmptyState verifiedOnly={verifiedOnly} /> : null}
-        {watches.length > 0 ? <LeaderboardTable watches={watches} /> : null}
+        <LeaderboardTable
+          watches={watches}
+          emptyStateTitle={
+            verifiedOnly ? "No verified watches yet" : "No eligible watches yet"
+          }
+          emptyStateBody={
+            verifiedOnly
+              ? "Nobody's crossed the 25 % verified-reading threshold in their current session. Start logging verified readings through the app and you could be first."
+              : "Nobody has logged enough readings yet. Create an account and be the first to appear here."
+          }
+        />
       </section>
 
       <section class="cf-container cf-lb-footnote">
@@ -65,170 +71,3 @@ export const LeaderboardPage = ({ watches, verifiedOnly }: LeaderboardPageProps)
     <Footer />
   </Layout>
 );
-
-function EmptyState({ verifiedOnly }: { verifiedOnly: boolean }) {
-  return (
-    <div class="cf-card">
-      <div class="cf-brackets" aria-hidden="true">
-        <span />
-      </div>
-      <h2 class="cf-card__title">
-        {verifiedOnly ? "No verified watches yet" : "No eligible watches yet"}
-      </h2>
-      <div class="cf-card__body">
-        <p>
-          {verifiedOnly
-            ? "Nobody's crossed the 25 % verified-reading threshold in their current session. Start logging verified readings through the app and you could be first."
-            : "Nobody has logged enough readings yet. Create an account and be the first to appear here."}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function LeaderboardTable({ watches }: { watches: RankedWatch[] }) {
-  return (
-    <table class="cf-lb-table">
-      <thead>
-        <tr>
-          <th scope="col" class="cf-lb-col-rank">
-            #
-          </th>
-          <th scope="col">Watch</th>
-          <th scope="col">Movement</th>
-          <th scope="col">Owner</th>
-          <th scope="col" class="cf-lb-col-num">
-            Drift
-          </th>
-          <th scope="col">Badge</th>
-        </tr>
-      </thead>
-      <tbody>
-        {watches.map((w) => (
-          <tr>
-            <td class="cf-lb-col-rank">{String(w.rank)}</td>
-            <td>
-              <a href={`/w/${w.watch_id}`}>
-                {formatWatchLabel({
-                  name: w.watch_name,
-                  brand: w.watch_brand,
-                  model: w.watch_model,
-                })}
-              </a>
-            </td>
-            <td>
-              <a href={`/m/${w.movement_id}`}>{w.movement_canonical_name}</a>
-            </td>
-            <td>
-              <a href={`/u/${w.owner_username}`}>@{w.owner_username}</a>
-            </td>
-            <td class="cf-lb-col-num">
-              {formatDriftRate(w.session_stats.avg_drift_rate_spd)}
-            </td>
-            <td>
-              {w.session_stats.verified_badge ? (
-                <span class="cf-lb-badge" title="25 %+ verified readings this session">
-                  Verified
-                </span>
-              ) : (
-                <span class="cf-lb-badge cf-lb-badge--muted">—</span>
-              )}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-// Scoped stylesheet for the leaderboard page. Keeps the table styling
-// out of the shared Layout stylesheet so /leaderboard doesn't pay the
-// cost on every public page. Inlined because we're already inlining
-// the design-token sheet — one more small <style> tag is cheaper than
-// a second HTTP round-trip for a stylesheet request.
-function LeaderboardStyles() {
-  const css = `
-.cf-lb-filters {
-  display: flex;
-  gap: 16px;
-  margin-top: 16px;
-  font-size: 0.875rem;
-}
-.cf-lb-filters a {
-  color: var(--cf-text-muted);
-  padding: 6px 12px;
-  border: 1px solid var(--cf-border);
-  border-radius: var(--cf-radius-full);
-}
-.cf-lb-filters a:hover { color: var(--cf-text); background: var(--cf-bg-300); }
-.cf-lb-filter--active {
-  color: var(--cf-text) !important;
-  border-color: var(--cf-orange) !important;
-  background: var(--cf-bg-200);
-}
-
-.cf-lb-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
-}
-.cf-lb-table thead th {
-  text-align: left;
-  padding: 12px;
-  border-bottom: 1px solid var(--cf-border);
-  font-weight: 500;
-  color: var(--cf-text-muted);
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-.cf-lb-table tbody td {
-  padding: 12px;
-  border-bottom: 1px solid var(--cf-border-light);
-  vertical-align: middle;
-}
-.cf-lb-col-rank {
-  width: 3rem;
-  font-family: var(--cf-font-mono);
-  color: var(--cf-text-muted);
-}
-.cf-lb-col-num {
-  font-family: var(--cf-font-mono);
-  text-align: right;
-  white-space: nowrap;
-}
-
-.cf-lb-badge {
-  display: inline-flex;
-  padding: 3px 10px;
-  border-radius: var(--cf-radius-full);
-  background: var(--cf-orange);
-  color: #FFFBF5;
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-}
-.cf-lb-badge--muted {
-  background: transparent;
-  color: var(--cf-text-subtle);
-}
-
-.cf-lb-verified-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--cf-orange);
-  vertical-align: middle;
-  margin: 0 4px;
-}
-
-.cf-lb-footnote {
-  padding: 24px 24px 48px;
-  color: var(--cf-text-muted);
-  font-size: 0.9rem;
-}
-.cf-lb-footnote p { max-width: 70ch; margin: 0; }
-`;
-  return <style>{css}</style>;
-}

--- a/src/public/leaderboard/table.tsx
+++ b/src/public/leaderboard/table.tsx
@@ -1,0 +1,201 @@
+// Shared leaderboard table component. Rendered by the global
+// /leaderboard page and the per-movement /m/:id page (slice #14).
+//
+// Kept as a pure component that takes a ranked list and emits the
+// table markup + the small empty-state block. Page-level chrome
+// (hero, filter nav, footnote, Chrono24 CTA) is NOT this component's
+// concern — each page wraps the table with its own context.
+//
+// The styles both pages need are colocated here too, exported as
+// <LeaderboardStyles /> so a page mounting the table picks up the
+// CSS automatically without duplicating the stylesheet.
+
+import type { RankedWatch } from "@/domain/leaderboard-query";
+import { formatDriftRate, formatWatchLabel } from "./format";
+
+export interface LeaderboardTableProps {
+  watches: RankedWatch[];
+  /**
+   * Copy shown when `watches` is empty. Different pages have different
+   * reasons for an empty list (no verified watches yet, no watches on
+   * this movement yet), so the caller supplies the copy.
+   */
+  emptyStateTitle: string;
+  emptyStateBody: string;
+  /**
+   * Whether to show the Movement column. The global leaderboard needs
+   * it (watches come from many movements); the per-movement page
+   * doesn't (everything on the page is the same movement by
+   * definition).
+   */
+  showMovementColumn?: boolean;
+}
+
+export const LeaderboardTable = ({
+  watches,
+  emptyStateTitle,
+  emptyStateBody,
+  showMovementColumn = true,
+}: LeaderboardTableProps) => {
+  if (watches.length === 0) {
+    return (
+      <div class="cf-card">
+        <div class="cf-brackets" aria-hidden="true">
+          <span />
+        </div>
+        <h2 class="cf-card__title">{emptyStateTitle}</h2>
+        <div class="cf-card__body">
+          <p>{emptyStateBody}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <table class="cf-lb-table">
+      <thead>
+        <tr>
+          <th scope="col" class="cf-lb-col-rank">
+            #
+          </th>
+          <th scope="col">Watch</th>
+          {showMovementColumn ? <th scope="col">Movement</th> : null}
+          <th scope="col">Owner</th>
+          <th scope="col" class="cf-lb-col-num">
+            Drift
+          </th>
+          <th scope="col">Badge</th>
+        </tr>
+      </thead>
+      <tbody>
+        {watches.map((w) => (
+          <tr>
+            <td class="cf-lb-col-rank">{String(w.rank)}</td>
+            <td>
+              <a href={`/w/${w.watch_id}`}>
+                {formatWatchLabel({
+                  name: w.watch_name,
+                  brand: w.watch_brand,
+                  model: w.watch_model,
+                })}
+              </a>
+            </td>
+            {showMovementColumn ? (
+              <td>
+                <a href={`/m/${w.movement_id}`}>{w.movement_canonical_name}</a>
+              </td>
+            ) : null}
+            <td>
+              <a href={`/u/${w.owner_username}`}>@{w.owner_username}</a>
+            </td>
+            <td class="cf-lb-col-num">
+              {formatDriftRate(w.session_stats.avg_drift_rate_spd)}
+            </td>
+            <td>
+              {w.session_stats.verified_badge ? (
+                <span class="cf-lb-badge" title="25 %+ verified readings this session">
+                  Verified
+                </span>
+              ) : (
+                <span class="cf-lb-badge cf-lb-badge--muted">—</span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+/**
+ * Scoped stylesheet for the leaderboard table + surrounding page
+ * chrome (filter nav, badge, footnote). Inlined because we already
+ * inline the design-tokens sheet — one extra <style> tag beats a
+ * second round-trip.
+ */
+export function LeaderboardStyles() {
+  const css = `
+.cf-lb-filters {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  font-size: 0.875rem;
+}
+.cf-lb-filters a {
+  color: var(--cf-text-muted);
+  padding: 6px 12px;
+  border: 1px solid var(--cf-border);
+  border-radius: var(--cf-radius-full);
+}
+.cf-lb-filters a:hover { color: var(--cf-text); background: var(--cf-bg-300); }
+.cf-lb-filter--active {
+  color: var(--cf-text) !important;
+  border-color: var(--cf-orange) !important;
+  background: var(--cf-bg-200);
+}
+
+.cf-lb-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+.cf-lb-table thead th {
+  text-align: left;
+  padding: 12px;
+  border-bottom: 1px solid var(--cf-border);
+  font-weight: 500;
+  color: var(--cf-text-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.cf-lb-table tbody td {
+  padding: 12px;
+  border-bottom: 1px solid var(--cf-border-light);
+  vertical-align: middle;
+}
+.cf-lb-col-rank {
+  width: 3rem;
+  font-family: var(--cf-font-mono);
+  color: var(--cf-text-muted);
+}
+.cf-lb-col-num {
+  font-family: var(--cf-font-mono);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.cf-lb-badge {
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: var(--cf-radius-full);
+  background: var(--cf-orange);
+  color: #FFFBF5;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.cf-lb-badge--muted {
+  background: transparent;
+  color: var(--cf-text-subtle);
+}
+
+.cf-lb-verified-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cf-orange);
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.cf-lb-footnote {
+  padding: 24px 24px 48px;
+  color: var(--cf-text-muted);
+  font-size: 0.9rem;
+}
+.cf-lb-footnote p { max-width: 70ch; margin: 0; }
+`;
+  return <style>{css}</style>;
+}

--- a/src/public/movement/page.tsx
+++ b/src/public/movement/page.tsx
@@ -1,0 +1,142 @@
+// Per-movement leaderboard page. Public SSR via hono/jsx — zero
+// client JS. Reuses <LeaderboardTable> from the global leaderboard
+// page so the table styling, badge rendering, and empty-state card
+// all stay consistent across the two surfaces.
+//
+// The commercial CTA lives here: a prominent "Shop on Chrono24"
+// button built via the chrono24-link domain module. Every Chrono24
+// URL in the app flows through that module, so adding an affiliate
+// ID later is a single-file change.
+
+import { Footer } from "../components/footer";
+import { Header } from "../components/header";
+import { Layout } from "../components/layout";
+import type { Movement } from "@/domain/movements/taxonomy";
+import type { RankedWatch } from "@/domain/leaderboard-query";
+import { buildChrono24Url } from "@/domain/chrono24-link";
+import { LeaderboardStyles, LeaderboardTable } from "../leaderboard/table";
+
+export interface MovementPageProps {
+  movement: Movement;
+  watches: RankedWatch[];
+}
+
+export const MovementPage = ({ movement, watches }: MovementPageProps) => {
+  const title = `Most accurate ${movement.canonical_name} watches — rated.watch`;
+  const description = `Drift rate leaderboard for the ${movement.canonical_name} ${movement.type} movement.`;
+  const chrono24Url = buildChrono24Url({
+    canonical_name: movement.canonical_name,
+    manufacturer: movement.manufacturer,
+    caliber: movement.caliber,
+  }).toString();
+
+  return (
+    <Layout title={title} description={description} pathname={`/m/${movement.id}`}>
+      <LeaderboardStyles />
+      <MovementPageStyles />
+      <Header />
+      <main>
+        <section class="cf-container cf-hero" aria-labelledby="mv-title">
+          <p class="cf-mv-crumbs">
+            <a href="/leaderboard">← Back to global leaderboard</a>
+          </p>
+          <h1 id="mv-title">{movement.canonical_name}</h1>
+          <p class="cf-mv-meta">
+            {movement.manufacturer} <span aria-hidden="true">·</span> {movement.caliber}{" "}
+            <span aria-hidden="true">·</span>{" "}
+            <span class="cf-mv-type">{movement.type}</span>
+          </p>
+          <div class="cf-mv-cta">
+            <a
+              class="cf-btn cf-btn--primary cf-mv-chrono24"
+              href={chrono24Url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Shop on Chrono24 →
+            </a>
+          </div>
+        </section>
+
+        <section class="cf-container cf-section" aria-label="Movement rankings">
+          <LeaderboardTable
+            watches={watches}
+            showMovementColumn={false}
+            emptyStateTitle="No ranked watches on this movement yet"
+            emptyStateBody={`Nobody with a ${movement.canonical_name} has logged enough readings to appear here yet. Create an account, add your watch, and start logging.`}
+          />
+        </section>
+
+        <section class="cf-container cf-lb-footnote">
+          <p>
+            Watches need at least <strong>7 days</strong> of readings and at least{" "}
+            <strong>3 readings</strong> since their current baseline to appear. The{" "}
+            <span class="cf-lb-verified-dot" aria-hidden="true"></span> verified badge
+            means 25 % or more of the readings in this session were captured through the
+            in-app camera flow (spoof-resistant).
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </Layout>
+  );
+};
+
+// Movement-page-specific chrome: the caliber meta line, back-link,
+// and CTA spacing. The shared leaderboard stylesheet already owns
+// the table + badge styling.
+function MovementPageStyles() {
+  const css = `
+.cf-mv-crumbs {
+  margin: 0 0 12px;
+  font-size: 0.875rem;
+}
+.cf-mv-crumbs a { color: var(--cf-text-muted); }
+.cf-mv-crumbs a:hover { color: var(--cf-text); }
+
+.cf-mv-meta {
+  color: var(--cf-text-muted);
+  font-family: var(--cf-font-mono);
+  font-size: 0.95rem;
+  margin: 0 0 24px;
+  letter-spacing: -0.01em;
+}
+.cf-mv-type { text-transform: capitalize; }
+
+.cf-mv-cta { margin-top: 8px; }
+.cf-mv-chrono24 {
+  padding: 14px 28px;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+`;
+  return <style>{css}</style>;
+}
+
+// ---- 404 page -----------------------------------------------------
+
+const NOT_FOUND_TITLE = "Movement not found — rated.watch";
+const NOT_FOUND_DESCRIPTION =
+  "The movement you're looking for doesn't exist or isn't published yet.";
+
+export const MovementNotFoundPage = () => (
+  <Layout
+    title={NOT_FOUND_TITLE}
+    description={NOT_FOUND_DESCRIPTION}
+    pathname="/m/unknown"
+  >
+    <Header />
+    <main>
+      <section class="cf-container cf-hero">
+        <h1>Movement not found</h1>
+        <p>{NOT_FOUND_DESCRIPTION}</p>
+        <p>
+          <a class="cf-btn cf-btn--ghost" href="/leaderboard">
+            ← Back to global leaderboard
+          </a>
+        </p>
+      </section>
+    </main>
+    <Footer />
+  </Layout>
+);

--- a/src/server/routes/movements.ts
+++ b/src/server/routes/movements.ts
@@ -20,6 +20,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { createDb } from "@/db";
+import { queryLeaderboard } from "@/domain/leaderboard-query";
 import { createMovementTaxonomy } from "@/domain/movements/taxonomy";
 import { submitMovement } from "@/domain/movements/submit";
 import { formatSubmitMovementErrors, submitMovementSchema } from "@/schemas/movement";
@@ -31,6 +32,19 @@ type Bindings = AuthEnv & { DB: D1Database; [key: string]: unknown };
 const movementsQuerySchema = z.object({
   q: z.string().trim().min(1).max(100).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+// Shared query schema for the per-movement leaderboard JSON endpoint.
+// Mirrors the shape of the global leaderboard query — same caps, same
+// boolean coercion rules — so the SPA can compose both endpoints with
+// identical client code.
+const perMovementLeaderboardQuerySchema = z.object({
+  verified_only: z
+    .union([z.literal("1"), z.literal("true"), z.literal("0"), z.literal("false")])
+    .optional()
+    .transform((v) => v === "1" || v === "true"),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
 });
 
 export const movementsRoute = new Hono<{
@@ -74,6 +88,36 @@ movementsRoute.get("/", async (c) => {
     suggestionsForUserId: submittingUserId,
   });
   return c.json(result);
+});
+
+// GET /api/v1/movements/:id/leaderboard — public, unauthed. Delegates
+// to queryLeaderboard with a movement_id filter. Returns 404 when
+// the movement is unknown or still pending; the public URL surface
+// must not leak pending submissions.
+movementsRoute.get("/:id/leaderboard", async (c) => {
+  const movementId = c.req.param("id");
+  const parsed = perMovementLeaderboardQuerySchema.safeParse({
+    verified_only: c.req.query("verified_only"),
+    limit: c.req.query("limit"),
+    offset: c.req.query("offset"),
+  });
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query", issues: parsed.error.issues }, 400);
+  }
+  const { verified_only, limit, offset } = parsed.data;
+
+  const db = createDb(c.env);
+  const taxonomy = createMovementTaxonomy(db);
+  const movement = await taxonomy.getBySlug(movementId);
+  if (!movement || movement.status !== "approved") {
+    return c.json({ error: "movement_not_found" }, 404);
+  }
+
+  const watches = await queryLeaderboard(
+    { movement_id: movement.id, verified_only, limit, offset },
+    db,
+  );
+  return c.json({ watches });
 });
 
 // POST is authed. Mounted after GET so the public search stays open.

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -6,8 +6,10 @@
 import { Hono } from "hono";
 import { createDb } from "@/db";
 import { queryLeaderboard } from "@/domain/leaderboard-query";
+import { createMovementTaxonomy } from "@/domain/movements/taxonomy";
 import { LandingPage } from "@/public/landing";
 import { LeaderboardPage } from "@/public/leaderboard/page";
+import { MovementNotFoundPage, MovementPage } from "@/public/movement/page";
 import { getAuth, type AuthEnv } from "@/server/auth";
 import { watchImagePublicRoute, watchImageRoute } from "@/server/routes/images";
 import { leaderboardRoute } from "@/server/routes/leaderboard";
@@ -46,6 +48,22 @@ app.get("/leaderboard", async (c) => {
   const watches = await queryLeaderboard({ verified_only: verifiedOnly, limit: 50 }, db);
   c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
   return c.html(<LeaderboardPage watches={watches} verifiedOnly={verifiedOnly} />);
+});
+
+// Public per-movement leaderboard (slice #14). 404 for unknown or
+// still-pending movements so the URL surface never leaks unapproved
+// submissions. Same cache header as the global page — reading
+// mutations explicitly purge both.
+app.get("/m/:movementId", async (c) => {
+  const db = createDb(c.env);
+  const taxonomy = createMovementTaxonomy(db);
+  const movement = await taxonomy.getBySlug(c.req.param("movementId"));
+  if (!movement || movement.status !== "approved") {
+    return c.html(<MovementNotFoundPage />, 404);
+  }
+  const watches = await queryLeaderboard({ movement_id: movement.id, limit: 50 }, db);
+  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+  return c.html(<MovementPage movement={movement} watches={watches} />);
 });
 
 // Better Auth owns every method under /api/v1/auth/*. We pass the raw

--- a/tests/integration/per-movement-leaderboard.test.ts
+++ b/tests/integration/per-movement-leaderboard.test.ts
@@ -1,0 +1,350 @@
+// Integration tests for slice 14: per-movement leaderboard (/m/:id)
+// and GET /api/v1/movements/:id/leaderboard.
+//
+// Seeds two approved movements + one pending movement, a few watches
+// per movement, and enough readings to make each watch eligible. Then
+// asserts:
+//   * The public HTML page only shows watches on THIS movement.
+//   * The JSON API shape matches /api/v1/leaderboard.
+//   * Pending / unknown movement ids return 404.
+//   * The page surfaces a Chrono24 link pointing at chrono24.com with
+//     the movement's canonical name as the query.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { beforeAll, describe, it, expect } from "vitest";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const runId = crypto.randomUUID().slice(0, 8);
+const id = (suffix: string) => `mlb-${runId}-${suffix}`;
+
+const SEED = {
+  users: {
+    owner1: {
+      id: id("user-1"),
+      name: "Mlb One",
+      email: `${id("u1")}@test`,
+      username: id("u-one"),
+    },
+    owner2: {
+      id: id("user-2"),
+      name: "Mlb Two",
+      email: `${id("u2")}@test`,
+      username: id("u-two"),
+    },
+  },
+  movements: {
+    alpha: {
+      id: id("mov-alpha"),
+      canonical_name: `ETA ${id("ALPHA").toUpperCase()}`,
+      manufacturer: "ETA",
+      caliber: id("ALPHA"),
+      status: "approved",
+      type: "automatic",
+    },
+    beta: {
+      id: id("mov-beta"),
+      canonical_name: `Seiko ${id("BETA").toUpperCase()}`,
+      manufacturer: "Seiko",
+      caliber: id("BETA"),
+      status: "approved",
+      type: "automatic",
+    },
+    pending: {
+      id: id("mov-pending"),
+      canonical_name: `Proto ${id("PEND").toUpperCase()}`,
+      manufacturer: "Proto",
+      caliber: id("PEND"),
+      status: "pending",
+      type: "automatic",
+    },
+  },
+  watches: {
+    alphaFast: {
+      id: id("w-alpha-fast"),
+      name: "Alpha Fast",
+      brand: "Rolex",
+      model: "ALPHAFAST",
+      movement_id: "alpha",
+      is_public: 1,
+    },
+    alphaSlow: {
+      id: id("w-alpha-slow"),
+      name: "Alpha Slow",
+      brand: "Omega",
+      model: "ALPHASLOW",
+      movement_id: "alpha",
+      is_public: 1,
+    },
+    betaOnly: {
+      id: id("w-beta"),
+      name: "Beta Only",
+      brand: "Seiko",
+      model: "BETAONLY",
+      movement_id: "beta",
+      is_public: 1,
+    },
+  },
+};
+
+async function seed() {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  const now = Date.now();
+
+  for (const u of Object.values(SEED.users)) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO user (id, name, email, emailVerified, username, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?, ?)",
+      )
+      .bind(
+        u.id,
+        u.name,
+        u.email,
+        u.username,
+        new Date(now).toISOString(),
+        new Date(now).toISOString(),
+      )
+      .run();
+  }
+
+  for (const m of Object.values(SEED.movements)) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(m.id, m.canonical_name, m.manufacturer, m.caliber, m.type, m.status, null)
+      .run();
+  }
+
+  const movByKey: Record<string, string> = {
+    alpha: SEED.movements.alpha.id,
+    beta: SEED.movements.beta.id,
+  };
+  const watchUserMap: Record<string, string> = {
+    alphaFast: SEED.users.owner1.id,
+    alphaSlow: SEED.users.owner2.id,
+    betaOnly: SEED.users.owner1.id,
+  };
+  for (const [key, w] of Object.entries(SEED.watches)) {
+    const userId = watchUserMap[key]!;
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(w.id, userId, w.name, w.brand, w.model, movByKey[w.movement_id]!, w.is_public)
+      .run();
+  }
+
+  // Readings — each watch gets baseline + 2 readings over 14 days so
+  // all three qualify for the leaderboard (≥7 days, ≥3 readings).
+  // alphaFast: drift 0.5 s/d (rank 1 on alpha)
+  // alphaSlow: drift -2.0 s/d (rank 2 on alpha)
+  // betaOnly:  drift 1.0 s/d (only watch on beta)
+  const base = now;
+  type R = {
+    watch: keyof typeof SEED.watches;
+    user: keyof typeof SEED.users;
+    t_offset_days: number;
+    deviation: number;
+    baseline?: boolean;
+  };
+  const readings: R[] = [
+    {
+      watch: "alphaFast",
+      user: "owner1",
+      t_offset_days: 0,
+      deviation: 0,
+      baseline: true,
+    },
+    { watch: "alphaFast", user: "owner1", t_offset_days: 7, deviation: 3.5 },
+    { watch: "alphaFast", user: "owner1", t_offset_days: 14, deviation: 7 },
+    {
+      watch: "alphaSlow",
+      user: "owner2",
+      t_offset_days: 0,
+      deviation: 0,
+      baseline: true,
+    },
+    { watch: "alphaSlow", user: "owner2", t_offset_days: 7, deviation: -14 },
+    { watch: "alphaSlow", user: "owner2", t_offset_days: 14, deviation: -28 },
+    { watch: "betaOnly", user: "owner1", t_offset_days: 0, deviation: 0, baseline: true },
+    { watch: "betaOnly", user: "owner1", t_offset_days: 7, deviation: 7 },
+    { watch: "betaOnly", user: "owner1", t_offset_days: 14, deviation: 14 },
+  ];
+
+  for (const r of readings) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO readings (id, watch_id, user_id, reference_timestamp, deviation_seconds, is_baseline, verified) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        id(`r-${r.watch}-${r.t_offset_days}`),
+        SEED.watches[r.watch].id,
+        SEED.users[r.user].id,
+        base + r.t_offset_days * DAY_MS,
+        r.deviation,
+        r.baseline ? 1 : 0,
+        0,
+      )
+      .run();
+  }
+}
+
+beforeAll(async () => {
+  await seed();
+});
+
+// ---- JSON API /api/v1/movements/:id/leaderboard -------------------
+
+describe("GET /api/v1/movements/:id/leaderboard", () => {
+  it("returns 200 JSON with only watches on the requested movement", async () => {
+    const res = await exports.default.fetch(
+      new Request(
+        `https://ratedwatch.test/api/v1/movements/${SEED.movements.alpha.id}/leaderboard`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { watches: Array<{ watch_id: string }> };
+    const ids = body.watches.map((w) => w.watch_id);
+    expect(ids).toContain(SEED.watches.alphaFast.id);
+    expect(ids).toContain(SEED.watches.alphaSlow.id);
+    expect(ids).not.toContain(SEED.watches.betaOnly.id);
+  });
+
+  it("returns the same envelope shape as the global leaderboard", async () => {
+    const res = await exports.default.fetch(
+      new Request(
+        `https://ratedwatch.test/api/v1/movements/${SEED.movements.beta.id}/leaderboard`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      watches: Array<{
+        watch_id: string;
+        movement_id: string;
+        session_stats: { eligible: boolean };
+      }>;
+    };
+    expect(Array.isArray(body.watches)).toBe(true);
+    expect(body.watches.length).toBeGreaterThan(0);
+    // Every row is on the requested movement.
+    for (const w of body.watches) {
+      expect(w.movement_id).toBe(SEED.movements.beta.id);
+    }
+  });
+
+  it("returns 404 for a pending movement", async () => {
+    const res = await exports.default.fetch(
+      new Request(
+        `https://ratedwatch.test/api/v1/movements/${SEED.movements.pending.id}/leaderboard`,
+      ),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown movement id", async () => {
+    const res = await exports.default.fetch(
+      new Request(
+        "https://ratedwatch.test/api/v1/movements/does-not-exist-slug/leaderboard",
+      ),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---- Public HTML page /m/:id --------------------------------------
+
+describe("GET /m/:movementId — public HTML", () => {
+  it("returns 200 text/html with the movement canonical name in the page", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain(SEED.movements.alpha.canonical_name);
+  });
+
+  it("only lists watches on the requested movement", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    // alpha watches present
+    expect(body).toContain(SEED.watches.alphaFast.model);
+    expect(body).toContain(SEED.watches.alphaSlow.model);
+    // beta watch NOT present
+    expect(body).not.toContain(SEED.watches.betaOnly.model);
+  });
+
+  it("emits a Chrono24 link with the movement canonical name as the query", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    // The link must point at chrono24.com/search/index.htm and carry
+    // an encoded `query=` parameter with the movement's canonical name.
+    expect(body).toMatch(/https:\/\/www\.chrono24\.com\/search\/index\.htm\?query=/);
+    const encoded = encodeURIComponent(SEED.movements.alpha.canonical_name).replace(
+      /%20/g,
+      "+",
+    );
+    expect(body).toContain(encoded);
+    // Security hardening on the anchor: noopener + new tab.
+    expect(body).toMatch(/target="_blank"/);
+    expect(body).toMatch(/rel="[^"]*noopener[^"]*"/);
+  });
+
+  it("includes the movement-specific OG title and description", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    expect(body).toContain(
+      `Most accurate ${SEED.movements.alpha.canonical_name} watches — rated.watch`,
+    );
+    expect(body).toContain(
+      `Drift rate leaderboard for the ${SEED.movements.alpha.canonical_name} ${SEED.movements.alpha.type} movement.`,
+    );
+  });
+
+  it("emits the aggressive Cache-Control header", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const cacheControl = res.headers.get("cache-control") ?? "";
+    expect(cacheControl).toMatch(/s-maxage=300/);
+    expect(cacheControl).toMatch(/stale-while-revalidate=86400/);
+  });
+
+  it("returns 404 HTML for a pending movement", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.pending.id}`),
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type") ?? "").toMatch(/text\/html/);
+  });
+
+  it("returns 404 HTML for an unknown movement id", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/m/no-such-movement-slug"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("emits zero client-side JavaScript", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    expect(body).not.toMatch(/<script\b/i);
+  });
+
+  it("links back to the global leaderboard", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    expect(body).toMatch(/href="\/leaderboard"/);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,9 @@
   // Workers Assets serves the Vite build output.
   //
   //  - The Worker owns `/` (SSR landing page), `/leaderboard` (SSR public
-  //    leaderboard, slice #13), and `/api/*` via run_worker_first.
-  //    Future public HTML routes (/m/:id, /u/:name, /w/:id) will be added
-  //    here as they land.
+  //    leaderboard, slice #13), `/m/*` (SSR per-movement pages, slice
+  //    #14), and `/api/*` via run_worker_first. Future public HTML
+  //    routes (/u/:name, /w/:id) will be added here as they land.
   //  - Everything else falls through to assets. not_found_handling =
   //    single-page-application rewrites unknown paths to /index.html so
   //    the SPA's client-side router (react-router) can take over.
@@ -20,7 +20,7 @@
     "directory": "./dist/",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/", "/leaderboard", "/api/*"]
+    "run_worker_first": ["/", "/leaderboard", "/m/*", "/api/*"]
   },
 
   // Data layer bindings. IDs come from `terraform output` in


### PR DESCRIPTION
Closes #15

## Summary

- New `chrono24-link` domain module (pure, unit-tested) as the single choke point for Chrono24 URL construction. Phase 1 returns a plain search URL; a future slice will wrap with affiliate ID right here rather than across the repo.
- `GET /api/v1/movements/:id/leaderboard` — delegates to `queryLeaderboard` with a `movement_id` filter; 404 for unknown or still-pending movements.
- Public SSR page `/m/:movementId` with a prominent "Shop on Chrono24" CTA (new tab, `rel="noopener noreferrer"`), movement-specific OG meta, 5-minute edge cache + 24h SWR, and a 404 page for pending/unknown movements.
- `wrangler.jsonc`: added `/m/*` to `run_worker_first` so the Worker claims the path before the SPA fallback.
- Extracted the leaderboard table + stylesheet into a shared `<LeaderboardTable>` component so both pages render consistently. `showMovementColumn={false}` drops the redundant column on the per-movement page.

## Tests

- 6 unit tests for `buildChrono24Url` covering special characters, ampersand/slash, unicode, trimming, and sparse manufacturer/caliber.
- 13 integration tests for the new API + HTML page: movement filtering, Chrono24 link shape (target=_blank, rel=noopener), OG meta, cache header, no-JS contract, 404 for pending + unknown.
- All 21 existing leaderboard integration tests still pass (refactor didn't regress).
- Full suite: **260 tests passing** in 27 test files.

## Hard-rule compliance

- Did not touch `src/server/routes/watches.ts`, `src/app/watches/**`, `src/public/user/**`, `src/public/watch/**`, or `src/server/routes/readings.ts`.
- `src/public/leaderboard/page.tsx` extended cleanly — shared table component + styles extracted into `src/public/leaderboard/table.tsx` so the per-movement page imports them; no regression in the global page.
- `src/worker/index.tsx`: added `/m/:movementId` mount + 3 imports. Minor.
- No migration needed.

## Notes

- Every Chrono24 URL in the app flows through `buildChrono24Url`; adding an affiliate ID later is a single-file change in `src/domain/chrono24-link/index.ts`.