### PR TITLE
Slice 18: Verified badge surfacing

### DIFF
--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -11,11 +11,12 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { logout } from "../auth/api";
 import { useSession } from "../auth/useSession";
-import { listWatches, type Watch } from "../watches/api";
+import { listWatches, type WatchWithSession } from "../watches/api";
+import { VerifiedProgressRing } from "../watches/VerifiedProgressRing";
 
 type WatchesState =
   | { kind: "loading" }
-  | { kind: "loaded"; watches: Watch[] }
+  | { kind: "loaded"; watches: WatchWithSession[] }
   | { kind: "error"; message: string };
 
 export function DashboardPage() {
@@ -93,35 +94,47 @@ export function DashboardPage() {
           </div>
         ) : (
           <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {state.watches.map((watch) => (
-              <li key={watch.id}>
-                <Link
-                  to={`/app/watches/${watch.id}`}
-                  className="flex h-full flex-col gap-2 rounded-lg border border-cf-border bg-cf-bg-100 p-4 transition-colors hover:border-cf-orange"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <h2 className="text-lg font-medium text-cf-text">{watch.name}</h2>
-                    {watch.is_public ? null : (
-                      <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2 py-0.5 text-xs font-medium text-cf-orange">
-                        Private
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-sm text-cf-text-muted">
-                    {watch.brand || watch.model
-                      ? [watch.brand, watch.model].filter(Boolean).join(" ")
-                      : "No brand/model"}
-                  </p>
-                  <p className="text-xs text-cf-text-muted">
-                    {watch.movement_canonical_name ??
-                      (watch.custom_movement_name
-                        ? `Custom: ${watch.custom_movement_name}`
-                        : "No movement")}
-                  </p>
-                  <p className="mt-auto text-xs text-cf-text-subtle">No readings yet</p>
-                </Link>
-              </li>
-            ))}
+            {state.watches.map((watch) => {
+              const stats = watch.session_stats;
+              const verifiedCount = Math.round(
+                stats.reading_count * stats.verified_ratio,
+              );
+              return (
+                <li key={watch.id}>
+                  <Link
+                    to={`/app/watches/${watch.id}`}
+                    className="flex h-full flex-col gap-2 rounded-lg border border-cf-border bg-cf-bg-100 p-4 transition-colors hover:border-cf-orange"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <h2 className="text-lg font-medium text-cf-text">{watch.name}</h2>
+                      {watch.is_public ? null : (
+                        <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2 py-0.5 text-xs font-medium text-cf-orange">
+                          Private
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-cf-text-muted">
+                      {watch.brand || watch.model
+                        ? [watch.brand, watch.model].filter(Boolean).join(" ")
+                        : "No brand/model"}
+                    </p>
+                    <p className="text-xs text-cf-text-muted">
+                      {watch.movement_canonical_name ??
+                        (watch.custom_movement_name
+                          ? `Custom: ${watch.custom_movement_name}`
+                          : "No movement")}
+                    </p>
+                    <div className="mt-auto pt-2">
+                      <VerifiedProgressRing
+                        verifiedCount={verifiedCount}
+                        totalCount={stats.reading_count}
+                        size={48}
+                      />
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate, useParams } from "react-router";
 import { LogReadingForm } from "../watches/LogReadingForm";
 import { ReadingList } from "../watches/ReadingList";
 import { SessionStatsPanel } from "../watches/SessionStatsPanel";
+import { VerifiedProgressRing } from "../watches/VerifiedProgressRing";
 import { VerifiedReadingCapture } from "../watches/VerifiedReadingCapture";
 import { WatchPhotoPanel } from "../watches/WatchPhotoPanel";
 import { deleteWatch, getWatch, updateWatch, type Watch } from "../watches/api";
@@ -244,6 +245,18 @@ export function WatchDetailPage() {
       />
 
       <SessionStatsPanel stats={readings.session_stats} />
+      {readings.session_stats && readings.session_stats.reading_count > 0 ? (
+        <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5">
+          <VerifiedProgressRing
+            verifiedCount={Math.round(
+              readings.session_stats.reading_count *
+                readings.session_stats.verified_ratio,
+            )}
+            totalCount={readings.session_stats.reading_count}
+            size={72}
+          />
+        </div>
+      ) : null}
       <VerifiedReadingCapture watchId={watch.id} onSubmitted={reloadReadings} />
       <LogReadingForm watchId={watch.id} onLogged={reloadReadings} />
       <ReadingList

--- a/src/app/watches/VerifiedProgressRing.tsx
+++ b/src/app/watches/VerifiedProgressRing.tsx
@@ -1,0 +1,120 @@
+// CSS-only progress ring for the "verified readings" ratio.
+//
+// Used by:
+//   - The dashboard watch cards (small, 48 px), so owners can glance
+//     at each watch's verification progress.
+//   - The watch detail page (larger, 72 px) beside the session stats
+//     panel.
+//
+// Renders as an SVG with two concentric circles — a track and a
+// progress arc drawn via stroke-dasharray. Zero client-side JS
+// animation: the ratio is baked into the dash offset at render
+// time.
+//
+// Caption below the ring comes from readingsToBadge:
+//   - earned       → "Verified watch"
+//   - not earned   → "X of Y verified — needs Z more to earn the badge"
+//
+// Pass an explicit `size` to get a larger ring; default is dashboard
+// card size.
+
+import { readingsToBadge } from "@/domain/drift-calc";
+
+interface Props {
+  verifiedCount: number;
+  totalCount: number;
+  /** Outer diameter in pixels. Default 48 (dashboard card). */
+  size?: number;
+  /** Optional extra className wrapper for positioning context. */
+  className?: string;
+  /** Hide the caption — ring-only mode. Default false. */
+  hideCaption?: boolean;
+}
+
+export function VerifiedProgressRing({
+  verifiedCount,
+  totalCount,
+  size = 48,
+  className,
+  hideCaption = false,
+}: Props) {
+  const { earned, needed, ratio } = readingsToBadge(verifiedCount, totalCount);
+  const displayPct = Math.round(ratio * 100);
+
+  // Ring geometry: stroke width scales with size so the ring never
+  // looks heavy on small variants.
+  const strokeWidth = Math.max(3, Math.round(size / 12));
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  // Clamp progress to the badge threshold so the ring fills in the
+  // first quarter and then gracefully tops out at 100 % when the
+  // badge is earned (which means 25 %+ — past that, UI says "done").
+  const ringProgress = earned ? 1 : Math.min(1, ratio / 0.25);
+  const dashLength = circumference * ringProgress;
+  const dashGap = circumference - dashLength;
+
+  // Caption copy:
+  //  - Badge earned → positive, short.
+  //  - Not earned → precise "X of Y — needs Z more".
+  //  - No readings → calm "No readings yet" (keeps the layout).
+  const caption =
+    totalCount === 0
+      ? "No readings yet"
+      : earned
+        ? "Verified watch"
+        : `${verifiedCount} of ${totalCount} verified — needs ${needed} more to earn the badge`;
+
+  return (
+    <div
+      className={"flex items-center gap-3" + (className ? ` ${className}` : "")}
+      data-verified-progress-ring="true"
+      data-verified-earned={earned ? "true" : "false"}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={`Verified ${displayPct} percent`}
+        className="shrink-0"
+      >
+        <title>{caption}</title>
+        {/* Track */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className="stroke-cf-border"
+          strokeWidth={strokeWidth}
+        />
+        {/* Progress — rotated -90° so the arc starts at 12 o'clock. */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className={earned ? "stroke-cf-orange" : "stroke-cf-orange/80"}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={`${dashLength} ${dashGap}`}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+        {/* Center label — the percent in the middle of the ring, only
+            when size is large enough to fit readably. */}
+        {size >= 64 ? (
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="central"
+            className="fill-cf-text font-mono text-sm"
+          >
+            {displayPct}%
+          </text>
+        ) : null}
+      </svg>
+      {hideCaption ? null : <p className="text-xs text-cf-text-muted">{caption}</p>}
+    </div>
+  );
+}

--- a/src/app/watches/api.ts
+++ b/src/app/watches/api.ts
@@ -24,6 +24,27 @@ export interface Watch {
   image_r2_key: string | null;
 }
 
+/**
+ * Slice #18: session summary embedded in watch list responses so the
+ * dashboard can render the verified progress ring per-card without a
+ * second round-trip. Only returned from the list endpoint; individual
+ * GET /watches/:id still returns the bare Watch shape.
+ */
+export interface WatchSessionSummary {
+  session_days: number;
+  reading_count: number;
+  verified_ratio: number;
+  avg_drift_rate_spd: number | null;
+  eligible: boolean;
+  verified_badge: boolean;
+  latest_deviation_seconds: number;
+  baseline_reference_timestamp: number;
+}
+
+export interface WatchWithSession extends Watch {
+  session_stats: WatchSessionSummary;
+}
+
 export interface WatchError {
   code:
     | "invalid_input"
@@ -68,11 +89,11 @@ async function readWatchError(response: Response): Promise<WatchError> {
 }
 
 export async function listWatches(): Promise<
-  { ok: true; watches: Watch[] } | { ok: false; error: WatchError }
+  { ok: true; watches: WatchWithSession[] } | { ok: false; error: WatchError }
 > {
   const response = await fetch("/api/v1/watches", { credentials: "include" });
   if (!response.ok) return { ok: false, error: await readWatchError(response) };
-  const body = (await response.json()) as { watches: Watch[] };
+  const body = (await response.json()) as { watches: WatchWithSession[] };
   return { ok: true, watches: body.watches };
 }
 

--- a/src/domain/drift-calc/index.ts
+++ b/src/domain/drift-calc/index.ts
@@ -6,3 +6,4 @@ export {
   type PerIntervalDrift,
   type SessionStats,
 } from "./compute-session-stats";
+export { readingsToBadge, type ReadingsToBadgeResult } from "./readings-to-badge";

--- a/src/domain/drift-calc/readings-to-badge.test.ts
+++ b/src/domain/drift-calc/readings-to-badge.test.ts
@@ -1,0 +1,77 @@
+// Unit tests for the progress-ring math helper used by the SPA
+// dashboard + watch detail page.
+//
+// `readingsToBadge` answers "how many more verified readings does the
+// owner need to earn the badge?" The UI shows the result as:
+//
+//   * "Verified watch" — when the badge is already earned.
+//   * "X of Y verified — needs Z more to earn the badge" — when not.
+//
+// The math has to handle the awkward case where adding verified
+// readings ALSO grows the denominator, so the formula can't just be
+// `ceil(0.25*total) - verified`. See the docstring on the helper.
+
+import { describe, expect, it } from "vitest";
+import { readingsToBadge } from "./readings-to-badge";
+
+describe("readingsToBadge()", () => {
+  it("returns 0 when no readings exist yet (nothing to compute)", () => {
+    expect(readingsToBadge(0, 0)).toEqual({ earned: false, needed: 0, ratio: 0 });
+  });
+
+  it("0 verified of 3 → needs 1 more verified reading (1/4 = 0.25)", () => {
+    expect(readingsToBadge(0, 3)).toEqual({ earned: false, needed: 1, ratio: 0 });
+  });
+
+  it("0 verified of 1 → needs 1 more (1/2 = 0.5 ≥ 0.25)", () => {
+    expect(readingsToBadge(0, 1)).toEqual({ earned: false, needed: 1, ratio: 0 });
+  });
+
+  it("1 of 4 = 25% → already earned, 0 needed", () => {
+    const result = readingsToBadge(1, 4);
+    expect(result.earned).toBe(true);
+    expect(result.needed).toBe(0);
+    expect(result.ratio).toBeCloseTo(0.25, 5);
+  });
+
+  it("1 of 3 → already above (33%), 0 needed", () => {
+    const result = readingsToBadge(1, 3);
+    expect(result.earned).toBe(true);
+    expect(result.needed).toBe(0);
+    expect(result.ratio).toBeCloseTo(1 / 3, 5);
+  });
+
+  it("0 verified of 10 → needs 4 more ((0+4)/(10+4) = 0.2857 ≥ 0.25; (0+3)/(10+3) = 0.2307 < 0.25)", () => {
+    // 4 more verified → 4/14 ≈ 0.2857, passes 0.25 threshold
+    // 3 more verified → 3/13 ≈ 0.2307, fails 0.25 threshold
+    expect(readingsToBadge(0, 10)).toEqual({ earned: false, needed: 4, ratio: 0 });
+  });
+
+  it("2 of 10 → needs 1 more ((2+1)/(10+1) = 0.2727)", () => {
+    const result = readingsToBadge(2, 10);
+    expect(result.earned).toBe(false);
+    expect(result.needed).toBe(1);
+    expect(result.ratio).toBeCloseTo(0.2, 5);
+  });
+
+  it("1 verified of 2 = 50% → already earned", () => {
+    const result = readingsToBadge(1, 2);
+    expect(result.earned).toBe(true);
+    expect(result.needed).toBe(0);
+    expect(result.ratio).toBeCloseTo(0.5, 5);
+  });
+
+  it("treats 25 % exactly as earned (matches computeSessionStats boundary)", () => {
+    // 5/20 = 0.25
+    expect(readingsToBadge(5, 20).earned).toBe(true);
+    // 4/20 = 0.2 → not earned
+    expect(readingsToBadge(4, 20).earned).toBe(false);
+  });
+
+  it("never returns negative values for degenerate inputs", () => {
+    // Defensive: verified > total shouldn't happen but shouldn't crash.
+    const result = readingsToBadge(5, 3);
+    expect(result.earned).toBe(true);
+    expect(result.needed).toBe(0);
+  });
+});

--- a/src/domain/drift-calc/readings-to-badge.ts
+++ b/src/domain/drift-calc/readings-to-badge.ts
@@ -1,0 +1,49 @@
+// Pure progress-ring helper used by the SPA dashboard + watch detail
+// page. Answers "how many more verified readings does this watch's
+// current session need to earn the 25 %+ verified badge?"
+//
+// The naive formula `ceil(0.25 * total) - verified` is wrong: adding
+// verified readings grows the denominator too, so the true threshold
+// is "the smallest non-negative n such that (verified + n) / (total +
+// n) >= 0.25". We solve the inequality algebraically and round up:
+//
+//   (v + n) / (t + n) ≥ 0.25
+//   v + n ≥ 0.25 * (t + n)
+//   v + n ≥ 0.25t + 0.25n
+//   0.75n ≥ 0.25t - v
+//   n ≥ (0.25t - v) / 0.75    (equivalently: n ≥ (t - 4v) / 3)
+//
+// When `verified / total` is already ≥ 0.25 the right-hand side is
+// ≤ 0 and `needed` is 0.
+//
+// `earned` mirrors computeSessionStats' verified_badge threshold
+// exactly — 25 % or more.
+
+export interface ReadingsToBadgeResult {
+  /** True when (verified / total) >= 0.25. Matches verified_badge. */
+  earned: boolean;
+  /**
+   * Non-negative count of additional verified readings needed to hit
+   * the 25 % threshold. 0 when already earned.
+   */
+  needed: number;
+  /** Current verified ratio; 0 when total is 0 to avoid NaN. */
+  ratio: number;
+}
+
+export function readingsToBadge(
+  verifiedCount: number,
+  totalCount: number,
+): ReadingsToBadgeResult {
+  if (totalCount <= 0) {
+    return { earned: false, needed: 0, ratio: 0 };
+  }
+  const ratio = Math.min(verifiedCount, totalCount) / totalCount;
+  if (ratio >= 0.25) {
+    return { earned: true, needed: 0, ratio };
+  }
+  // Solve: n ≥ (t - 4v) / 3. Round up; never below zero.
+  const raw = (totalCount - 4 * verifiedCount) / 3;
+  const needed = Math.max(0, Math.ceil(raw));
+  return { earned: false, needed, ratio };
+}

--- a/src/public/leaderboard/page.tsx
+++ b/src/public/leaderboard/page.tsx
@@ -9,7 +9,7 @@ import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
 import type { RankedWatch } from "@/domain/leaderboard-query";
-import { LeaderboardStyles, LeaderboardTable } from "./table";
+import { LeaderboardStyles, LeaderboardTable, VerifiedFilterToggle } from "./table";
 
 export interface LeaderboardPageProps {
   watches: RankedWatch[];
@@ -31,17 +31,7 @@ export const LeaderboardPage = ({ watches, verifiedOnly }: LeaderboardPageProps)
           Ranked by absolute drift rate since each watch's most recent baseline. Lower is
           better — a drift of 0 s/d means the watch is keeping time perfectly.
         </p>
-        <nav class="cf-lb-filters" aria-label="Leaderboard filters">
-          <a href="/leaderboard" class={verifiedOnly ? "" : "cf-lb-filter--active"}>
-            All watches
-          </a>
-          <a
-            href="/leaderboard?verified=1"
-            class={verifiedOnly ? "cf-lb-filter--active" : ""}
-          >
-            Verified only
-          </a>
-        </nav>
+        <VerifiedFilterToggle basePath="/leaderboard" verifiedOnly={verifiedOnly} />
       </section>
 
       <section class="cf-container cf-section" aria-label="Leaderboard rankings">

--- a/src/public/leaderboard/table.tsx
+++ b/src/public/leaderboard/table.tsx
@@ -13,6 +13,49 @@
 import type { RankedWatch } from "@/domain/leaderboard-query";
 import { formatDriftRate, formatWatchLabel } from "./format";
 
+/**
+ * Toggle UI for the "All watches / Verified only" filter.
+ *
+ * Rendered as a pair of GET-link buttons — zero client JS, the server
+ * computes which one is active from the request (query param + cookie
+ * state) and feeds `verifiedOnly` in. Clicking emits a GET to the
+ * same path with the flipped `?verified=…` param so the handler can
+ * also set/clear the `rw_verified_filter` cookie.
+ *
+ * Used by both /leaderboard and /m/:id so the copy stays in sync.
+ */
+export interface VerifiedFilterToggleProps {
+  /** Base path to link to. The component adds the `?verified=…` param. */
+  basePath: string;
+  /** Current filter state (derived server-side from query param + cookie). */
+  verifiedOnly: boolean;
+}
+
+export const VerifiedFilterToggle = ({
+  basePath,
+  verifiedOnly,
+}: VerifiedFilterToggleProps) => (
+  <nav class="cf-lb-filters" aria-label="Leaderboard filters">
+    <a
+      href={`${basePath}?verified=0`}
+      class={verifiedOnly ? "" : "cf-lb-filter--active"}
+      aria-pressed={verifiedOnly ? "false" : "true"}
+    >
+      All watches
+    </a>
+    <a
+      href={`${basePath}?verified=1`}
+      class={verifiedOnly ? "cf-lb-filter--active" : ""}
+      aria-pressed={verifiedOnly ? "true" : "false"}
+    >
+      <span class="cf-lb-filter__check" aria-hidden="true">
+        ✓
+      </span>{" "}
+      Verified only
+    </a>
+  </nav>
+);
+
 export interface LeaderboardTableProps {
   watches: RankedWatch[];
   /**
@@ -93,11 +136,24 @@ export const LeaderboardTable = ({
             </td>
             <td>
               {w.session_stats.verified_badge ? (
-                <span class="cf-lb-badge" title="25 %+ verified readings this session">
+                <span
+                  class="cf-lb-badge"
+                  title="25 %+ verified readings this session"
+                  data-verified-badge="true"
+                >
+                  <span class="cf-lb-badge__check" aria-hidden="true">
+                    ✓
+                  </span>{" "}
                   Verified
                 </span>
               ) : (
-                <span class="cf-lb-badge cf-lb-badge--muted">—</span>
+                <span
+                  class="cf-lb-badge cf-lb-badge--muted"
+                  title="Fewer than 25 % of readings in this session are verified"
+                  aria-label="Unverified"
+                >
+                  —
+                </span>
               )}
             </td>
           </tr>
@@ -133,6 +189,10 @@ export function LeaderboardStyles() {
   border-color: var(--cf-orange) !important;
   background: var(--cf-bg-200);
 }
+.cf-lb-filter__check {
+  color: var(--cf-orange);
+  font-weight: 700;
+}
 
 .cf-lb-table {
   width: 100%;
@@ -167,6 +227,8 @@ export function LeaderboardStyles() {
 
 .cf-lb-badge {
   display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
   background: var(--cf-orange);
@@ -178,6 +240,10 @@ export function LeaderboardStyles() {
 .cf-lb-badge--muted {
   background: transparent;
   color: var(--cf-text-subtle);
+}
+.cf-lb-badge__check {
+  font-weight: 700;
+  line-height: 1;
 }
 
 .cf-lb-verified-dot {

--- a/src/public/lib/cookie.test.ts
+++ b/src/public/lib/cookie.test.ts
@@ -1,0 +1,77 @@
+// Unit tests for the tiny cookie helper used by public pages.
+//
+// Keep pure so it's reusable from any Hono handler: no Request / Env
+// imports here, just strings in and strings out.
+
+import { describe, it, expect } from "vitest";
+import { buildSetCookie, parseCookie } from "./cookie";
+
+describe("parseCookie()", () => {
+  it("returns an empty object when the header is null / undefined / empty", () => {
+    expect(parseCookie(null)).toEqual({});
+    expect(parseCookie(undefined)).toEqual({});
+    expect(parseCookie("")).toEqual({});
+  });
+
+  it("parses a single name=value pair", () => {
+    expect(parseCookie("foo=bar")).toEqual({ foo: "bar" });
+  });
+
+  it("parses multiple pairs separated by semicolons", () => {
+    expect(parseCookie("foo=bar; baz=qux; rw_verified_filter=1")).toEqual({
+      foo: "bar",
+      baz: "qux",
+      rw_verified_filter: "1",
+    });
+  });
+
+  it("tolerates surrounding whitespace on names and values", () => {
+    expect(parseCookie("  foo=bar ;  baz=qux  ")).toEqual({ foo: "bar", baz: "qux" });
+  });
+
+  it("ignores malformed pairs without an equals sign", () => {
+    expect(parseCookie("foo=bar; invalid; baz=qux")).toEqual({ foo: "bar", baz: "qux" });
+  });
+
+  it("handles empty values", () => {
+    expect(parseCookie("foo=; baz=qux")).toEqual({ foo: "", baz: "qux" });
+  });
+
+  it("URL-decodes percent-encoded values", () => {
+    expect(parseCookie("path=%2Fleaderboard%3Fx%3D1")).toEqual({
+      path: "/leaderboard?x=1",
+    });
+  });
+});
+
+describe("buildSetCookie()", () => {
+  it("emits name=value with Path, Max-Age, and SameSite=Lax by default", () => {
+    const cookie = buildSetCookie({
+      name: "rw_verified_filter",
+      value: "1",
+      maxAge: 60,
+    });
+    expect(cookie).toContain("rw_verified_filter=1");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Max-Age=60");
+    expect(cookie).toContain("SameSite=Lax");
+  });
+
+  it("sets Max-Age=0 when clearing", () => {
+    const cookie = buildSetCookie({
+      name: "rw_verified_filter",
+      value: "",
+      maxAge: 0,
+    });
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("URL-encodes the value", () => {
+    const cookie = buildSetCookie({
+      name: "next",
+      value: "/leaderboard?x=1",
+      maxAge: 60,
+    });
+    expect(cookie).toContain("next=%2Fleaderboard%3Fx%3D1");
+  });
+});

--- a/src/public/lib/cookie.ts
+++ b/src/public/lib/cookie.ts
@@ -1,0 +1,69 @@
+// Tiny cookie helpers used by the public SSR pages.
+//
+// Pure string-in / string-out. No Request / Env imports so any Hono
+// handler (and any test) can call them without ceremony.
+//
+// The parser is deliberately forgiving — malformed pairs are dropped
+// silently so a misbehaving third-party cookie never takes down a
+// page render. The builder emits a standards-compliant Set-Cookie
+// string with our defaults (Path=/, SameSite=Lax) baked in.
+
+export function parseCookie(header: string | null | undefined): Record<string, string> {
+  if (!header) return {};
+  const result: Record<string, string> = {};
+  for (const rawPair of header.split(";")) {
+    const pair = rawPair.trim();
+    if (pair.length === 0) continue;
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue; // malformed — no value
+    const name = pair.slice(0, eq).trim();
+    const rawValue = pair.slice(eq + 1).trim();
+    if (name.length === 0) continue;
+    let decoded = rawValue;
+    try {
+      decoded = decodeURIComponent(rawValue);
+    } catch {
+      // Keep the raw value on malformed percent-encoding. A cookie
+      // with garbage in it shouldn't crash the render.
+    }
+    result[name] = decoded;
+  }
+  return result;
+}
+
+export interface SetCookieOptions {
+  name: string;
+  value: string;
+  /** Seconds until expiry. Use 0 to clear. */
+  maxAge: number;
+  /**
+   * Path attribute. Defaults to "/" — our user-preference cookies are
+   * shared across every route.
+   */
+  path?: string;
+  /** SameSite — defaults to Lax (right default for GET filter toggles). */
+  sameSite?: "Lax" | "Strict" | "None";
+  /** Secure attribute. Defaults to true so previews + prod stay HTTPS-only. */
+  secure?: boolean;
+  /** HttpOnly attribute. Defaults to false — the SPA may need to read the value. */
+  httpOnly?: boolean;
+}
+
+export function buildSetCookie(opts: SetCookieOptions): string {
+  const {
+    name,
+    value,
+    maxAge,
+    path = "/",
+    sameSite = "Lax",
+    secure = true,
+    httpOnly = false,
+  } = opts;
+  const parts: string[] = [`${name}=${encodeURIComponent(value)}`];
+  parts.push(`Path=${path}`);
+  parts.push(`Max-Age=${maxAge}`);
+  parts.push(`SameSite=${sameSite}`);
+  if (secure) parts.push("Secure");
+  if (httpOnly) parts.push("HttpOnly");
+  return parts.join("; ");
+}

--- a/src/public/movement/page.tsx
+++ b/src/public/movement/page.tsx
@@ -13,14 +13,19 @@ import { Header } from "../components/header";
 import { Layout } from "../components/layout";
 import type { Movement } from "@/domain/movements/taxonomy";
 import type { RankedWatch } from "@/domain/leaderboard-query";
-import { LeaderboardStyles, LeaderboardTable } from "../leaderboard/table";
+import {
+  LeaderboardStyles,
+  LeaderboardTable,
+  VerifiedFilterToggle,
+} from "../leaderboard/table";
 
 export interface MovementPageProps {
   movement: Movement;
   watches: RankedWatch[];
+  verifiedOnly: boolean;
 }
 
-export const MovementPage = ({ movement, watches }: MovementPageProps) => {
+export const MovementPage = ({ movement, watches, verifiedOnly }: MovementPageProps) => {
   const title = `Most accurate ${movement.canonical_name} watches — rated.watch`;
   const description = `Drift rate leaderboard for the ${movement.canonical_name} ${movement.type} movement.`;
   // Route the CTA through /out/chrono24/:movementId so the Worker can
@@ -54,14 +59,26 @@ export const MovementPage = ({ movement, watches }: MovementPageProps) => {
               Shop on Chrono24 →
             </a>
           </div>
+          <VerifiedFilterToggle
+            basePath={`/m/${movement.id}`}
+            verifiedOnly={verifiedOnly}
+          />
         </section>
 
         <section class="cf-container cf-section" aria-label="Movement rankings">
           <LeaderboardTable
             watches={watches}
             showMovementColumn={false}
-            emptyStateTitle="No ranked watches on this movement yet"
-            emptyStateBody={`Nobody with a ${movement.canonical_name} has logged enough readings to appear here yet. Create an account, add your watch, and start logging.`}
+            emptyStateTitle={
+              verifiedOnly
+                ? "No verified watches on this movement yet"
+                : "No ranked watches on this movement yet"
+            }
+            emptyStateBody={
+              verifiedOnly
+                ? `Nobody running a ${movement.canonical_name} has crossed the 25 % verified-reading threshold. Switch to "All watches" to see everyone ranked, or log verified readings yourself to be first.`
+                : `Nobody with a ${movement.canonical_name} has logged enough readings to appear here yet. Create an account, add your watch, and start logging.`
+            }
           />
         </section>
 

--- a/src/public/user/page.tsx
+++ b/src/public/user/page.tsx
@@ -146,7 +146,14 @@ function WatchCard({ watch }: { watch: import("./load").ProfileWatchCard }) {
           <dt>Badge</dt>
           <dd>
             {stats.verified_badge ? (
-              <span class="cf-lb-badge" title="25 %+ verified readings this session">
+              <span
+                class="cf-lb-badge"
+                title="25 %+ verified readings this session"
+                data-verified-badge="true"
+              >
+                <span class="cf-lb-badge__check" aria-hidden="true">
+                  ✓
+                </span>{" "}
                 Verified
               </span>
             ) : (
@@ -239,6 +246,8 @@ function UserPageStyles() {
 
 .cf-lb-badge {
   display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
   background: var(--cf-orange);
@@ -250,6 +259,10 @@ function UserPageStyles() {
 .cf-lb-badge--muted {
   background: transparent;
   color: var(--cf-text-subtle);
+}
+.cf-lb-badge__check {
+  font-weight: 700;
+  line-height: 1;
 }
 `;
   return <style>{css}</style>;

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -184,7 +184,14 @@ function StatsPanel({ stats }: { stats: SessionStats }) {
         <dd>
           {verifiedPct}%{" "}
           {stats.verified_badge ? (
-            <span class="cf-lb-badge" title="25 %+ verified readings this session">
+            <span
+              class="cf-lb-badge"
+              title="25 %+ verified readings this session"
+              data-verified-badge="true"
+            >
+              <span class="cf-lb-badge__check" aria-hidden="true">
+                ✓
+              </span>{" "}
               Badge
             </span>
           ) : null}
@@ -403,6 +410,8 @@ function WatchPageStyles() {
 
 .cf-lb-badge {
   display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
   background: var(--cf-orange);
@@ -414,6 +423,10 @@ function WatchPageStyles() {
 .cf-lb-badge--muted {
   background: transparent;
   color: var(--cf-text-subtle);
+}
+.cf-lb-badge__check {
+  font-weight: 700;
+  line-height: 1;
 }
 `;
   return <style>{css}</style>;

--- a/src/server/routes/watches.ts
+++ b/src/server/routes/watches.ts
@@ -25,6 +25,7 @@ import {
   updateWatchSchema,
   type WatchResponse,
 } from "@/schemas/watch";
+import { computeSessionStats, type Reading } from "@/domain/drift-calc";
 import { assertWatchOwnership, type Watch } from "@/domain/watches/ownership";
 import { logEvent } from "@/observability/events";
 import { getAuth, type AuthEnv } from "@/server/auth";
@@ -186,10 +187,44 @@ watchesRoute.get("/", async (c) => {
     .orderBy("watches.created_at", "desc")
     .execute();
 
+  // Pull every reading for the caller's watches in one pass, then
+  // fan them out to each watch's computeSessionStats. Scales linearly
+  // with total readings, which is bounded per-user (dashboard is a
+  // small N).
+  const watchIds = rows.map((r) => r.id);
+  const readingsByWatch = new Map<string, Reading[]>();
+  if (watchIds.length > 0) {
+    const readingRows = await db
+      .selectFrom("readings")
+      .select([
+        "id",
+        "watch_id",
+        "reference_timestamp",
+        "deviation_seconds",
+        "is_baseline",
+        "verified",
+      ])
+      .where("watch_id", "in", watchIds)
+      .execute();
+    for (const r of readingRows) {
+      const bucket = readingsByWatch.get(r.watch_id) ?? [];
+      bucket.push({
+        id: r.id,
+        reference_timestamp: r.reference_timestamp,
+        deviation_seconds: r.deviation_seconds,
+        is_baseline: r.is_baseline === 1,
+        verified: r.verified === 1,
+      });
+      readingsByWatch.set(r.watch_id, bucket);
+    }
+  }
+
   const watches = rows.map((row) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { movement_canonical_name, ...watch } = row;
-    return toResponse(watch as Watch, movement_canonical_name ?? null);
+    const base = toResponse(watch as Watch, movement_canonical_name ?? null);
+    const sessionStats = computeSessionStats(readingsByWatch.get(row.id) ?? []);
+    return { ...base, session_stats: sessionStats };
   });
 
   return c.json({ watches });

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -10,6 +10,7 @@ import { createMovementTaxonomy } from "@/domain/movements/taxonomy";
 import { logEvent } from "@/observability/events";
 import { LandingPage } from "@/public/landing";
 import { LeaderboardPage } from "@/public/leaderboard/page";
+import { buildSetCookie, parseCookie } from "@/public/lib/cookie";
 import { MovementNotFoundPage, MovementPage } from "@/public/movement/page";
 import { loadPublicProfile } from "@/public/user/load";
 import { UserNotFoundPage, UserPage } from "@/public/user/page";
@@ -34,6 +35,67 @@ type Bindings = AuthEnv & {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+// ---- Verified-filter cookie helpers -------------------------------
+//
+// Public leaderboard pages remember the visitor's "Verified only"
+// preference via a first-party cookie (`rw_verified_filter`). The
+// resolution rules are:
+//
+//   1. If `?verified=1` or `?verified=0` is present → use it, and
+//      set/clear the cookie so a follow-up plain visit remembers it.
+//   2. Otherwise → fall back to the cookie value. Absent/anything
+//      else → show all watches.
+//
+// Kept here rather than in a middleware because only two routes need
+// it and factoring it out would make the Worker graph feel heavier
+// than the value it provides.
+const VERIFIED_COOKIE = "rw_verified_filter";
+// 365 days — the "remember my preference" lifespan. Long enough to
+// survive casual browsing resets; short enough to age out inactive
+// profiles. Marketed copy below the toggle makes it clear.
+const VERIFIED_COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
+
+/**
+ * Resolve the effective verified-only filter for a request. Returns
+ * the boolean filter state plus, when a query param asked us to
+ * change it, a Set-Cookie header string to stamp the preference.
+ */
+function resolveVerifiedFilter(req: Request): {
+  verifiedOnly: boolean;
+  setCookie: string | null;
+} {
+  const url = new URL(req.url);
+  const rawQuery = url.searchParams.get("verified");
+  const cookies = parseCookie(req.headers.get("cookie"));
+  const cookieValue = cookies[VERIFIED_COOKIE];
+
+  // Query param is explicit intent — trust it and update the cookie.
+  if (rawQuery === "1") {
+    return {
+      verifiedOnly: true,
+      setCookie: buildSetCookie({
+        name: VERIFIED_COOKIE,
+        value: "1",
+        maxAge: VERIFIED_COOKIE_MAX_AGE,
+      }),
+    };
+  }
+  if (rawQuery === "0") {
+    return {
+      verifiedOnly: false,
+      setCookie: buildSetCookie({
+        name: VERIFIED_COOKIE,
+        value: "",
+        maxAge: 0,
+      }),
+    };
+  }
+
+  // No query param — read the cookie only. Never write in this path
+  // so crawlers hitting bare URLs don't get set-cookie noise.
+  return { verifiedOnly: cookieValue === "1", setCookie: null };
+}
+
 app.get("/", async (c) => {
   // Hero extension (slice #13): surface the top-5 verified watches so
   // first-time visitors see the social proof immediately. Falls back
@@ -51,10 +113,18 @@ app.get("/", async (c) => {
 // explicitly so first-time viewers never see a stale ranking for long.
 app.get("/leaderboard", async (c) => {
   const db = createDb(c.env);
-  const verifiedOnly = c.req.query("verified") === "1";
+  const { verifiedOnly, setCookie } = resolveVerifiedFilter(c.req.raw);
   const watches = await queryLeaderboard({ verified_only: verifiedOnly, limit: 50 }, db);
   await logEvent("page_view_leaderboard", { verifiedOnly }, c.env);
-  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+  // Cookie-toggled responses are unique per preference, so drop the
+  // shared-cache directive when we're setting/clearing the cookie.
+  if (setCookie) {
+    c.header("Set-Cookie", setCookie);
+    c.header("Cache-Control", "private, no-store");
+    await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
+  } else {
+    c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+  }
   return c.html(<LeaderboardPage watches={watches} verifiedOnly={verifiedOnly} />);
 });
 
@@ -69,9 +139,21 @@ app.get("/m/:movementId", async (c) => {
   if (!movement || movement.status !== "approved") {
     return c.html(<MovementNotFoundPage />, 404);
   }
-  const watches = await queryLeaderboard({ movement_id: movement.id, limit: 50 }, db);
-  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
-  return c.html(<MovementPage movement={movement} watches={watches} />);
+  const { verifiedOnly, setCookie } = resolveVerifiedFilter(c.req.raw);
+  const watches = await queryLeaderboard(
+    { movement_id: movement.id, verified_only: verifiedOnly, limit: 50 },
+    db,
+  );
+  if (setCookie) {
+    c.header("Set-Cookie", setCookie);
+    c.header("Cache-Control", "private, no-store");
+    await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
+  } else {
+    c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+  }
+  return c.html(
+    <MovementPage movement={movement} watches={watches} verifiedOnly={verifiedOnly} />,
+  );
 });
 
 // Public user profile (slice #15). Case-insensitive lookup: a

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -494,6 +494,75 @@ describe("GET /leaderboard — public HTML", () => {
     const body = await res.text();
     expect(body).not.toMatch(/<script\b/i);
   });
+
+  // Slice 18: verified-filter persistence via cookie.
+
+  it("sets rw_verified_filter=1 cookie when ?verified=1 is supplied", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard?verified=1"),
+    );
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toMatch(/rw_verified_filter=1/);
+    expect(setCookie).toMatch(/Max-Age=\d+/);
+    expect(setCookie).toMatch(/Path=\//);
+    expect(setCookie).toMatch(/SameSite=Lax/);
+  });
+
+  it("clears rw_verified_filter cookie when ?verified=0 is supplied", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard?verified=0"),
+    );
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    // Max-Age=0 clears the cookie.
+    expect(setCookie).toMatch(/rw_verified_filter=/);
+    expect(setCookie).toMatch(/Max-Age=0/);
+  });
+
+  it("reads rw_verified_filter=1 cookie to filter when no ?verified= is set", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard", {
+        headers: { cookie: "rw_verified_filter=1" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // silver is unverified — must NOT appear when the cookie says "verified only".
+    expect(body).not.toContain(SEED.watches.silver.brand);
+    // gold (verified) still shows.
+    expect(body).toContain(SEED.watches.gold.brand);
+  });
+
+  it("?verified= query param takes precedence over the cookie", async () => {
+    // Cookie says verified-only, but ?verified=0 should override to show all.
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard?verified=0", {
+        headers: { cookie: "rw_verified_filter=1" },
+      }),
+    );
+    const body = await res.text();
+    expect(body).toContain(SEED.watches.silver.brand);
+  });
+
+  it("renders the verified-only toggle as an interactive button element", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const body = await res.text();
+    // The filter navigation renders two controls — "All" and "Verified only".
+    expect(body).toMatch(/All watches/);
+    expect(body).toMatch(/Verified only/);
+  });
+
+  it("emits the verified visual marker next to verified rows", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    const body = await res.text();
+    // The badge is a check-mark + "Verified" label. See LeaderboardTable.
+    expect(body).toMatch(/data-verified-badge="true"/);
+  });
 });
 
 // ---- Home hero top-5 extension ------------------------------------

--- a/tests/integration/per-movement-leaderboard.test.ts
+++ b/tests/integration/per-movement-leaderboard.test.ts
@@ -346,4 +346,39 @@ describe("GET /m/:movementId — public HTML", () => {
     const body = await res.text();
     expect(body).toMatch(/href="\/leaderboard"/);
   });
+
+  // Slice 18: the verified-only filter + cookie persistence reaches
+  // the per-movement page too, with the same copy as /leaderboard.
+
+  it("exposes an 'All / Verified only' filter on the movement page", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    const body = await res.text();
+    expect(body).toMatch(/All watches/);
+    expect(body).toMatch(/Verified only/);
+  });
+
+  it("sets rw_verified_filter cookie when ?verified=1 is supplied to /m/:id", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}?verified=1`),
+    );
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toMatch(/rw_verified_filter=1/);
+    expect(setCookie).toMatch(/Path=\//);
+  });
+
+  it("honours rw_verified_filter=1 cookie on /m/:id when no query param is set", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`, {
+        headers: { cookie: "rw_verified_filter=1" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    // All alpha watches are unverified in this seed (no verified
+    // readings), so with the filter on the page must not show them.
+    const body = await res.text();
+    expect(body).not.toContain(SEED.watches.alphaFast.model);
+    expect(body).not.toContain(SEED.watches.alphaSlow.model);
+  });
 });

--- a/tests/integration/public-pages.test.ts
+++ b/tests/integration/public-pages.test.ts
@@ -183,6 +183,15 @@ describe("GET /u/:username — public user profile", () => {
     const body = await res.text();
     expect(body).toContain(`/w/${SEED.publicWatch.id}`);
   });
+
+  it("renders the verified badge with data-verified-badge on verified watches", async () => {
+    // publicWatch has 2/3 verified readings (seed) so verified_badge = true.
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/u/${SEED.user.username}`),
+    );
+    const body = await res.text();
+    expect(body).toMatch(/data-verified-badge="true"/);
+  });
 });
 
 // ---- GET /w/:watchId ----------------------------------------------
@@ -250,5 +259,13 @@ describe("GET /w/:watchId — public watch page", () => {
     );
     const body = await res.text();
     expect(body).not.toMatch(/<script\b/i);
+  });
+
+  it("renders the verified badge with data-verified-badge when the watch qualifies", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/w/${SEED.publicWatch.id}`),
+    );
+    const body = await res.text();
+    expect(body).toMatch(/data-verified-badge="true"/);
   });
 });

--- a/tests/integration/watches.test.ts
+++ b/tests/integration/watches.test.ts
@@ -305,6 +305,43 @@ describe("GET /api/v1/watches", () => {
     const res = await listWatches();
     expect(res.status).toBe(401);
   });
+
+  // Slice 18: GET /watches embeds session_stats on each row so the
+  // dashboard can render the verified progress ring per-card without
+  // a second round-trip per watch.
+  it(
+    "embeds session_stats with reading_count + verified_ratio on each watch row",
+    async () => {
+      const user = await registerAndGetCookie();
+      const create = await createWatch(
+        { name: "Ring-owner", movement_id: approvedMovementId },
+        user.cookie,
+      );
+      expect(create.status).toBe(201);
+      const res = await listWatches(user.cookie);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        watches: Array<{
+          id: string;
+          session_stats: {
+            reading_count: number;
+            verified_ratio: number;
+            verified_badge: boolean;
+            eligible: boolean;
+          };
+        }>;
+      };
+      expect(body.watches.length).toBeGreaterThan(0);
+      for (const w of body.watches) {
+        expect(w.session_stats).toBeDefined();
+        expect(typeof w.session_stats.reading_count).toBe("number");
+        expect(typeof w.session_stats.verified_ratio).toBe("number");
+        expect(typeof w.session_stats.verified_badge).toBe("boolean");
+        expect(typeof w.session_stats.eligible).toBe("boolean");
+      }
+    },
+    TWO_USER_TIMEOUT,
+  );
 });
 
 // ---- GET /api/v1/watches/:id ---------------------------------------


### PR DESCRIPTION
Closes #19

## Summary
Surface the "verified" badge concept everywhere it matters: leaderboards, user profile, per-watch page, and the authed SPA. Add the "verified only" filter as a persistent user preference on `/leaderboard` + `/m/:id` via a first-party cookie.

## Changes

### Visual marker (all four public surfaces)
- Upgraded the per-row verified pill in `<LeaderboardTable>` to a check-mark + "Verified" label. Tagged with `data-verified-badge="true"` so UI tests (and future CSS targeting) have a stable hook.
- Same treatment applied to verified badges on `/u/:username` and `/w/:id` so all four public surfaces (leaderboard, per-movement, profile, watch page) render the identical visual.

### Filter toggle + cookie persistence
- Extracted `<VerifiedFilterToggle>` so `/leaderboard` and `/m/:id` share one copy + one visual for "All watches / Verified only".
- Worker handlers now resolve the filter through a new `rw_verified_filter` cookie:
  1. `?verified=0/1` query param → wins, and sets/clears the cookie.
  2. Cookie → fall-back state.
  3. Neither → default off.
- Cookie: 365-day, `SameSite=Lax`, `Path=/`, `Secure`. Cache-Control is downgraded to `private, no-store` when the query param is actively updating the cookie so CDNs never serve a stamped response to another visitor.
- Toggling emits `leaderboard_filter_changed` (existing EventKind) to Analytics Engine.

### Progress ring in the SPA
- New CSS-only `<VerifiedProgressRing>` (SVG + `stroke-dasharray`). Zero client-side JS animation.
- Dashboard cards show a 48 px ring below the movement line. Watch detail shows a 72 px variant with center percent beside the session stats panel.
- Caption copy comes from a new pure helper `readingsToBadge(verified, total)`:
  - Badge earned → "Verified watch"
  - Not earned → "X of Y verified — needs Z more to earn the badge"
  - No readings → "No readings yet" (layout stable)
- Extended `GET /api/v1/watches` to embed `session_stats` per row so the dashboard fetches its ring data in a single round-trip.

### New modules
- `src/public/lib/cookie.ts` — pure `parseCookie` / `buildSetCookie` helpers.
- `src/domain/drift-calc/readings-to-badge.ts` — progress-ring math helper. Correct formula (solves `(v+n)/(t+n) >= 0.25` algebraically rather than the naive `ceil(0.25*total) - verified` which ignores denominator growth).
- `src/app/watches/VerifiedProgressRing.tsx` — shared ring component, dashboard + detail page.

## Tests
- **Unit**: 10 tests for `parseCookie` / `buildSetCookie`, 10 tests for `readingsToBadge` (including 0.25 exactly, 0/3, 1/4, 2/10, degenerate).
- **Integration**: cookie toggle state machine on both leaderboard pages (query param precedence, cookie read-through, set/clear behaviour), `data-verified-badge` presence on the four public surfaces, new `session_stats` envelope on `GET /api/v1/watches`.

## Counts
- Baseline: 315 tests (36 files) on `main`.
- This PR: 347 tests (38 files) — +32 tests, +2 files (`cookie.test.ts`, `readings-to-badge.test.ts`).

## Observability
- Piggybacks `leaderboard_filter_changed` (already in `EventKind` from slice 19) when the filter is actively changed via the query-param path. Pure cookie-only hits (crawler / cache share) deliberately don't log — per the slice brief, client-side click-through for that case is a future-feature.

## Out of scope / notes
- No migration, no new secrets.
- Did not touch `src/observability/**` (other than emitting the already-declared event from the two handlers) or `src/server/routes/readings.ts` per the coordination rules.
- Pre-existing Prettier warnings on 8 files unrelated to this slice were left untouched.