### PR TITLE
feat(design): palette v3 — cool-neutral zinc

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,61 +1,75 @@
 /*
- * rated.watch SPA styles.
+ * rated.watch SPA styles — palette v3 (cool-neutral zinc).
  *
- * Tailwind v4 is included via @tailwindcss/vite. We register the CF
- * Workers design-system palette in a @theme block so that `bg-cf-bg-100`,
- * `text-cf-text`, `text-cf-orange`, etc. become first-class utilities
- * inside the SPA. Public SSR pages declare the same variables inline in
- * src/public/components/layout.tsx — keep the two in sync when tokens
+ * Tailwind v4 is included via @tailwindcss/vite. The @theme block
+ * registers the palette tokens so `bg-cf-bg-100`, `text-cf-text`,
+ * `text-cf-orange`, etc. become first-class utilities. Public SSR
+ * pages declare the same variables inline in src/public/components/
+ * layout.tsx (via tokens.ts) — keep the two in sync when tokens
  * change.
  *
- * Dark-mode strategy: we use the standard `prefers-color-scheme` media
- * query at the :root level (same as the public pages) rather than a
- * `.dark` class, because slice 3 doesn't ship a theme toggle yet. When
- * one lands (later slice), flip to a class-based strategy via Tailwind's
- * custom-variant and a localStorage-backed <html class="dark"> switch.
+ * Dark-mode strategy: `prefers-color-scheme` media query at :root
+ * (same as public pages), not a `.dark` class. When a theme toggle
+ * ships, flip to a class-based strategy.
+ *
+ * Naming note: the token names `cf-orange` / `cf-bg-100` are
+ * intentionally preserved to avoid a repo-wide class rename. Their
+ * semantic meaning is "accent" / "page background"; the actual
+ * hex values below are zinc-family, no orange anywhere. A future
+ * cleanup can rename the tokens to semantic names.
  */
 
 @import "tailwindcss";
 
 @theme {
-  --color-cf-orange: #ff4801;
-  --color-cf-orange-hover: #ff7038;
-  --color-cf-text: #521000;
-  --color-cf-text-muted: rgba(82, 16, 0, 0.6);
-  --color-cf-text-subtle: rgba(82, 16, 0, 0.38);
-  --color-cf-bg-page: #f5f1eb;
-  --color-cf-bg-100: #fffbf5;
-  --color-cf-bg-200: #fffdfb;
-  --color-cf-bg-300: #fef7ed;
-  --color-cf-border: #ebd5c1;
+  /* "Accent" (formerly orange) — the primary CTA color.
+   * Light: zinc-700. Dark: zinc-200 (inverted).
+   * Mid-charcoal against near-white bg; inverse on dark bg.
+   * No saturated brand color; the product relies on typographic
+   * hierarchy + contrast, not hue, for emphasis. */
+  --color-cf-orange: #3f3f46;
+  --color-cf-orange-hover: #27272a;
+
+  /* Text — zinc-900 light, zinc-50 dark. */
+  --color-cf-text: #18181b;
+  --color-cf-text-muted: #71717a; /* zinc-500 */
+  --color-cf-text-subtle: #a1a1aa; /* zinc-400 */
+
+  /* Page / card background. `bg-page` is the outer shell, `bg-100`
+   * the main content area, `bg-200` the lifted card, `bg-300` the
+   * inset (e.g. the stats panel on the watch detail page). */
+  --color-cf-bg-page: #f4f4f5; /* zinc-100 — outer */
+  --color-cf-bg-100: #fafafa; /* zinc-50  — page bg */
+  --color-cf-bg-200: #ffffff; /* pure white — cards */
+  --color-cf-bg-300: #f4f4f5; /* zinc-100 — inset */
+
+  --color-cf-border: #e4e4e7; /* zinc-200 */
 
   --font-sans:
-    "FT Kunst Grotesk", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, sans-serif;
+    "FT Kunst Grotesk", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
   --font-mono:
-    "Apercu Mono Pro", "JetBrains Mono", "SF Mono", "Fira Code", Consolas,
-    monospace;
+    "Apercu Mono Pro", "JetBrains Mono", "SF Mono", "Fira Code", Consolas, monospace;
 
   --radius-cf-full: 9999px;
 }
 
-/*
- * Dark-mode token overrides. Tailwind's `dark:` variants default to a
- * `prefers-color-scheme: dark` media query, which is exactly what we
- * want here: the tokens flip automatically based on OS preference.
- */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-cf-orange: #f14602;
-    --color-cf-orange-hover: #ff6d33;
-    --color-cf-text: #f0e3de;
-    --color-cf-text-muted: rgba(255, 253, 251, 0.56);
-    --color-cf-text-subtle: rgba(255, 253, 251, 0.38);
-    --color-cf-bg-page: #0d0d0d;
-    --color-cf-bg-100: #121212;
-    --color-cf-bg-200: #191817;
-    --color-cf-bg-300: #2a2927;
-    --color-cf-border: rgba(240, 227, 222, 0.13);
+    --color-cf-orange: #e4e4e7; /* zinc-200 — CTA inverted */
+    --color-cf-orange-hover: #fafafa; /* zinc-50 on hover */
+
+    --color-cf-text: #fafafa; /* zinc-50 */
+    --color-cf-text-muted: #a1a1aa; /* zinc-400 */
+    --color-cf-text-subtle: #71717a; /* zinc-500 */
+
+    --color-cf-bg-page: #000000; /* full black outer shell */
+    --color-cf-bg-100: #09090b; /* zinc-950 — page */
+    --color-cf-bg-200: #18181b; /* zinc-900 — cards */
+    --color-cf-bg-300: #27272a; /* zinc-800 — inset */
+
+    --color-cf-border: #27272a; /* zinc-800 */
+
     color-scheme: dark;
   }
 }

--- a/src/public/components/tokens.ts
+++ b/src/public/components/tokens.ts
@@ -1,39 +1,42 @@
-// CF Workers design tokens — single source of truth for palette, radii,
+// Design tokens — single source of truth for palette, radii,
 // typography, and motion used by both the public SSR pages and the SPA.
 //
-// We expose the raw hex/token values here (not a CSS string) so components
-// that render inline colour (e.g. the <meta name="theme-color">) don't have
-// to grep out of a stylesheet. The matching CSS custom properties are
-// emitted by `<DesignTokensStyle />` in `layout.tsx`.
+// Palette v3: cool-neutral zinc family, no warm accent. Token names
+// still reference "orange" for minimum repo churn — actual hex values
+// are zinc-family (mid-charcoal CTA light / near-white CTA dark).
+// Semantic rename (orange → accent) is a followup.
 //
-// See ~/design/CF-WORKERS-DESIGN.md §2 and §3 for the full reference.
+// The matching CSS custom properties are emitted by
+// <DesignTokensStyle /> in `layout.tsx` (public SSR) and by the
+// `@theme` block in `src/app/styles.css` (SPA). Keep all three in
+// sync.
 
 export const tokens = {
   light: {
-    orange: "#FF4801",
-    orangeHover: "#FF7038",
-    text: "#521000",
-    textMuted: "rgba(82, 16, 0, 0.6)",
-    textSubtle: "rgba(82, 16, 0, 0.38)",
-    bgPage: "#F5F1EB",
-    bg100: "#FFFBF5",
-    bg200: "#FFFDFB",
-    bg300: "#FEF7ED",
-    border: "#EBD5C1",
-    borderLight: "rgba(235, 213, 193, 0.5)",
+    orange: "#3F3F46", // zinc-700, primary CTA
+    orangeHover: "#27272A", // zinc-800
+    text: "#18181B", // zinc-900
+    textMuted: "#71717A", // zinc-500
+    textSubtle: "#A1A1AA", // zinc-400
+    bgPage: "#F4F4F5", // zinc-100, outer shell
+    bg100: "#FAFAFA", // zinc-50, main content
+    bg200: "#FFFFFF", // pure white, cards
+    bg300: "#F4F4F5", // zinc-100, inset
+    border: "#E4E4E7", // zinc-200
+    borderLight: "rgba(228, 228, 231, 0.5)",
   },
   dark: {
-    orange: "#F14602",
-    orangeHover: "#FF6D33",
-    text: "#F0E3DE",
-    textMuted: "rgba(255, 253, 251, 0.56)",
-    textSubtle: "rgba(255, 253, 251, 0.38)",
-    bgPage: "#0D0D0D",
-    bg100: "#121212",
-    bg200: "#191817",
-    bg300: "#2A2927",
-    border: "rgba(240, 227, 222, 0.13)",
-    borderLight: "rgba(240, 227, 222, 0.08)",
+    orange: "#E4E4E7", // zinc-200, CTA inverted
+    orangeHover: "#FAFAFA", // zinc-50
+    text: "#FAFAFA", // zinc-50
+    textMuted: "#A1A1AA", // zinc-400
+    textSubtle: "#71717A", // zinc-500
+    bgPage: "#000000", // full black outer shell
+    bg100: "#09090B", // zinc-950, page
+    bg200: "#18181B", // zinc-900, cards
+    bg300: "#27272A", // zinc-800, inset
+    border: "#27272A", // zinc-800
+    borderLight: "rgba(39, 39, 42, 0.5)",
   },
   font: {
     sans: '"FT Kunst Grotesk", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',

--- a/tests/integration/home.test.ts
+++ b/tests/integration/home.test.ts
@@ -9,47 +9,39 @@ import { describe, it, expect } from "vitest";
 
 describe("GET / — design system + home shell", () => {
   it("returns 200 HTML with Content-Type text/html", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type") ?? "").toMatch(/text\/html/);
   });
 
   it("includes theme-color meta tags for both light and dark schemes", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
 
-    // Warm cream in light, near-black in dark — see CF Workers design doc.
+    // Palette v3 (cool-neutral zinc): near-white page in light, full
+    // black in dark. Was warm-cream / warm-near-black pre-v3.
     expect(body).toMatch(
-      /<meta\s+name="theme-color"\s+content="#FFFBF5"\s+media="\(prefers-color-scheme:\s*light\)"\s*\/?>/,
+      /<meta\s+name="theme-color"\s+content="#FAFAFA"\s+media="\(prefers-color-scheme:\s*light\)"\s*\/?>/,
     );
     expect(body).toMatch(
-      /<meta\s+name="theme-color"\s+content="#121212"\s+media="\(prefers-color-scheme:\s*dark\)"\s*\/?>/,
+      /<meta\s+name="theme-color"\s+content="#09090B"\s+media="\(prefers-color-scheme:\s*dark\)"\s*\/?>/,
     );
   });
 
-  it("embeds the CF Workers design tokens as CSS custom properties", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+  it("embeds the design tokens as CSS custom properties", async () => {
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
 
-    // Accent, background, and text tokens must be present either inlined or
-    // via a linked stylesheet. We assert the canonical hex values appear
-    // somewhere in the served HTML so future refactors (inline vs linked
-    // sheet) don't silently drop the palette.
-    expect(body).toContain("#FF4801"); // primary accent
-    expect(body).toContain("#FFFBF5"); // cream light bg
-    expect(body).toContain("#121212"); // dark bg
+    // Accent, background, and text tokens must be present either inlined
+    // or via a linked stylesheet. Asserting the canonical hex values
+    // catches silent palette drops during refactors.
+    expect(body).toContain("#3F3F46"); // primary accent (zinc-700, CTA light)
+    expect(body).toContain("#FAFAFA"); // page bg light (zinc-50)
+    expect(body).toContain("#09090B"); // page bg dark (zinc-950)
   });
 
   it("renders the hero tagline", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
 
     // The tagline anchors the home page and the social share card. It must
@@ -58,17 +50,13 @@ describe("GET / — design system + home shell", () => {
   });
 
   it("teases leaderboards as the next thing to ship", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
     expect(body).toMatch(/leaderboards/i);
   });
 
   it("emits zero client-side JavaScript — no <script> tags on /", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
 
     // Public pages must be pure SSR — any <script> tag (classic, module,
@@ -78,9 +66,7 @@ describe("GET / — design system + home shell", () => {
   });
 
   it("respects prefers-color-scheme via a CSS media query", async () => {
-    const response = await exports.default.fetch(
-      new Request("https://ratedwatch.test/"),
-    );
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
     const body = await response.text();
     expect(body).toMatch(/prefers-color-scheme\s*:\s*dark/i);
   });

--- a/tests/integration/spa-shell.test.ts
+++ b/tests/integration/spa-shell.test.ts
@@ -62,9 +62,11 @@ describe("SPA shell — /app/*", () => {
     // Canonical palette hex values — asserted via the @theme tokens
     // registered in src/app/styles.css. If someone regresses the theme
     // block or drops the import, this fires.
-    expect(css).toContain("#ff4801"); // primary accent (light)
-    expect(css).toContain("#fffbf5"); // cream bg (light)
-    expect(css).toContain("#121212"); // dark bg
+    // Palette v3 (cool-neutral zinc). Token names still reference
+    // "orange" but the hex values are zinc-family.
+    expect(css).toContain("#3f3f46"); // CTA accent (zinc-700, light)
+    expect(css).toContain("#fafafa"); // page bg (zinc-50, light)
+    expect(css).toContain("#09090b"); // page bg (zinc-950, dark)
     // Dark-mode media query must be present — slice 3 ships no theme
     // toggle, so OS preference is the only signal.
     expect(css).toMatch(/prefers-color-scheme\s*:\s*dark/i);


### PR DESCRIPTION
Replaces the warm-cream + amber palette from slices 3-18 with a cool-neutral zinc scale. See commit for token-by-token diff.

Token names (`cf-orange`, `cf-bg-100`, etc.) intentionally preserved to avoid touching ~30 component files — the hex values they map to are the only thing that changes. Semantic rename is a followup.

352 tests passing locally after updating home.test.ts + spa-shell.test.ts assertions for the new hex values.