### PR TITLE
Slice 17: Verified reading frontend

### DIFF
--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate, useParams } from "react-router";
 import { LogReadingForm } from "../watches/LogReadingForm";
 import { ReadingList } from "../watches/ReadingList";
 import { SessionStatsPanel } from "../watches/SessionStatsPanel";
+import { VerifiedReadingCapture } from "../watches/VerifiedReadingCapture";
 import { WatchPhotoPanel } from "../watches/WatchPhotoPanel";
 import { deleteWatch, getWatch, updateWatch, type Watch } from "../watches/api";
 import { listReadings, type Reading, type SessionStats } from "../watches/readings";
@@ -243,6 +244,7 @@ export function WatchDetailPage() {
       />
 
       <SessionStatsPanel stats={readings.session_stats} />
+      <VerifiedReadingCapture watchId={watch.id} onSubmitted={reloadReadings} />
       <LogReadingForm watchId={watch.id} onLogged={reloadReadings} />
       <ReadingList
         readings={readings.readings}

--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -1,0 +1,317 @@
+// Slice #17 (issue #18). Camera-capture + upload UI for verified
+// readings. Lives on the watch detail page, above the manual
+// LogReadingForm. Owner-gated at the page level; this component
+// assumes it will only ever render for the watch's owner.
+//
+// UX flow:
+//
+//   1. No file yet → big "Take photo" button. On mobile the <input>
+//      has `capture="environment"` so tapping it opens the rear
+//      camera directly (iOS 10+ / Chrome for Android). On desktop
+//      the same input behaves as a file picker, and we surface a
+//      line of copy explaining that a fresh photo is still required
+//      for the reading to count.
+//   2. File chosen → preview via URL.createObjectURL + a checkbox
+//      for baseline ("I just set the watch") + "Submit verified
+//      reading" / "Choose a different photo" buttons.
+//   3. Submitting → spinner. A single-line note tells the user the
+//      server stamps the reference time at RECEIPT, not capture, so
+//      they're not surprised by the ~1s latency.
+//   4. Success → show the AI-read dial time, the computed deviation,
+//      and a "Save another" button that resets to state (1).
+//   5. Error → human copy from verifiedReadingErrors.ts + a "Try
+//      again" button that keeps the same file (you probably want to
+//      resubmit, not re-capture, if the error was transient).
+//
+// Trust rules (matching slice #16):
+//   * Client-side EXIF / capture time is never sent. The server's
+//     `Date.now()` at request receipt IS the reference time.
+//   * Desktop uploads go through the SAME endpoint and get the same
+//     trust level. We don't lie about that in the copy — the badge
+//     comes from the verified-ratio on the session, not from a per-
+//     upload "mobile vs desktop" flag.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createVerifiedReading,
+  type Reading,
+  type VerifiedReadingSubmission,
+} from "./readings";
+
+interface Props {
+  watchId: string;
+  /**
+   * Fires after a successful verified submission so the parent can
+   * re-fetch the readings list and the session-stats panel. The new
+   * reading is passed so callers can render an inline confirmation
+   * without a second round-trip if they want to.
+   */
+  onSubmitted: (reading: Reading) => void;
+}
+
+type UiState =
+  | { kind: "idle" }
+  | { kind: "chosen"; file: File; previewUrl: string }
+  | { kind: "submitting"; file: File; previewUrl: string }
+  | { kind: "success"; reading: Reading }
+  | {
+      kind: "error";
+      file: File;
+      previewUrl: string;
+      message: string;
+    };
+
+/**
+ * Format a signed deviation (seconds) as "+1.2s" / "-0.4s" for the
+ * success banner. Positive = watch is ahead of reference.
+ */
+function formatDeviation(seconds: number): string {
+  const sign = seconds > 0 ? "+" : seconds < 0 ? "" : "";
+  return `${sign}${seconds.toFixed(1)}s`;
+}
+
+/**
+ * Render the AI-inferred dial time from a reading row. The server
+ * stores reference_timestamp (ms) + deviation_seconds; dial time is
+ * reference + deviation. We render HH:MM:SS in local time so the
+ * user's reaction is "yes, that's what the watch said" without
+ * timezone math.
+ */
+function formatDialTime(reading: Reading): string {
+  const dialMs = reading.reference_timestamp + reading.deviation_seconds * 1000;
+  const d = new Date(dialMs);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
+  const [state, setState] = useState<UiState>({ kind: "idle" });
+  const [isBaseline, setIsBaseline] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Revoke object URLs when they change or the component unmounts.
+  // We create them in `handleFileChosen` and in the retry path in
+  // `handleRetry`, and track the last-known URL so every handoff
+  // revokes cleanly regardless of which UiState variant produced it.
+  const liveUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    return () => {
+      if (liveUrlRef.current) URL.revokeObjectURL(liveUrlRef.current);
+    };
+  }, []);
+
+  const setPreview = useCallback((file: File): string => {
+    if (liveUrlRef.current) URL.revokeObjectURL(liveUrlRef.current);
+    const url = URL.createObjectURL(file);
+    liveUrlRef.current = url;
+    return url;
+  }, []);
+
+  function clearPreview() {
+    if (liveUrlRef.current) URL.revokeObjectURL(liveUrlRef.current);
+    liveUrlRef.current = null;
+  }
+
+  const handleFileChosen = useCallback(
+    (file: File) => {
+      const previewUrl = setPreview(file);
+      setState({ kind: "chosen", file, previewUrl });
+    },
+    [setPreview],
+  );
+
+  function openFilePicker() {
+    // Reset the <input> so choosing the same file twice still fires
+    // `change`. `current.click()` is what forces the camera on
+    // mobile — a programmatic click on a `capture=environment` input
+    // triggers the OS camera the same way as a user tap.
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+      fileInputRef.current.click();
+    }
+  }
+
+  async function handleSubmit() {
+    // Guard against double-clicks; also appeases the type narrowing
+    // below since we only have a file in the chosen/error states.
+    if (state.kind !== "chosen" && state.kind !== "error") return;
+    const submission: VerifiedReadingSubmission = {
+      image: state.file,
+      isBaseline,
+    };
+    setState({
+      kind: "submitting",
+      file: state.file,
+      previewUrl: state.previewUrl,
+    });
+    const result = await createVerifiedReading(watchId, submission);
+    if (!result.ok) {
+      // Keep the file + preview so the user can retry without re-
+      // capturing. Swap UiState so the error banner renders.
+      setState({
+        kind: "error",
+        file: submission.image,
+        previewUrl: liveUrlRef.current ?? "",
+        message: result.error.message,
+      });
+      return;
+    }
+    // Wipe the preview on success — the next "Save another" tap
+    // starts from a fresh camera.
+    clearPreview();
+    setIsBaseline(false);
+    setState({ kind: "success", reading: result.reading });
+    onSubmitted(result.reading);
+  }
+
+  function handleCancelOrReset() {
+    clearPreview();
+    setIsBaseline(false);
+    setState({ kind: "idle" });
+  }
+
+  const showIdle = state.kind === "idle";
+  const showChosen = state.kind === "chosen" || state.kind === "error";
+  const showSubmitting = state.kind === "submitting";
+  const showSuccess = state.kind === "success";
+
+  // preview URL for the <img> in chosen/submitting/error states
+  const preview =
+    state.kind === "chosen" || state.kind === "submitting" || state.kind === "error"
+      ? state.previewUrl
+      : null;
+
+  return (
+    <section
+      aria-label="Verified reading"
+      className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5"
+    >
+      <h2 className="mb-1 text-sm font-medium text-cf-text">Log a verified reading</h2>
+      <p className="mb-4 text-xs text-cf-text-muted">
+        Take a photo of the dial and we&apos;ll read it against the server clock at the
+        moment we receive your upload. No timestamp from your device is trusted — the
+        reference time is &ldquo;now&rdquo; on the server.
+      </p>
+
+      {/* Hidden input. Rendered once, reused across the idle/chosen
+          flows. `capture="environment"` steers mobile browsers to the
+          rear camera; desktop silently ignores it. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="sr-only"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFileChosen(file);
+        }}
+      />
+
+      {showIdle ? (
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={openFilePicker}
+            className="inline-flex w-full items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-3 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90 sm:w-auto"
+          >
+            Take photo
+          </button>
+          <p className="text-xs text-cf-text-subtle">
+            On desktop this opens a file picker — for the reading to count, use a fresh
+            photo, not an old one from your library.
+          </p>
+        </div>
+      ) : null}
+
+      {preview ? (
+        <img
+          src={preview}
+          alt="Captured dial"
+          className="mb-4 max-h-80 rounded-md border border-cf-border object-contain"
+        />
+      ) : null}
+
+      {state.kind === "error" ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+        >
+          {state.message}
+        </p>
+      ) : null}
+
+      {showChosen ? (
+        <div className="flex flex-col gap-3">
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={isBaseline}
+              onChange={(e) => setIsBaseline(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-orange focus:ring-cf-orange"
+            />
+            <span>
+              <span className="text-cf-text">This is a baseline</span>
+              <span className="ml-1 text-cf-text-muted">
+                — I just set the watch to the exact time
+              </span>
+            </span>
+          </label>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              className="inline-flex items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-2.5 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90"
+            >
+              Submit verified reading
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelOrReset}
+              className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-text-muted"
+            >
+              Choose a different photo
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {showSubmitting ? (
+        <p className="flex items-center gap-2 text-sm text-cf-text-muted">
+          <span
+            aria-hidden="true"
+            className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-cf-orange border-t-transparent"
+          />
+          Reading the dial…
+        </p>
+      ) : null}
+
+      {showSuccess ? (
+        <div
+          role="status"
+          className="rounded-md border border-cf-orange/30 bg-cf-bg-100 px-4 py-3"
+        >
+          <p className="text-sm text-cf-text">
+            Saved. Dial read at{" "}
+            <span className="font-mono text-cf-orange">
+              {formatDialTime(state.reading)}
+            </span>
+            , deviation{" "}
+            <span className="font-mono text-cf-orange">
+              {formatDeviation(state.reading.deviation_seconds)}
+            </span>
+            .
+          </p>
+          <button
+            type="button"
+            onClick={handleCancelOrReset}
+            className="mt-3 inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-4 py-2 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"
+          >
+            Save another
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -7,6 +7,11 @@
 // the shared Zod schemas on the server side are the contract source
 // of truth, these interfaces mirror them.
 
+import {
+  mapVerifiedReadingError,
+  type VerifiedReadingErrorMessage,
+} from "./verifiedReadingErrors";
+
 export interface Reading {
   id: string;
   watch_id: string;
@@ -125,4 +130,55 @@ export async function deleteReading(
   });
   if (!response.ok) return { ok: false, error: await readError(response) };
   return { ok: true };
+}
+
+// -------------------------------------------------------------------
+// Slice #17 (issue #18): verified readings — camera-captured + AI-read.
+// -------------------------------------------------------------------
+//
+// The backend (slice #16) accepts a multipart body with an `image`
+// file and an optional `is_baseline` toggle. It returns 201 with the
+// full reading row on success, 422 on AI refusal / implausible / un-
+// parseable output, 503 when the `ai_reading_v2` feature flag is off
+// for the caller, and the usual 4xx auth/ownership codes.
+//
+// We don't surface the verifier's raw_response to the SPA — the
+// mapped message in verifiedReadingErrors.ts is enough. If we ever
+// want debug info in the UI, we'll plumb it through separately.
+
+export interface VerifiedReadingSubmission {
+  image: File;
+  isBaseline: boolean;
+}
+
+export async function createVerifiedReading(
+  watchId: string,
+  submission: VerifiedReadingSubmission,
+): Promise<
+  { ok: true; reading: Reading } | { ok: false; error: VerifiedReadingErrorMessage }
+> {
+  const form = new FormData();
+  form.append("image", submission.image);
+  form.append("is_baseline", submission.isBaseline ? "true" : "false");
+
+  const response = await fetch(
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings/verified`,
+    {
+      method: "POST",
+      body: form,
+      credentials: "include",
+    },
+  );
+  if (!response.ok) {
+    let serverCode: string | undefined;
+    try {
+      const parsed = (await response.json()) as { error?: string };
+      serverCode = parsed.error;
+    } catch {
+      /* non-JSON body */
+    }
+    return { ok: false, error: mapVerifiedReadingError(response.status, serverCode) };
+  }
+  const reading = (await response.json()) as Reading;
+  return { ok: true, reading };
 }

--- a/src/app/watches/verifiedReadingErrors.test.ts
+++ b/src/app/watches/verifiedReadingErrors.test.ts
@@ -1,0 +1,61 @@
+// Tests for the error mapper used by VerifiedReadingCapture. The server
+// returns a small enum of error codes for the /readings/verified
+// endpoint; we map them to user-facing copy here and unit-test the
+// mapping in isolation so the React component stays dumb.
+//
+// The mapping is the single place where backend error vocabulary
+// crosses into the UI — if the wording drifts on either side, the
+// tests here and the integration tests in slice #16 pin both ends.
+
+import { describe, expect, it } from "vitest";
+import { mapVerifiedReadingError } from "./verifiedReadingErrors";
+
+describe("mapVerifiedReadingError", () => {
+  it("maps ai_refused (422) to a re-take hint", () => {
+    expect(mapVerifiedReadingError(422, "ai_refused").message).toMatch(
+      /couldn't read the dial/i,
+    );
+  });
+
+  it("maps ai_unparseable (422) to a generic AI-response error", () => {
+    expect(mapVerifiedReadingError(422, "ai_unparseable").message).toMatch(
+      /unexpected response/i,
+    );
+  });
+
+  it("maps ai_implausible (422) to a lighting/glass retry hint", () => {
+    expect(mapVerifiedReadingError(422, "ai_implausible").message).toMatch(
+      /reading looked off/i,
+    );
+  });
+
+  it("maps verified_readings_disabled (503) to an account-not-enabled copy", () => {
+    const mapped = mapVerifiedReadingError(503, "verified_readings_disabled");
+    expect(mapped.message).toMatch(/verified readings aren't enabled/i);
+    expect(mapped.code).toBe("verified_readings_disabled");
+  });
+
+  it("maps image_required (400) to a choose-photo hint", () => {
+    expect(mapVerifiedReadingError(400, "image_required").message).toMatch(
+      /choose a photo/i,
+    );
+  });
+
+  it("maps image_too_large (413) to a max-size hint", () => {
+    expect(mapVerifiedReadingError(413, "image_too_large").message).toMatch(/10 MB/);
+  });
+
+  it("falls back to the generic copy for unmatched 4xx", () => {
+    expect(mapVerifiedReadingError(401).message).toMatch(/something went wrong/i);
+  });
+
+  it("falls back to the generic copy for unmatched 5xx", () => {
+    expect(mapVerifiedReadingError(500).message).toMatch(/something went wrong/i);
+  });
+
+  it("falls back to the generic copy when the server gives us an unknown code", () => {
+    expect(mapVerifiedReadingError(422, "martian_invasion").message).toMatch(
+      /something went wrong/i,
+    );
+  });
+});

--- a/src/app/watches/verifiedReadingErrors.ts
+++ b/src/app/watches/verifiedReadingErrors.ts
@@ -1,0 +1,87 @@
+// Verified-reading error mapper.
+//
+// POST /api/v1/watches/:id/readings/verified (slice #16) returns a
+// small enum of server-side errors. The SPA must render human copy,
+// never raw JSON. Keeping this mapping here — not inside the component
+// — means it's unit-testable without a DOM and gives a single point of
+// truth if the wording changes.
+//
+// Known server codes (see src/server/routes/readings.ts):
+//   * 422 + error: "ai_refused"          → AI wouldn't read the dial
+//   * 422 + error: "ai_unparseable"      → AI response wasn't JSON we expected
+//   * 422 + error: "ai_implausible"      → AI read a dial time too far off
+//   * 503 + error: "verified_readings_disabled" → feature flag off for this user
+//   * 400 + error: "image_required"      → form didn't include the file (client bug)
+//   * 413 + error: "image_too_large"     → image > 10 MB
+//   * 401/403/404/500                    → generic
+//
+// Every unmapped case falls back to a single "something went wrong"
+// line so we never leak raw status codes into the UI.
+
+export type VerifiedReadingErrorCode =
+  | "ai_refused"
+  | "ai_unparseable"
+  | "ai_implausible"
+  | "verified_readings_disabled"
+  | "image_required"
+  | "image_too_large"
+  | "unknown";
+
+export interface VerifiedReadingErrorMessage {
+  code: VerifiedReadingErrorCode;
+  message: string;
+}
+
+const GENERIC: VerifiedReadingErrorMessage = {
+  code: "unknown",
+  message: "Something went wrong — try again",
+};
+
+export function mapVerifiedReadingError(
+  status: number,
+  serverCode?: string,
+): VerifiedReadingErrorMessage {
+  if (status === 503 && serverCode === "verified_readings_disabled") {
+    return {
+      code: "verified_readings_disabled",
+      message: "Verified readings aren't enabled for your account yet",
+    };
+  }
+
+  if (status === 422) {
+    if (serverCode === "ai_refused") {
+      return {
+        code: "ai_refused",
+        message: "We couldn't read the dial in your photo — try a clearer shot",
+      };
+    }
+    if (serverCode === "ai_unparseable") {
+      return {
+        code: "ai_unparseable",
+        message: "The AI returned an unexpected response — try again",
+      };
+    }
+    if (serverCode === "ai_implausible") {
+      return {
+        code: "ai_implausible",
+        message: "The reading looked off (bad lighting or dirty glass?) — try again",
+      };
+    }
+  }
+
+  if (status === 413 && serverCode === "image_too_large") {
+    return {
+      code: "image_too_large",
+      message: "Image is too large — the maximum is 10 MB",
+    };
+  }
+
+  if (status === 400 && serverCode === "image_required") {
+    return {
+      code: "image_required",
+      message: "Please choose a photo first",
+    };
+  }
+
+  return GENERIC;
+}

--- a/tests/e2e/verified-reading.smoke.test.ts
+++ b/tests/e2e/verified-reading.smoke.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+// Slice #17 (issue #18). Smoke test for the verified-reading frontend.
+//
+// We deliberately DO NOT exercise the real AI pipeline here. Slice
+// #16's integration tests already cover the happy + error paths of
+// POST /api/v1/watches/:id/readings/verified against a fake AI
+// binding. E2E against the preview Worker runs with Workers AI, which
+// we can't mock, and the `ai_reading_v2` feature flag is default-off
+// for freshly-registered CI users anyway.
+//
+// What we DO exercise:
+//   * the "Take photo" button renders inside the detail page
+//   * the hidden file input carries the mobile-camera attributes
+//     (`accept="image/*"` + `capture="environment"`)
+//   * choosing a file surfaces the baseline checkbox and submit
+//     button
+//   * submitting with the flag off renders the mapped error copy
+//     ("Verified readings aren't enabled for your account yet"),
+//     not raw JSON
+//
+// That proves every frontend wire — the route, the SPA API client,
+// the error mapper — is connected to the real backend. The AI path
+// itself is covered elsewhere.
+
+// ------------------------------------------------------------------
+// A 1×1 transparent PNG. Smallest valid PNG; the /readings/verified
+// endpoint cares about size > 0, not about actual image content —
+// the flag gate rejects us LONG before the AI ever looks at the file.
+// Embedded as base64 + decoded at test-time so no fixture file ships
+// with the repo.
+// ------------------------------------------------------------------
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg==";
+
+function tinyPngBuffer(): Buffer {
+  return Buffer.from(TINY_PNG_BASE64, "base64");
+}
+
+test("register → add watch → verified-reading flow renders and surfaces flag-off copy", async ({
+  page,
+}) => {
+  // Pre-flight: movements taxonomy must be live on the preview D1.
+  // See the note in watches.smoke.test.ts for why this is a hard
+  // gate — the add-watch flow can't populate the typeahead without it.
+  const healthRes = await page.request.get("/api/v1/movements?q=eta");
+  if (healthRes.status() !== 200) {
+    throw new Error(
+      `Movements API returned ${healthRes.status()} for ?q=eta. ` +
+        "Operator needs to run `wrangler d1 migrations apply rated-watch-db --remote` " +
+        "before the preview deploy can serve the add-watch flow.",
+    );
+  }
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `e2e-verified-${uniqueSuffix}@rated.watch.test`;
+  const password = "e2e-smoke-password";
+  const name = "E2E Verified User";
+  const watchName = `Verified smoke watch ${uniqueSuffix}`;
+
+  // ---- 1. Register + land on dashboard ---------------------------
+  await page.goto("/app/register");
+  await page.getByLabel("Display name").fill(name);
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: /create account/i }).click();
+  await page.waitForURL("**/app/dashboard", { timeout: 15_000 });
+
+  // ---- 2. Add a watch -------------------------------------------
+  await page.getByRole("link", { name: "Add watch", exact: true }).click();
+  await page.waitForURL("**/app/watches/new", { timeout: 10_000 });
+
+  await page.getByLabel("Name").fill(watchName);
+
+  const movementInput = page.getByLabel("Movement");
+  await movementInput.fill("ETA");
+  const option = page.getByRole("listbox").getByText(/^ETA 2824-2$/);
+  await option.waitFor({ state: "visible", timeout: 10_000 });
+  await option.click();
+
+  await page.getByRole("button", { name: /add watch/i }).click();
+  await page.waitForURL(/\/app\/watches\/[^/]+$/, { timeout: 15_000 });
+  await expect(page.getByRole("heading", { level: 1, name: watchName })).toBeVisible();
+
+  // ---- 3. Verified-reading panel is on the detail page ----------
+  const panel = page.getByRole("region", { name: "Verified reading" });
+  await expect(panel).toBeVisible();
+  await expect(
+    panel.getByRole("heading", { name: /log a verified reading/i }),
+  ).toBeVisible();
+
+  // The hidden input must carry the mobile-camera attributes so the
+  // OS opens the rear camera on tap. Playwright can locate sr-only
+  // inputs without `.click()`-ing them; we just need them in the DOM.
+  const fileInput = panel.locator('input[type="file"]');
+  await expect(fileInput).toHaveAttribute("accept", "image/*");
+  await expect(fileInput).toHaveAttribute("capture", "environment");
+
+  // ---- 4. Choose a file without triggering the real camera ------
+  // Playwright's `setInputFiles` bypasses the browser picker, which
+  // is exactly what we want for a headless run. The generated file
+  // name is irrelevant; the server only cares about the bytes.
+  await fileInput.setInputFiles({
+    name: "dial.png",
+    mimeType: "image/png",
+    buffer: tinyPngBuffer(),
+  });
+
+  // After choosing, the submit button + baseline checkbox appear.
+  const submitBtn = panel.getByRole("button", { name: /submit verified reading/i });
+  await expect(submitBtn).toBeVisible();
+  await expect(panel.getByText(/this is a baseline/i)).toBeVisible();
+
+  // ---- 5. Submit → flag-off error copy --------------------------
+  // The preview Worker uses the production `ai_reading_v2` flag,
+  // which defaults off for a freshly-registered user. The backend
+  // returns 503 { error: "verified_readings_disabled" } and the SPA
+  // maps that to the copy below.
+  await submitBtn.click();
+  const errorBanner = panel.getByRole("alert");
+  await expect(errorBanner).toContainText(/verified readings aren't enabled/i, {
+    timeout: 10_000,
+  });
+});


### PR DESCRIPTION
Closes #18

## Summary

Adds the SPA camera-capture + upload UI that posts to `POST /api/v1/watches/:id/readings/verified` (slice #16). Owner-only, mounted on `/app/watches/:id` between the session-stats panel and the manual `LogReadingForm`.

## Changes

- **`src/app/watches/verifiedReadingErrors.ts`** — Pure (status, serverCode) → user-facing message mapper. All backend error codes (`ai_refused`, `ai_unparseable`, `ai_implausible`, `verified_readings_disabled`, `image_required`, `image_too_large`) get human copy; everything else falls back to a single "Something went wrong — try again" line so we never leak raw JSON. 9 unit tests.
- **`src/app/watches/readings.ts`** — New `createVerifiedReading()` client that builds the multipart body (`image` + `is_baseline`), posts it, and returns a discriminated result using the mapper on failure.
- **`src/app/watches/VerifiedReadingCapture.tsx`** — New component:
  - Hidden `<input type="file" accept="image/*" capture="environment">` reused across the flow. On mobile the `capture` attribute steers iOS / Chrome for Android to the rear camera; on desktop the same input is a file picker and we surface copy explaining the fresh-photo requirement.
  - State machine: idle → chosen → submitting → success | error. Preview via `URL.createObjectURL`, revoked on every transition and on unmount.
  - Baseline checkbox mirrors `LogReadingForm`'s "I just set the watch" semantics.
  - Success renders AI-read dial time + signed deviation + "Save another".
  - Error banner keeps the same file queued so the user can retry without re-capturing.
- **`src/app/pages/WatchDetailPage.tsx`** — Mounts `<VerifiedReadingCapture>` under `SessionStatsPanel`, above `LogReadingForm`. Wires `onSubmitted` to the existing `reloadReadings` handler so the stats panel re-computes `verified_ratio` after each successful submit.
- **`tests/e2e/verified-reading.smoke.test.ts`** — Playwright smoke test: register → add watch → open detail page → assert the verified-reading panel renders with the right file-input attributes → upload a tiny inline PNG → submit → assert the mapped "Verified readings aren't enabled for your account yet" error appears (backend returns 503 because the default-off `ai_reading_v2` flag is not set for CI users). This exercises the full frontend path without depending on real AI.

## Test coverage

- **288 → 297 unit + integration tests** (9 new for the error mapper). Slice #16's integration tests already cover every AI branch of `POST /readings/verified` against a fake AI binding.
- **3 E2E smokes** (auth, watches, new verified-reading). The verified-reading spec runs entirely against the real preview Worker and asserts on the backend's flag-off behaviour, giving us a deterministic end-to-end signal.
- **No UI-behaviour integration tests**: the project has no DOM/jsdom harness, and adding one just for this slice isn't worth the churn. Backend coverage is solid and the E2E exercises the browser wiring.

## Deploy notes

- **No migration.** No `wrangler.jsonc` change. Pure SPA addition.
- To actually _use_ the verified-reading flow in prod, operator still needs to set `ai_reading_v2` to on for the user(s) via `npm run flags:set` (the flag is default-off by design). Without that, the panel is still rendered and the error message is the documented 503 copy.

## Coordination

Stayed inside `src/app/watches/**` + `src/app/pages/WatchDetailPage.tsx` + new E2E test. **Did not touch** `src/observability/**`, `src/worker/index.tsx`, `wrangler.jsonc`, or `src/server/routes/**` — those are Worker O's territory for slice #19.