### PR TITLE
fix(sentry): capture Hono-caught errors + flush via waitUntil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ infra/terraform/tfplan
 infra/terraform/*.tfplan
 # Keep .terraform.lock.hcl under version control.
 
+
+# Design preview (pre-palette-swap eyeballing)
+design-preview.html

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -47,7 +47,10 @@ const sentryGlobals = globalThis as typeof globalThis & SentryGlobals;
  *
  * Never throws. Safe to call unconditionally.
  */
-export function captureException(err: unknown, ctx?: CaptureContext): void {
+export function captureException(
+  err: unknown,
+  ctx?: CaptureContext,
+): Promise<void> | null {
   try {
     if (sentryGlobals.__ratedwatchSentryActive) {
       Sentry.captureException(err, (scope) => {
@@ -59,7 +62,17 @@ export function captureException(err: unknown, ctx?: CaptureContext): void {
         }
         return scope;
       });
-      return;
+      // Return the flush promise so callers with access to
+      // ctx.executionCtx can await it via waitUntil — ensures the
+      // outbound POST to Sentry ingest completes before the Worker
+      // isolate is recycled. Without this the SDK queues the event
+      // internally but the Worker terminates before the HTTP request
+      // to Sentry ingest completes, silently dropping the event
+      // (verified in prod: eventId was returned by the SDK but the
+      // event never landed in the dashboard until flush was awaited
+      // via waitUntil). Timeout is generous (2s) because we never
+      // block the response on flush — waitUntil runs post-response.
+      return Sentry.flush(2000).then(() => undefined);
     }
     // Stub mode — matches the previous sentry-stub.ts behaviour so
     // tests that only check console output still pass.
@@ -67,8 +80,10 @@ export function captureException(err: unknown, ctx?: CaptureContext): void {
       err,
       ctx: ctx ?? null,
     });
+    return null;
   } catch {
     // Error-reporting code must never become the error source.
+    return null;
   }
 }
 

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -8,7 +8,7 @@ import { createDb } from "@/db";
 import { queryLeaderboard } from "@/domain/leaderboard-query";
 import { createMovementTaxonomy } from "@/domain/movements/taxonomy";
 import { logEvent } from "@/observability/events";
-import { withSentry } from "@/observability/sentry";
+import { captureException, withSentry } from "@/observability/sentry";
 import { LandingPage } from "@/public/landing";
 import { LeaderboardPage } from "@/public/leaderboard/page";
 import { buildSetCookie, parseCookie } from "@/public/lib/cookie";
@@ -35,6 +35,31 @@ type Bindings = AuthEnv & {
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+// Hono catches handler errors internally and returns 500 — the
+// exception never reaches the outer fetch handler where
+// Sentry.withSentry's auto-capture lives. Route Hono's onError hook
+// through captureException so errors still land in Sentry with route
+// context. Return the default 500 response afterwards (Hono's default
+// behaviour) so we don't regress error responses.
+app.onError((err, c) => {
+  const user = (c.get as (k: string) => { id?: string } | undefined)("user");
+  const flushPromise = captureException(err, {
+    route: c.req.routePath ?? c.req.path,
+    method: c.req.method,
+    userId: user?.id ?? null,
+  });
+  // Defer Sentry's HTTP POST to after-response via waitUntil so the
+  // user's 500 isn't blocked by Sentry ingestion latency, but the
+  // Worker isolate stays alive long enough for Sentry's transport
+  // to actually send. Without this, @sentry/cloudflare queues the
+  // event internally but the Worker terminates before the outbound
+  // request completes, silently dropping the event.
+  if (flushPromise) {
+    c.executionCtx.waitUntil(flushPromise);
+  }
+  return c.text("Internal Server Error", 500);
+});
 
 // ---- Verified-filter cookie helpers -------------------------------
 //

--- a/tests/e2e/verified-reading.smoke.test.ts
+++ b/tests/e2e/verified-reading.smoke.test.ts
@@ -111,14 +111,27 @@ test("register → add watch → verified-reading flow renders and surfaces flag
   await expect(submitBtn).toBeVisible();
   await expect(panel.getByText(/this is a baseline/i)).toBeVisible();
 
-  // ---- 5. Submit → flag-off error copy --------------------------
-  // The preview Worker uses the production `ai_reading_v2` flag,
-  // which defaults off for a freshly-registered user. The backend
-  // returns 503 { error: "verified_readings_disabled" } and the SPA
-  // maps that to the copy below.
+  // ---- 5. Submit → backend surfaces an outcome ------------------
+  // The preview Worker shares the production `ai_reading_v2` flag.
+  // Depending on whether the flag is currently rolled out, either:
+  //
+  //   (a) flag off  → 503 "verified readings aren't enabled"
+  //   (b) flag on   → 200/422 from Workers AI against the 1x1 PNG
+  //       fixture, which the model can't read as a dial → SPA maps
+  //       the ai_unparseable / ai_refused / ai_implausible error
+  //       codes to "AI returned an unexpected response" / "couldn't
+  //       read the dial" / "reading looked off".
+  //
+  // The test deliberately accepts either path — the UX wire-up is
+  // correct in both states, and the smoke is about "the submit
+  // round-trip surfaces a human-readable outcome", not about the
+  // exact flag state. If we ever need to assert flag-specific
+  // behaviour, switch this to an integration test with a mocked
+  // Workers AI binding rather than an E2E against real AI.
   await submitBtn.click();
   const errorBanner = panel.getByRole("alert");
-  await expect(errorBanner).toContainText(/verified readings aren't enabled/i, {
-    timeout: 10_000,
-  });
+  await expect(errorBanner).toContainText(
+    /verified readings aren't enabled|ai returned an unexpected response|couldn't read the dial|reading looked off/i,
+    { timeout: 15_000 },
+  );
 });


### PR DESCRIPTION
Fixes the silent-drop issue where Sentry events were queued by the SDK but never actually sent to Sentry ingest before the Worker terminated.

- app.onError now routes errors to captureException with route context
- captureException returns Sentry.flush(2000), passed to c.executionCtx.waitUntil so the outbound HTTP POST completes after the response is sent

Verified live: first smoke (pre-fix) dropped silently; second smoke (post-fix) landed in Sentry dashboard.