### PR TITLE
infra: rated.watch apex → ratedwatch custom domain (slice #21)

### DIFF
--- a/infra/terraform/workers-domain.tf
+++ b/infra/terraform/workers-domain.tf
@@ -1,0 +1,30 @@
+# Workers Custom Domain — rated.watch apex → ratedwatch Worker.
+#
+# This is the slice #21 cutover: users typing `rated.watch` now hit the
+# deployed Worker directly rather than falling through to the placeholder
+# A record that used to live here (pointing at 1.2.3.4). Cloudflare
+# manages the DNS record and the edge TLS certificate automatically
+# when this resource is created — the prior manual A records on the
+# apex and the wildcard were removed out-of-band before the first apply.
+#
+# The Worker also stays accessible on `ratedwatch.nmoura.workers.dev`
+# because `workers_dev: true` is implicitly on in wrangler.jsonc. A
+# future cleanup slice can disable that once rated.watch is the
+# canonical URL everywhere (SEO / analytics reasons).
+#
+# `www.rated.watch` is NOT managed here — phase 1 is apex-only. Add a
+# second resource + a DNS A record (or CNAME flattening) if a www
+# redirect becomes necessary.
+
+resource "cloudflare_workers_custom_domain" "apex" {
+  account_id  = var.account_id
+  zone_id     = var.zone_id
+  hostname    = "rated.watch"
+  service     = var.worker_name
+  environment = "production"
+}
+
+output "custom_domain_hostname" {
+  description = "Canonical hostname for the ratedwatch Worker after cutover."
+  value       = cloudflare_workers_custom_domain.apex.hostname
+}


### PR DESCRIPTION
Closes #22.

Slice 21 cutover — rated.watch now serves the ratedwatch Worker instead of the archived watchdrift prototype.

## Live verification

```
GET rated.watch/                    → 200 | 8937 bytes (hono landing)
GET rated.watch/leaderboard         → 200 | 10903 bytes
GET rated.watch/app/login           → 200 | 1540 bytes
GET rated.watch/api/v1/movements    → 200 | 523 bytes (3 ETA matches)
GET rated.watch/m/eta-2892-a2       → 200 | 11663 bytes
```

## Changes in this PR

- `infra/terraform/workers-domain.tf` — new resource `cloudflare_workers_custom_domain.apex` pointing rated.watch at the ratedwatch Worker.

## Out-of-band operator actions performed before apply

1. Deleted the placeholder apex A record (`rated.watch → 1.2.3.4`) and the wildcard (`*.rated.watch → 1.2.3.4`). Custom domains refuse to take over hostnames with existing A/CNAME records.
2. Deleted the dangling workers route `rated.watch/*` → `watchdrift` (the archived prototype). Routes take precedence over custom domains — without deleting this, the cutover succeeded at the Terraform layer but traffic still went to watchdrift.

These were manual API calls rather than TF resources because they're one-shot cleanups of pre-existing dashboard state.

## Followups

- www.rated.watch — not handled yet; apex only.
- Retire the `watchdrift` Worker itself (`wrangler delete watchdrift`) — cosmetic, the route is already gone.
- Disable `workers_dev: true` in wrangler.jsonc once rated.watch is the canonical URL everywhere (removes `ratedwatch.nmoura.workers.dev` from indexing).