### PR TITLE
chore(design): rename cf-orange/cf-bg-N tokens to semantic names

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,31 +6,24 @@ import { Link, Outlet } from "react-router";
 
 export function App() {
   return (
-    <div className="min-h-screen flex flex-col bg-cf-bg-100 text-cf-text font-sans">
-      <header className="border-b border-cf-border bg-cf-bg-100">
+    <div className="min-h-screen flex flex-col bg-cf-bg text-cf-text font-sans">
+      <header className="border-b border-cf-border bg-cf-bg">
         <div className="mx-auto flex max-w-[1200px] items-center justify-between gap-4 px-6 py-4">
           <Link
             to="/app"
             className="font-mono text-base font-medium tracking-tight text-cf-text hover:text-cf-text"
             aria-label="rated.watch app home"
           >
-            rated<span className="text-cf-orange">.</span>watch
+            rated<span className="text-cf-accent">.</span>watch
           </Link>
-          <nav
-            aria-label="App primary"
-            className="flex gap-6 text-sm text-cf-text-muted"
-          >
+          <nav aria-label="App primary" className="flex gap-6 text-sm text-cf-text-muted">
             <Link to="/app/dashboard" className="hover:text-cf-text">
               Dashboard
             </Link>
             <Link to="/app/settings" className="hover:text-cf-text">
               Settings
             </Link>
-            <a
-              href="/"
-              className="hover:text-cf-text"
-              aria-label="Back to public site"
-            >
+            <a href="/" className="hover:text-cf-text" aria-label="Back to public site">
               ← Site
             </a>
           </nav>
@@ -43,8 +36,7 @@ export function App() {
       </main>
       <footer className="border-t border-cf-border py-8 text-sm text-cf-text-subtle">
         <div className="mx-auto max-w-[1200px] px-6">
-          rated.watch — authed area. Placeholder screens ship in a later
-          slice.
+          rated.watch — authed area. Placeholder screens ship in a later slice.
         </div>
       </footer>
     </div>

--- a/src/app/components/GoogleSignInButton.tsx
+++ b/src/app/components/GoogleSignInButton.tsx
@@ -9,7 +9,7 @@
 // use by the email-password primary action (see LoginPage /
 // RegisterPage). Google's brand guidelines allow either a white or
 // coloured surface so long as the mark stays in its brand colours.
-// We keep the background warm (cf-bg-100) and use the official Google
+// We keep the background warm (cf-bg) and use the official Google
 // SVG in its multi-colour form; the surrounding text is cf-text.
 
 import { useState } from "react";
@@ -51,8 +51,8 @@ export function GoogleSignInButton({
         aria-label={label}
         className={
           "inline-flex items-center justify-center gap-3 rounded-full border " +
-          "border-cf-border bg-cf-bg-100 px-6 py-3 text-sm font-medium " +
-          "text-cf-text transition-colors hover:border-cf-orange hover:text-cf-text " +
+          "border-cf-border bg-cf-bg px-6 py-3 text-sm font-medium " +
+          "text-cf-text transition-colors hover:border-cf-accent hover:text-cf-text " +
           "disabled:opacity-60 " +
           className
         }
@@ -87,7 +87,7 @@ export function GoogleSignInButton({
       {error ? (
         <p
           role="alert"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {error}
         </p>

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -55,7 +55,7 @@ export function DashboardPage() {
           {user ? (
             <p className="text-cf-text">
               Logged in as{" "}
-              <span className="font-mono text-cf-orange">@{user.username}</span>.
+              <span className="font-mono text-cf-accent">@{user.username}</span>.
             </p>
           ) : (
             <p className="text-cf-text-muted">Loading profile…</p>
@@ -63,7 +63,7 @@ export function DashboardPage() {
         </div>
         <Link
           to="/app/watches/new"
-          className="inline-flex items-center justify-center rounded-full bg-cf-orange px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover"
+          className="inline-flex items-center justify-center rounded-full bg-cf-accent px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover"
         >
           Add watch
         </Link>
@@ -75,19 +75,19 @@ export function DashboardPage() {
         ) : state.kind === "error" ? (
           <p
             role="alert"
-            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+            className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
           >
             {state.message}
           </p>
         ) : state.watches.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-cf-border bg-cf-bg-200 px-6 py-10 text-center">
+          <div className="rounded-lg border border-dashed border-cf-border bg-cf-surface px-6 py-10 text-center">
             <p className="mb-3 text-cf-text">No watches yet.</p>
             <p className="mb-4 text-sm text-cf-text-muted">
               Add your first watch to start tracking accuracy against a reference.
             </p>
             <Link
               to="/app/watches/new"
-              className="inline-flex items-center justify-center rounded-full bg-cf-orange px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover"
+              className="inline-flex items-center justify-center rounded-full bg-cf-accent px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover"
             >
               Add your first watch
             </Link>
@@ -103,12 +103,12 @@ export function DashboardPage() {
                 <li key={watch.id}>
                   <Link
                     to={`/app/watches/${watch.id}`}
-                    className="flex h-full flex-col gap-2 rounded-lg border border-cf-border bg-cf-bg-100 p-4 transition-colors hover:border-cf-orange"
+                    className="flex h-full flex-col gap-2 rounded-lg border border-cf-border bg-cf-bg p-4 transition-colors hover:border-cf-accent"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <h2 className="text-lg font-medium text-cf-text">{watch.name}</h2>
                       {watch.is_public ? null : (
-                        <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2 py-0.5 text-xs font-medium text-cf-orange">
+                        <span className="rounded-full border border-cf-accent/40 bg-cf-accent/10 px-2 py-0.5 text-xs font-medium text-cf-accent">
                           Private
                         </span>
                       )}
@@ -142,7 +142,7 @@ export function DashboardPage() {
       <button
         type="button"
         onClick={onLogout}
-        className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"
+        className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-accent hover:text-cf-accent"
       >
         Sign out
       </button>

--- a/src/app/pages/EditWatchPage.tsx
+++ b/src/app/pages/EditWatchPage.tsx
@@ -125,13 +125,13 @@ export function EditWatchPage() {
       <section className="mx-auto max-w-2xl">
         <p
           role="alert"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {state.message}
         </p>
         <Link
           to="/app/dashboard"
-          className="mt-4 inline-block text-sm text-cf-orange hover:underline"
+          className="mt-4 inline-block text-sm text-cf-accent hover:underline"
         >
           ← Back to dashboard
         </Link>

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -40,7 +40,7 @@ export function LoginPage() {
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
         </label>
         <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
@@ -52,13 +52,13 @@ export function LoginPage() {
             minLength={8}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
         </label>
         {error ? (
           <p
             role="alert"
-            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+            className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
           >
             {error}
           </p>
@@ -66,7 +66,7 @@ export function LoginPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover disabled:opacity-60"
         >
           {submitting ? "Signing in…" : "Sign in"}
         </button>
@@ -84,7 +84,7 @@ export function LoginPage() {
       <GoogleSignInButton label="Continue with Google" />
       <p className="mt-6 text-sm text-cf-text-muted">
         New here?{" "}
-        <Link to="/app/register" className="text-cf-orange hover:underline">
+        <Link to="/app/register" className="text-cf-accent hover:underline">
           Create an account
         </Link>
         .

--- a/src/app/pages/NotFoundPage.tsx
+++ b/src/app/pages/NotFoundPage.tsx
@@ -6,18 +6,18 @@ import { Link } from "react-router";
 
 export function NotFoundPage() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-[1200px] flex-col items-start justify-center gap-4 bg-cf-bg-100 px-6 font-sans text-cf-text">
+    <main className="mx-auto flex min-h-screen max-w-[1200px] flex-col items-start justify-center gap-4 bg-cf-bg px-6 font-sans text-cf-text">
       <p className="font-mono text-sm text-cf-text-subtle">404</p>
       <h1 className="text-4xl font-medium tracking-tight">
         This page doesn't exist yet.
       </h1>
       <p className="max-w-[56ch] text-cf-text-muted">
-        The rated.watch SPA is still growing. If you followed a link here
-        from an earlier slice, the target probably hasn't shipped yet.
+        The rated.watch SPA is still growing. If you followed a link here from an earlier
+        slice, the target probably hasn't shipped yet.
       </p>
       <Link
         to="/app/dashboard"
-        className="mt-4 inline-flex items-center gap-2 rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover"
+        className="mt-4 inline-flex items-center gap-2 rounded-full bg-cf-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover"
       >
         Back to dashboard →
       </Link>

--- a/src/app/pages/RegisterPage.tsx
+++ b/src/app/pages/RegisterPage.tsx
@@ -49,7 +49,7 @@ export function RegisterPage() {
             maxLength={100}
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
         </label>
         <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
@@ -60,7 +60,7 @@ export function RegisterPage() {
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
         </label>
         <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
@@ -72,13 +72,13 @@ export function RegisterPage() {
             minLength={8}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
         </label>
         {error ? (
           <p
             role="alert"
-            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+            className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
           >
             {error}
           </p>
@@ -86,7 +86,7 @@ export function RegisterPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-cf-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover disabled:opacity-60"
         >
           {submitting ? "Creating account…" : "Create account"}
         </button>
@@ -104,7 +104,7 @@ export function RegisterPage() {
       <GoogleSignInButton label="Continue with Google" />
       <p className="mt-6 text-sm text-cf-text-muted">
         Already have an account?{" "}
-        <Link to="/app/login" className="text-cf-orange hover:underline">
+        <Link to="/app/login" className="text-cf-accent hover:underline">
           Sign in
         </Link>
         .

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -79,7 +79,7 @@ export function SettingsPage() {
             type="email"
             readOnly
             value={user?.email ?? ""}
-            className="rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2 font-sans text-base text-cf-text-muted outline-none"
+            className="rounded-md border border-cf-border bg-cf-surface px-3 py-2 font-sans text-base text-cf-text-muted outline-none"
           />
         </label>
 
@@ -106,10 +106,10 @@ export function SettingsPage() {
             }}
             aria-invalid={fieldError ? true : undefined}
             aria-describedby={fieldError ? "username-error" : undefined}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
           {fieldError ? (
-            <span id="username-error" role="alert" className="text-sm text-cf-orange">
+            <span id="username-error" role="alert" className="text-sm text-cf-accent">
               {fieldError}
             </span>
           ) : (
@@ -123,7 +123,7 @@ export function SettingsPage() {
         {status.kind === "error" ? (
           <p
             role="alert"
-            className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+            className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
           >
             {status.message}
           </p>
@@ -131,7 +131,7 @@ export function SettingsPage() {
         {status.kind === "success" ? (
           <p
             role="status"
-            className="rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2 text-sm text-cf-text"
+            className="rounded-md border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text"
           >
             {status.message}
           </p>
@@ -144,7 +144,7 @@ export function SettingsPage() {
             status.kind === "submitting" ||
             username.trim() === (user?.username ?? "")
           }
-          className="mt-2 inline-flex items-center justify-center self-start rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+          className="mt-2 inline-flex items-center justify-center self-start rounded-full bg-cf-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover disabled:opacity-60"
         >
           {status.kind === "submitting" ? "Saving…" : "Save changes"}
         </button>

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -142,13 +142,13 @@ export function WatchDetailPage() {
       <section className="mx-auto max-w-2xl">
         <p
           role="alert"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {state.message}
         </p>
         <Link
           to="/app/dashboard"
-          className="mt-4 inline-block text-sm text-cf-orange hover:underline"
+          className="mt-4 inline-block text-sm text-cf-accent hover:underline"
         >
           ← Back to dashboard
         </Link>
@@ -186,8 +186,8 @@ export function WatchDetailPage() {
             disabled={togglingVisibility}
             className={
               watch.is_public
-                ? "inline-flex items-center gap-2 rounded-full border border-cf-border bg-cf-bg-200 px-3 py-1 text-xs font-medium text-cf-text-muted transition-colors hover:border-cf-orange hover:text-cf-orange disabled:opacity-60"
-                : "inline-flex items-center gap-2 rounded-full border border-cf-orange/40 bg-cf-orange/10 px-3 py-1 text-xs font-medium text-cf-orange transition-colors hover:bg-cf-orange/20 disabled:opacity-60"
+                ? "inline-flex items-center gap-2 rounded-full border border-cf-border bg-cf-surface px-3 py-1 text-xs font-medium text-cf-text-muted transition-colors hover:border-cf-accent hover:text-cf-accent disabled:opacity-60"
+                : "inline-flex items-center gap-2 rounded-full border border-cf-accent/40 bg-cf-accent/10 px-3 py-1 text-xs font-medium text-cf-accent transition-colors hover:bg-cf-accent/20 disabled:opacity-60"
             }
           >
             <span
@@ -195,7 +195,7 @@ export function WatchDetailPage() {
               className={
                 watch.is_public
                   ? "inline-block h-2 w-2 rounded-full bg-cf-text-muted"
-                  : "inline-block h-2 w-2 rounded-full bg-cf-orange"
+                  : "inline-block h-2 w-2 rounded-full bg-cf-accent"
               }
             />
             {togglingVisibility
@@ -205,7 +205,7 @@ export function WatchDetailPage() {
                 : "Private"}
           </button>
           {visibilityError ? (
-            <p role="alert" className="text-xs text-cf-orange">
+            <p role="alert" className="text-xs text-cf-accent">
               {visibilityError}
             </p>
           ) : null}
@@ -232,7 +232,7 @@ export function WatchDetailPage() {
       {readings.error ? (
         <p
           role="alert"
-          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="mb-4 rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {readings.error}
         </p>
@@ -246,7 +246,7 @@ export function WatchDetailPage() {
 
       <SessionStatsPanel stats={readings.session_stats} />
       {readings.session_stats && readings.session_stats.reading_count > 0 ? (
-        <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5">
+        <div className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5">
           <VerifiedProgressRing
             verifiedCount={Math.round(
               readings.session_stats.reading_count *
@@ -268,7 +268,7 @@ export function WatchDetailPage() {
       <div className="mt-10 flex flex-wrap items-center gap-3">
         <Link
           to={`/app/watches/${watch.id}/edit`}
-          className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"
+          className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-accent hover:text-cf-accent"
         >
           Edit
         </Link>
@@ -276,7 +276,7 @@ export function WatchDetailPage() {
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="inline-flex items-center justify-center rounded-full border border-cf-orange/40 bg-cf-orange/10 px-5 py-2.5 text-sm font-medium text-cf-orange transition-colors hover:border-cf-orange hover:bg-cf-orange/20 disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full border border-cf-accent/40 bg-cf-accent/10 px-5 py-2.5 text-sm font-medium text-cf-accent transition-colors hover:border-cf-accent hover:bg-cf-accent/20 disabled:opacity-60"
         >
           {deleting ? "Deleting…" : "Delete"}
         </button>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2,8 +2,8 @@
  * rated.watch SPA styles — palette v3 (cool-neutral zinc).
  *
  * Tailwind v4 is included via @tailwindcss/vite. The @theme block
- * registers the palette tokens so `bg-cf-bg-100`, `text-cf-text`,
- * `text-cf-orange`, etc. become first-class utilities. Public SSR
+ * registers the palette tokens so `bg-cf-bg`, `text-cf-text`,
+ * `text-cf-accent`, etc. become first-class utilities. Public SSR
  * pages declare the same variables inline in src/public/components/
  * layout.tsx (via tokens.ts) — keep the two in sync when tokens
  * change.
@@ -12,36 +12,37 @@
  * (same as public pages), not a `.dark` class. When a theme toggle
  * ships, flip to a class-based strategy.
  *
- * Naming note: the token names `cf-orange` / `cf-bg-100` are
- * intentionally preserved to avoid a repo-wide class rename. Their
- * semantic meaning is "accent" / "page background"; the actual
- * hex values below are zinc-family, no orange anywhere. A future
- * cleanup can rename the tokens to semantic names.
+ * Naming: tokens are semantic. `cf-accent` = primary CTA,
+ * `cf-bg`/`cf-surface`/`cf-surface-inset` form a three-step
+ * background stack (page → card → inset), `cf-shell` is the
+ * rarely-used outer-shell background behind main. The actual hex
+ * values are zinc-family — no warm accent anywhere.
  */
 
 @import "tailwindcss";
 
 @theme {
-  /* "Accent" (formerly orange) — the primary CTA color.
+  /* Accent — the primary CTA color.
    * Light: zinc-700. Dark: zinc-200 (inverted).
    * Mid-charcoal against near-white bg; inverse on dark bg.
    * No saturated brand color; the product relies on typographic
    * hierarchy + contrast, not hue, for emphasis. */
-  --color-cf-orange: #3f3f46;
-  --color-cf-orange-hover: #27272a;
+  --color-cf-accent: #3f3f46;
+  --color-cf-accent-hover: #27272a;
 
   /* Text — zinc-900 light, zinc-50 dark. */
   --color-cf-text: #18181b;
   --color-cf-text-muted: #71717a; /* zinc-500 */
   --color-cf-text-subtle: #a1a1aa; /* zinc-400 */
 
-  /* Page / card background. `bg-page` is the outer shell, `bg-100`
-   * the main content area, `bg-200` the lifted card, `bg-300` the
-   * inset (e.g. the stats panel on the watch detail page). */
-  --color-cf-bg-page: #f4f4f5; /* zinc-100 — outer */
-  --color-cf-bg-100: #fafafa; /* zinc-50  — page bg */
-  --color-cf-bg-200: #ffffff; /* pure white — cards */
-  --color-cf-bg-300: #f4f4f5; /* zinc-100 — inset */
+  /* Background stack. `shell` is the outer shell (rarely used),
+   * `bg` is the main content area, `surface` is the lifted card,
+   * `surface-inset` is the inset (e.g. the stats panel on the
+   * watch detail page). */
+  --color-cf-shell: #f4f4f5; /* zinc-100 — outer */
+  --color-cf-bg: #fafafa; /* zinc-50  — page bg */
+  --color-cf-surface: #ffffff; /* pure white — cards */
+  --color-cf-surface-inset: #f4f4f5; /* zinc-100 — inset */
 
   --color-cf-border: #e4e4e7; /* zinc-200 */
 
@@ -56,17 +57,17 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-cf-orange: #e4e4e7; /* zinc-200 — CTA inverted */
-    --color-cf-orange-hover: #fafafa; /* zinc-50 on hover */
+    --color-cf-accent: #e4e4e7; /* zinc-200 — CTA inverted */
+    --color-cf-accent-hover: #fafafa; /* zinc-50 on hover */
 
     --color-cf-text: #fafafa; /* zinc-50 */
     --color-cf-text-muted: #a1a1aa; /* zinc-400 */
     --color-cf-text-subtle: #71717a; /* zinc-500 */
 
-    --color-cf-bg-page: #000000; /* full black outer shell */
-    --color-cf-bg-100: #09090b; /* zinc-950 — page */
-    --color-cf-bg-200: #18181b; /* zinc-900 — cards */
-    --color-cf-bg-300: #27272a; /* zinc-800 — inset */
+    --color-cf-shell: #000000; /* full black outer shell */
+    --color-cf-bg: #09090b; /* zinc-950 — page */
+    --color-cf-surface: #18181b; /* zinc-900 — cards */
+    --color-cf-surface-inset: #27272a; /* zinc-800 — inset */
 
     --color-cf-border: #27272a; /* zinc-800 */
 
@@ -80,7 +81,7 @@
 
 html,
 body {
-  background: var(--color-cf-bg-100);
+  background: var(--color-cf-bg);
   color: var(--color-cf-text);
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;

--- a/src/app/watches/LogReadingForm.tsx
+++ b/src/app/watches/LogReadingForm.tsx
@@ -96,14 +96,14 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
     <form
       onSubmit={handleSubmit}
       noValidate
-      className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5"
+      className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5"
     >
       <h2 className="mb-4 text-sm font-medium text-cf-text">Log a reading</h2>
 
       {error ? (
         <p
           role="alert"
-          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="mb-4 rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {error}
         </p>
@@ -129,10 +129,10 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
             disabled={isBaseline || submitting}
             placeholder="e.g. 2.5 or -1.3"
             aria-invalid={!!fieldErrors.deviation_seconds}
-            className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-mono text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-orange focus:outline-none disabled:opacity-60"
+            className="w-full rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-mono text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-accent focus:outline-none disabled:opacity-60"
           />
           {fieldErrors.deviation_seconds ? (
-            <span className="mt-1 block text-xs text-cf-orange">
+            <span className="mt-1 block text-xs text-cf-accent">
               {fieldErrors.deviation_seconds}
             </span>
           ) : null}
@@ -145,7 +145,7 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
             value={refInput}
             onChange={(e) => setRefInput(e.target.value)}
             disabled={submitting}
-            className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-mono text-sm text-cf-text focus:border-cf-orange focus:outline-none disabled:opacity-60"
+            className="w-full rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-mono text-sm text-cf-text focus:border-cf-accent focus:outline-none disabled:opacity-60"
           />
         </label>
       </div>
@@ -156,7 +156,7 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
           checked={isBaseline}
           onChange={(e) => setIsBaseline(e.target.checked)}
           disabled={submitting}
-          className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-orange focus:ring-cf-orange"
+          className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-accent focus:ring-cf-accent"
         />
         <span>
           <span className="text-cf-text">This is a baseline</span>
@@ -174,7 +174,7 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
           disabled={submitting}
           rows={2}
           maxLength={500}
-          className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-orange focus:outline-none disabled:opacity-60"
+          className="w-full rounded-md border border-cf-border bg-cf-bg px-3 py-2 text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-accent focus:outline-none disabled:opacity-60"
           placeholder="e.g. worn overnight face-up, 20ºC"
         />
       </label>
@@ -182,7 +182,7 @@ export function LogReadingForm({ watchId, onLogged }: Props) {
       <button
         type="submit"
         disabled={submitting}
-        className="inline-flex items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-2.5 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90 disabled:opacity-60"
+        className="inline-flex items-center justify-center rounded-full border border-cf-accent bg-cf-accent px-5 py-2.5 text-sm font-medium text-cf-bg transition-colors hover:bg-cf-accent/90 disabled:opacity-60"
       >
         {submitting ? "Logging…" : "Log reading"}
       </button>

--- a/src/app/watches/MovementTypeahead.tsx
+++ b/src/app/watches/MovementTypeahead.tsx
@@ -120,11 +120,11 @@ export function MovementTypeahead({
       <label htmlFor={inputId}>{label}</label>
 
       {selection ? (
-        <div className="flex items-center gap-2 rounded-md border border-cf-border bg-cf-bg-200 px-3 py-2">
+        <div className="flex items-center gap-2 rounded-md border border-cf-border bg-cf-surface px-3 py-2">
           <span className="flex-1 text-cf-text">
             {selection.canonical_name}
             {selection.status === "pending" ? (
-              <span className="ml-2 rounded-full bg-cf-orange/20 px-2 py-0.5 text-xs text-cf-orange">
+              <span className="ml-2 rounded-full bg-cf-accent/20 px-2 py-0.5 text-xs text-cf-accent">
                 Pending approval
               </span>
             ) : null}
@@ -132,7 +132,7 @@ export function MovementTypeahead({
           <button
             type="button"
             onClick={handleClear}
-            className="text-xs text-cf-orange hover:underline"
+            className="text-xs text-cf-accent hover:underline"
           >
             Change
           </button>
@@ -160,13 +160,13 @@ export function MovementTypeahead({
             placeholder="Search calibers — e.g. ETA 2892-A2"
             aria-invalid={errorMessage ? true : undefined}
             aria-describedby={errorMessage ? `${inputId}-error` : undefined}
-            className="w-full rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="w-full rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
 
           {open && query.trim().length > 0 ? (
             <ul
               role="listbox"
-              className="absolute left-0 right-0 top-full z-10 mt-1 max-h-72 overflow-auto rounded-md border border-cf-border bg-cf-bg-100 shadow-lg"
+              className="absolute left-0 right-0 top-full z-10 mt-1 max-h-72 overflow-auto rounded-md border border-cf-border bg-cf-bg shadow-lg"
             >
               {loading ? (
                 <li className="px-3 py-2 text-sm text-cf-text-muted">Searching…</li>
@@ -180,7 +180,7 @@ export function MovementTypeahead({
                       setSubmitOpen(true);
                       setOpen(false);
                     }}
-                    className="text-cf-orange hover:underline"
+                    className="text-cf-accent hover:underline"
                   >
                     Can&rsquo;t find it? Submit new movement
                   </button>
@@ -198,7 +198,7 @@ export function MovementTypeahead({
                           event.preventDefault();
                           handleSelect(option);
                         }}
-                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-bg-200"
+                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-surface"
                       >
                         <span className="font-sans text-base text-cf-text">
                           {option.canonical_name}
@@ -210,7 +210,7 @@ export function MovementTypeahead({
                     </li>
                   ))}
                   {suggestions.length > 0 ? (
-                    <li className="border-t border-cf-border bg-cf-bg-200 px-3 py-1 text-xs font-medium uppercase tracking-wide text-cf-text-muted">
+                    <li className="border-t border-cf-border bg-cf-surface px-3 py-1 text-xs font-medium uppercase tracking-wide text-cf-text-muted">
                       Your pending submissions
                     </li>
                   ) : null}
@@ -222,11 +222,11 @@ export function MovementTypeahead({
                           event.preventDefault();
                           handleSelect(option);
                         }}
-                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-bg-200"
+                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-cf-surface"
                       >
                         <span className="font-sans text-base text-cf-text">
                           {option.canonical_name}
-                          <span className="ml-2 rounded-full bg-cf-orange/20 px-2 py-0.5 text-xs text-cf-orange">
+                          <span className="ml-2 rounded-full bg-cf-accent/20 px-2 py-0.5 text-xs text-cf-accent">
                             Pending
                           </span>
                         </span>
@@ -244,7 +244,7 @@ export function MovementTypeahead({
                         setSubmitOpen(true);
                         setOpen(false);
                       }}
-                      className="text-cf-orange hover:underline"
+                      className="text-cf-accent hover:underline"
                     >
                       Can&rsquo;t find it? Submit new movement
                     </button>
@@ -267,7 +267,7 @@ export function MovementTypeahead({
       {submitNotice ? (
         <p
           role="status"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {submitNotice.kind === "created" ? (
             <>
@@ -284,7 +284,7 @@ export function MovementTypeahead({
       ) : null}
 
       {errorMessage ? (
-        <span id={`${inputId}-error`} role="alert" className="text-sm text-cf-orange">
+        <span id={`${inputId}-error`} role="alert" className="text-sm text-cf-accent">
           {errorMessage}
         </span>
       ) : (

--- a/src/app/watches/ReadingList.tsx
+++ b/src/app/watches/ReadingList.tsx
@@ -65,13 +65,13 @@ export function ReadingList({ readings, perInterval, onDeleted }: Props) {
   }
 
   return (
-    <div className="mb-6 overflow-hidden rounded-lg border border-cf-border bg-cf-bg-200">
+    <div className="mb-6 overflow-hidden rounded-lg border border-cf-border bg-cf-surface">
       <div className="border-b border-cf-border px-5 py-3 text-sm font-medium text-cf-text">
         Reading log
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-cf-bg-100 text-left text-xs uppercase tracking-wide text-cf-text-subtle">
+          <thead className="bg-cf-bg text-left text-xs uppercase tracking-wide text-cf-text-subtle">
             <tr>
               <th className="px-4 py-2">Reference time</th>
               <th className="px-4 py-2">Deviation</th>
@@ -92,7 +92,7 @@ export function ReadingList({ readings, perInterval, onDeleted }: Props) {
                   <td className="px-4 py-3 font-mono text-xs text-cf-text">
                     {formatTime(r.reference_timestamp)}
                     {r.is_baseline ? (
-                      <span className="ml-2 rounded-full border border-cf-orange/40 bg-cf-orange/10 px-1.5 py-0.5 text-[10px] font-medium text-cf-orange">
+                      <span className="ml-2 rounded-full border border-cf-accent/40 bg-cf-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-cf-accent">
                         baseline
                       </span>
                     ) : null}
@@ -114,7 +114,7 @@ export function ReadingList({ readings, perInterval, onDeleted }: Props) {
                       type="button"
                       onClick={() => handleDelete(r.id)}
                       disabled={deletingId === r.id}
-                      className="text-xs text-cf-text-muted transition-colors hover:text-cf-orange disabled:opacity-60"
+                      className="text-xs text-cf-text-muted transition-colors hover:text-cf-accent disabled:opacity-60"
                     >
                       {deletingId === r.id ? "Deleting…" : "Delete"}
                     </button>

--- a/src/app/watches/SessionStatsPanel.tsx
+++ b/src/app/watches/SessionStatsPanel.tsx
@@ -5,7 +5,7 @@
 // Design rules (AGENTS.md):
 //   * Hide avg_drift when reading_count < 2 (no drift computable yet).
 //   * Show eligibility + verified-badge as chips. Tone stays neutral
-//     while the watch is ineligible; warm CF orange when a milestone
+//     while the watch is ineligible; accent color when a milestone
 //     is hit.
 
 import type { SessionStats } from "./readings";
@@ -37,7 +37,7 @@ function formatDeviation(secs: number): string {
 export function SessionStatsPanel({ stats }: Props) {
   if (!stats || stats.reading_count === 0) {
     return (
-      <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 px-5 py-4 text-sm text-cf-text-muted">
+      <div className="mb-6 rounded-lg border border-cf-border bg-cf-surface px-5 py-4 text-sm text-cf-text-muted">
         <p className="mb-1 font-medium text-cf-text">No readings yet</p>
         <p>
           Log your first reading below. Mark it as a baseline to start a tracking session.
@@ -52,25 +52,25 @@ export function SessionStatsPanel({ stats }: Props) {
   const showAvgDrift = stats.reading_count >= 2 && stats.avg_drift_rate_spd !== null;
 
   return (
-    <div className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5">
+    <div className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5">
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <h2 className="mr-2 text-sm font-medium text-cf-text">
           {hasSession ? "Current session" : "Readings logged"}
         </h2>
         {hasSession && stats.eligible ? (
-          <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2.5 py-0.5 text-xs font-medium text-cf-orange">
+          <span className="rounded-full border border-cf-accent/40 bg-cf-accent/10 px-2.5 py-0.5 text-xs font-medium text-cf-accent">
             Eligible
           </span>
         ) : hasSession ? (
           <span
-            className="rounded-full border border-cf-border bg-cf-bg-100 px-2.5 py-0.5 text-xs font-medium text-cf-text-muted"
+            className="rounded-full border border-cf-border bg-cf-bg px-2.5 py-0.5 text-xs font-medium text-cf-text-muted"
             title="Eligible for ranking after 7 days and 3 readings"
           >
             Not eligible yet
           </span>
         ) : null}
         {stats.verified_badge ? (
-          <span className="rounded-full border border-cf-orange/40 bg-cf-orange/10 px-2.5 py-0.5 text-xs font-medium text-cf-orange">
+          <span className="rounded-full border border-cf-accent/40 bg-cf-accent/10 px-2.5 py-0.5 text-xs font-medium text-cf-accent">
             Verified
           </span>
         ) : null}

--- a/src/app/watches/SubmitMovementSubForm.tsx
+++ b/src/app/watches/SubmitMovementSubForm.tsx
@@ -101,7 +101,7 @@ export function SubmitMovementSubForm({
 
   return (
     <form
-      className="mt-2 flex flex-col gap-3 rounded-md border border-cf-border bg-cf-bg-200 p-4 text-sm"
+      className="mt-2 flex flex-col gap-3 rounded-md border border-cf-border bg-cf-surface p-4 text-sm"
       onSubmit={handleSubmit}
       noValidate
     >
@@ -120,10 +120,10 @@ export function SubmitMovementSubForm({
           onChange={(event) => setCanonicalName(event.target.value)}
           placeholder="e.g. Seiko NH36A"
           aria-invalid={fieldErrors.canonical_name ? true : undefined}
-          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
         />
         {fieldErrors.canonical_name ? (
-          <span role="alert" className="text-sm text-cf-orange">
+          <span role="alert" className="text-sm text-cf-accent">
             {fieldErrors.canonical_name}
           </span>
         ) : null}
@@ -140,10 +140,10 @@ export function SubmitMovementSubForm({
             onChange={(event) => setManufacturer(event.target.value)}
             placeholder="e.g. Seiko"
             aria-invalid={fieldErrors.manufacturer ? true : undefined}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
           {fieldErrors.manufacturer ? (
-            <span role="alert" className="text-sm text-cf-orange">
+            <span role="alert" className="text-sm text-cf-accent">
               {fieldErrors.manufacturer}
             </span>
           ) : null}
@@ -158,10 +158,10 @@ export function SubmitMovementSubForm({
             onChange={(event) => setCaliber(event.target.value)}
             placeholder="e.g. NH36A"
             aria-invalid={fieldErrors.caliber ? true : undefined}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
           {fieldErrors.caliber ? (
-            <span role="alert" className="text-sm text-cf-orange">
+            <span role="alert" className="text-sm text-cf-accent">
               {fieldErrors.caliber}
             </span>
           ) : null}
@@ -174,7 +174,7 @@ export function SubmitMovementSubForm({
           value={type}
           onChange={(event) => setType(event.target.value as MovementType)}
           aria-invalid={fieldErrors.type ? true : undefined}
-          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
         >
           {TYPE_OPTIONS.map((option) => (
             <option key={option.value} value={option.value}>
@@ -183,7 +183,7 @@ export function SubmitMovementSubForm({
           ))}
         </select>
         {fieldErrors.type ? (
-          <span role="alert" className="text-sm text-cf-orange">
+          <span role="alert" className="text-sm text-cf-accent">
             {fieldErrors.type}
           </span>
         ) : null}
@@ -198,10 +198,10 @@ export function SubmitMovementSubForm({
           onChange={(event) => setNotes(event.target.value)}
           placeholder="Where did you learn about this caliber? Any references?"
           aria-invalid={fieldErrors.notes ? true : undefined}
-          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
         />
         {fieldErrors.notes ? (
-          <span role="alert" className="text-sm text-cf-orange">
+          <span role="alert" className="text-sm text-cf-accent">
             {fieldErrors.notes}
           </span>
         ) : null}
@@ -210,7 +210,7 @@ export function SubmitMovementSubForm({
       {formError ? (
         <p
           role="alert"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-cf-text"
         >
           {formError}
         </p>
@@ -220,7 +220,7 @@ export function SubmitMovementSubForm({
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex items-center justify-center rounded-full bg-cf-orange px-5 py-2 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full bg-cf-accent px-5 py-2 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover disabled:opacity-60"
         >
           {submitting ? "Submitting…" : "Submit movement"}
         </button>

--- a/src/app/watches/VerifiedProgressRing.tsx
+++ b/src/app/watches/VerifiedProgressRing.tsx
@@ -94,7 +94,7 @@ export function VerifiedProgressRing({
           cy={size / 2}
           r={radius}
           fill="none"
-          className={earned ? "stroke-cf-orange" : "stroke-cf-orange/80"}
+          className={earned ? "stroke-cf-accent" : "stroke-cf-accent/80"}
           strokeWidth={strokeWidth}
           strokeLinecap="round"
           strokeDasharray={`${dashLength} ${dashGap}`}

--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -184,7 +184,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
   return (
     <section
       aria-label="Verified reading"
-      className="mb-6 rounded-lg border border-cf-border bg-cf-bg-200 p-5"
+      className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5"
     >
       <h2 className="mb-1 text-sm font-medium text-cf-text">Log a verified reading</h2>
       <p className="mb-4 text-xs text-cf-text-muted">
@@ -213,7 +213,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
           <button
             type="button"
             onClick={openFilePicker}
-            className="inline-flex w-full items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-3 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90 sm:w-auto"
+            className="inline-flex w-full items-center justify-center rounded-full border border-cf-accent bg-cf-accent px-5 py-3 text-sm font-medium text-cf-bg transition-colors hover:bg-cf-accent/90 sm:w-auto"
           >
             Take photo
           </button>
@@ -235,7 +235,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
       {state.kind === "error" ? (
         <p
           role="alert"
-          className="mb-4 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="mb-4 rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {state.message}
         </p>
@@ -248,7 +248,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
               type="checkbox"
               checked={isBaseline}
               onChange={(e) => setIsBaseline(e.target.checked)}
-              className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-orange focus:ring-cf-orange"
+              className="mt-0.5 h-4 w-4 rounded border-cf-border text-cf-accent focus:ring-cf-accent"
             />
             <span>
               <span className="text-cf-text">This is a baseline</span>
@@ -262,7 +262,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
             <button
               type="button"
               onClick={handleSubmit}
-              className="inline-flex items-center justify-center rounded-full border border-cf-orange bg-cf-orange px-5 py-2.5 text-sm font-medium text-cf-bg-100 transition-colors hover:bg-cf-orange/90"
+              className="inline-flex items-center justify-center rounded-full border border-cf-accent bg-cf-accent px-5 py-2.5 text-sm font-medium text-cf-bg transition-colors hover:bg-cf-accent/90"
             >
               Submit verified reading
             </button>
@@ -281,7 +281,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
         <p className="flex items-center gap-2 text-sm text-cf-text-muted">
           <span
             aria-hidden="true"
-            className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-cf-orange border-t-transparent"
+            className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-cf-accent border-t-transparent"
           />
           Reading the dial…
         </p>
@@ -290,15 +290,15 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
       {showSuccess ? (
         <div
           role="status"
-          className="rounded-md border border-cf-orange/30 bg-cf-bg-100 px-4 py-3"
+          className="rounded-md border border-cf-accent/30 bg-cf-bg px-4 py-3"
         >
           <p className="text-sm text-cf-text">
             Saved. Dial read at{" "}
-            <span className="font-mono text-cf-orange">
+            <span className="font-mono text-cf-accent">
               {formatDialTime(state.reading)}
             </span>
             , deviation{" "}
-            <span className="font-mono text-cf-orange">
+            <span className="font-mono text-cf-accent">
               {formatDeviation(state.reading.deviation_seconds)}
             </span>
             .
@@ -306,7 +306,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
           <button
             type="button"
             onClick={handleCancelOrReset}
-            className="mt-3 inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-4 py-2 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange"
+            className="mt-3 inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-4 py-2 text-sm font-medium text-cf-text transition-colors hover:border-cf-accent hover:text-cf-accent"
           >
             Save another
           </button>

--- a/src/app/watches/WatchForm.tsx
+++ b/src/app/watches/WatchForm.tsx
@@ -99,10 +99,10 @@ export function WatchForm({
           value={values.name}
           onChange={(event) => update("name", event.target.value)}
           aria-invalid={fieldErrors.name ? true : undefined}
-          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
         />
         {fieldErrors.name ? (
-          <span role="alert" className="text-sm text-cf-orange">
+          <span role="alert" className="text-sm text-cf-accent">
             {fieldErrors.name}
           </span>
         ) : null}
@@ -117,10 +117,10 @@ export function WatchForm({
             value={values.brand}
             onChange={(event) => update("brand", event.target.value)}
             aria-invalid={fieldErrors.brand ? true : undefined}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
           {fieldErrors.brand ? (
-            <span role="alert" className="text-sm text-cf-orange">
+            <span role="alert" className="text-sm text-cf-accent">
               {fieldErrors.brand}
             </span>
           ) : null}
@@ -134,10 +134,10 @@ export function WatchForm({
             value={values.model}
             onChange={(event) => update("model", event.target.value)}
             aria-invalid={fieldErrors.model ? true : undefined}
-            className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+            className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
           />
           {fieldErrors.model ? (
-            <span role="alert" className="text-sm text-cf-orange">
+            <span role="alert" className="text-sm text-cf-accent">
               {fieldErrors.model}
             </span>
           ) : null}
@@ -159,10 +159,10 @@ export function WatchForm({
           value={values.notes}
           onChange={(event) => update("notes", event.target.value)}
           aria-invalid={fieldErrors.notes ? true : undefined}
-          className="rounded-md border border-cf-border bg-cf-bg-100 px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-orange"
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text outline-none focus:border-cf-accent"
         />
         {fieldErrors.notes ? (
-          <span role="alert" className="text-sm text-cf-orange">
+          <span role="alert" className="text-sm text-cf-accent">
             {fieldErrors.notes}
           </span>
         ) : null}
@@ -173,7 +173,7 @@ export function WatchForm({
           type="checkbox"
           checked={values.is_public}
           onChange={(event) => update("is_public", event.target.checked)}
-          className="h-4 w-4 rounded border-cf-border accent-cf-orange"
+          className="h-4 w-4 rounded border-cf-border accent-cf-accent"
         />
         Public — visible on leaderboards and your public profile
       </label>
@@ -181,7 +181,7 @@ export function WatchForm({
       {formError ? (
         <p
           role="alert"
-          className="rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {formError}
         </p>
@@ -191,7 +191,7 @@ export function WatchForm({
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex items-center justify-center rounded-full bg-cf-orange px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-orange-hover disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full bg-cf-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-cf-accent-hover disabled:opacity-60"
         >
           {submitting ? submittingLabel : submitLabel}
         </button>

--- a/src/app/watches/WatchPhotoPanel.tsx
+++ b/src/app/watches/WatchPhotoPanel.tsx
@@ -142,7 +142,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
   return (
     <section
       aria-label="Watch photo"
-      className="mb-8 rounded-lg border border-cf-border bg-cf-bg-200 p-4"
+      className="mb-8 rounded-lg border border-cf-border bg-cf-surface p-4"
     >
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-cf-text-muted">
         Photo
@@ -170,7 +170,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
       {error ? (
         <p
           role="alert"
-          className="mb-3 rounded-md border border-cf-orange/40 bg-cf-orange/10 px-3 py-2 text-sm text-cf-text"
+          className="mb-3 rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
         >
           {error}
         </p>
@@ -183,7 +183,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
             type="button"
             onClick={handleUpload}
             disabled={busy !== null}
-            className="inline-flex items-center justify-center rounded-full bg-cf-orange px-5 py-2.5 text-sm font-medium text-black transition-colors hover:bg-cf-orange/90 disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-full bg-cf-accent px-5 py-2.5 text-sm font-medium text-black transition-colors hover:bg-cf-accent/90 disabled:opacity-60"
           >
             {busy === "upload" ? "Uploading…" : "Upload photo"}
           </button>
@@ -212,9 +212,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
           onDragLeave={() => setDragActive(false)}
           onDrop={onDrop}
           className={`flex flex-wrap items-center gap-3 rounded-md border-2 border-dashed p-4 transition-colors ${
-            dragActive
-              ? "border-cf-orange bg-cf-orange/10"
-              : "border-cf-border bg-cf-bg-100"
+            dragActive ? "border-cf-accent bg-cf-accent/10" : "border-cf-border bg-cf-bg"
           }`}
         >
           <input
@@ -228,7 +226,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={busy !== null}
-            className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-orange hover:text-cf-orange disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-full border border-cf-border bg-transparent px-5 py-2.5 text-sm font-medium text-cf-text transition-colors hover:border-cf-accent hover:text-cf-accent disabled:opacity-60"
           >
             {imageKey ? "Replace photo" : "Choose photo"}
           </button>
@@ -240,7 +238,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
               type="button"
               onClick={handleDelete}
               disabled={busy !== null}
-              className="ml-auto inline-flex items-center justify-center rounded-full border border-cf-orange/40 bg-cf-orange/10 px-4 py-2 text-sm font-medium text-cf-orange transition-colors hover:border-cf-orange hover:bg-cf-orange/20 disabled:opacity-60"
+              className="ml-auto inline-flex items-center justify-center rounded-full border border-cf-accent/40 bg-cf-accent/10 px-4 py-2 text-sm font-medium text-cf-accent transition-colors hover:border-cf-accent hover:bg-cf-accent/20 disabled:opacity-60"
             >
               {busy === "delete" ? "Removing…" : "Remove photo"}
             </button>
@@ -257,7 +255,7 @@ function WatchSilhouette() {
   return (
     <div
       aria-hidden="true"
-      className="flex h-40 w-full max-w-xs items-center justify-center rounded-md border border-dashed border-cf-border bg-cf-bg-100 text-cf-text-subtle"
+      className="flex h-40 w-full max-w-xs items-center justify-center rounded-md border border-dashed border-cf-border bg-cf-bg text-cf-text-subtle"
     >
       <svg
         width="48"

--- a/src/public/components/button.tsx
+++ b/src/public/components/button.tsx
@@ -3,7 +3,7 @@
 // button (to be added under src/app/ui/ later).
 //
 // Two variants in slice 3:
-//   - "primary": orange fill, white text. CTAs.
+//   - "primary": accent fill, white text. CTAs.
 //   - "ghost":   border + muted text. Secondary actions.
 //
 // The `as` prop lets the same styling apply to <a>, so link-buttons on the

--- a/src/public/components/layout.tsx
+++ b/src/public/components/layout.tsx
@@ -36,15 +36,15 @@ function DesignTokensStyle() {
   // tag with static CSS text is fine since no user data flows in here.
   const css = `
 :root {
-  --cf-orange: ${l.orange};
-  --cf-orange-hover: ${l.orangeHover};
+  --cf-accent: ${l.accent};
+  --cf-accent-hover: ${l.accentHover};
   --cf-text: ${l.text};
   --cf-text-muted: ${l.textMuted};
   --cf-text-subtle: ${l.textSubtle};
-  --cf-bg-page: ${l.bgPage};
-  --cf-bg-100: ${l.bg100};
-  --cf-bg-200: ${l.bg200};
-  --cf-bg-300: ${l.bg300};
+  --cf-shell: ${l.shell};
+  --cf-bg: ${l.bg};
+  --cf-surface: ${l.surface};
+  --cf-surface-inset: ${l.surfaceInset};
   --cf-border: ${l.border};
   --cf-border-light: ${l.borderLight};
   --cf-font-sans: ${tokens.font.sans};
@@ -59,15 +59,15 @@ function DesignTokensStyle() {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --cf-orange: ${d.orange};
-    --cf-orange-hover: ${d.orangeHover};
+    --cf-accent: ${d.accent};
+    --cf-accent-hover: ${d.accentHover};
     --cf-text: ${d.text};
     --cf-text-muted: ${d.textMuted};
     --cf-text-subtle: ${d.textSubtle};
-    --cf-bg-page: ${d.bgPage};
-    --cf-bg-100: ${d.bg100};
-    --cf-bg-200: ${d.bg200};
-    --cf-bg-300: ${d.bg300};
+    --cf-shell: ${d.shell};
+    --cf-bg: ${d.bg};
+    --cf-surface: ${d.surface};
+    --cf-surface-inset: ${d.surfaceInset};
     --cf-border: ${d.border};
     --cf-border-light: ${d.borderLight};
     color-scheme: dark;
@@ -81,7 +81,7 @@ function DesignTokensStyle() {
 html, body {
   margin: 0;
   padding: 0;
-  background: var(--cf-bg-100);
+  background: var(--cf-bg);
   color: var(--cf-text);
   font-family: var(--cf-font-sans);
   font-size: 16px;
@@ -93,14 +93,14 @@ html, body {
 }
 
 a {
-  color: var(--cf-orange);
+  color: var(--cf-accent);
   text-decoration: none;
   transition: color 0.15s ease;
 }
-a:hover { color: var(--cf-orange-hover); }
+a:hover { color: var(--cf-accent-hover); }
 
 :focus-visible {
-  outline: 2px solid var(--cf-orange);
+  outline: 2px solid var(--cf-accent);
   outline-offset: 2px;
   border-radius: var(--cf-radius-sm);
 }
@@ -136,7 +136,7 @@ a:hover { color: var(--cf-orange-hover); }
 
 .cf-card {
   position: relative;
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-lg);
   padding: 24px;
@@ -165,7 +165,7 @@ a:hover { color: var(--cf-orange-hover); }
   position: absolute;
   width: 8px;
   height: 8px;
-  background: var(--cf-bg-100);
+  background: var(--cf-bg);
   border: 1px solid var(--cf-border);
   border-radius: 1.5px;
 }
@@ -192,24 +192,24 @@ a:hover { color: var(--cf-orange-hover); }
               border-color 0.16s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 .cf-btn--primary {
-  background: var(--cf-orange);
+  background: var(--cf-accent);
   color: #FFFBF5;
 }
-.cf-btn--primary:hover { background: var(--cf-orange-hover); color: #FFFBF5; }
+.cf-btn--primary:hover { background: var(--cf-accent-hover); color: #FFFBF5; }
 .cf-btn--ghost {
   background: transparent;
   color: var(--cf-text);
   border-color: var(--cf-border);
 }
 .cf-btn--ghost:hover {
-  background: var(--cf-bg-300);
+  background: var(--cf-surface-inset);
   color: var(--cf-text);
 }
 
 .cf-header {
   border-bottom: 1px solid var(--cf-border);
   padding: 16px 0;
-  background: var(--cf-bg-100);
+  background: var(--cf-bg);
 }
 .cf-header__inner {
   display: flex;
@@ -224,7 +224,7 @@ a:hover { color: var(--cf-orange-hover); }
   color: var(--cf-text);
   font-weight: 500;
 }
-.cf-logo__accent { color: var(--cf-orange); }
+.cf-logo__accent { color: var(--cf-accent); }
 
 .cf-nav {
   display: flex;
@@ -274,12 +274,12 @@ export const Layout = ({ title, description, pathname, children }: LayoutProps) 
             schemes. Tests assert both tags are present. */}
         <meta
           name="theme-color"
-          content={tokens.light.bg100}
+          content={tokens.light.bg}
           media="(prefers-color-scheme: light)"
         />
         <meta
           name="theme-color"
-          content={tokens.dark.bg100}
+          content={tokens.dark.bg}
           media="(prefers-color-scheme: dark)"
         />
 

--- a/src/public/components/tokens.ts
+++ b/src/public/components/tokens.ts
@@ -1,10 +1,12 @@
 // Design tokens — single source of truth for palette, radii,
 // typography, and motion used by both the public SSR pages and the SPA.
 //
-// Palette v3: cool-neutral zinc family, no warm accent. Token names
-// still reference "orange" for minimum repo churn — actual hex values
-// are zinc-family (mid-charcoal CTA light / near-white CTA dark).
-// Semantic rename (orange → accent) is a followup.
+// Palette v3: cool-neutral zinc family, no warm accent. Names are
+// semantic (`accent`, `bg`, `surface`, `surfaceInset`, `shell`) and
+// deliberately avoid hue-based labels — the actual hex values are
+// zinc-family (mid-charcoal CTA light / near-white CTA dark). A
+// historical rename from `orange`/`bg100-300`/`bgPage` to these
+// semantic names happened in one commit — see git blame on this file.
 //
 // The matching CSS custom properties are emitted by
 // <DesignTokensStyle /> in `layout.tsx` (public SSR) and by the
@@ -13,28 +15,28 @@
 
 export const tokens = {
   light: {
-    orange: "#3F3F46", // zinc-700, primary CTA
-    orangeHover: "#27272A", // zinc-800
+    accent: "#3F3F46", // zinc-700, primary CTA
+    accentHover: "#27272A", // zinc-800
     text: "#18181B", // zinc-900
     textMuted: "#71717A", // zinc-500
     textSubtle: "#A1A1AA", // zinc-400
-    bgPage: "#F4F4F5", // zinc-100, outer shell
-    bg100: "#FAFAFA", // zinc-50, main content
-    bg200: "#FFFFFF", // pure white, cards
-    bg300: "#F4F4F5", // zinc-100, inset
+    shell: "#F4F4F5", // zinc-100, outer shell
+    bg: "#FAFAFA", // zinc-50, main content
+    surface: "#FFFFFF", // pure white, cards
+    surfaceInset: "#F4F4F5", // zinc-100, inset
     border: "#E4E4E7", // zinc-200
     borderLight: "rgba(228, 228, 231, 0.5)",
   },
   dark: {
-    orange: "#E4E4E7", // zinc-200, CTA inverted
-    orangeHover: "#FAFAFA", // zinc-50
+    accent: "#E4E4E7", // zinc-200, CTA inverted
+    accentHover: "#FAFAFA", // zinc-50
     text: "#FAFAFA", // zinc-50
     textMuted: "#A1A1AA", // zinc-400
     textSubtle: "#71717A", // zinc-500
-    bgPage: "#000000", // full black outer shell
-    bg100: "#09090B", // zinc-950, page
-    bg200: "#18181B", // zinc-900, cards
-    bg300: "#27272A", // zinc-800, inset
+    shell: "#000000", // full black outer shell
+    bg: "#09090B", // zinc-950, page
+    surface: "#18181B", // zinc-900, cards
+    surfaceInset: "#27272A", // zinc-800, inset
     border: "#27272A", // zinc-800
     borderLight: "rgba(39, 39, 42, 0.5)",
   },

--- a/src/public/leaderboard/table.tsx
+++ b/src/public/leaderboard/table.tsx
@@ -183,14 +183,14 @@ export function LeaderboardStyles() {
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-full);
 }
-.cf-lb-filters a:hover { color: var(--cf-text); background: var(--cf-bg-300); }
+.cf-lb-filters a:hover { color: var(--cf-text); background: var(--cf-surface-inset); }
 .cf-lb-filter--active {
   color: var(--cf-text) !important;
-  border-color: var(--cf-orange) !important;
-  background: var(--cf-bg-200);
+  border-color: var(--cf-accent) !important;
+  background: var(--cf-surface);
 }
 .cf-lb-filter__check {
-  color: var(--cf-orange);
+  color: var(--cf-accent);
   font-weight: 700;
 }
 
@@ -231,7 +231,7 @@ export function LeaderboardStyles() {
   gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
-  background: var(--cf-orange);
+  background: var(--cf-accent);
   color: #FFFBF5;
   font-size: 0.75rem;
   font-weight: 500;
@@ -251,7 +251,7 @@ export function LeaderboardStyles() {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--cf-orange);
+  background: var(--cf-accent);
   vertical-align: middle;
   margin: 0 4px;
 }

--- a/src/public/user/page.tsx
+++ b/src/public/user/page.tsx
@@ -178,7 +178,7 @@ function UserPageStyles() {
 }
 .cf-user-meta code {
   font-family: var(--cf-font-mono);
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   padding: 1px 6px;
   border-radius: var(--cf-radius-sm);
 }
@@ -198,7 +198,7 @@ function UserPageStyles() {
 .cf-user-card {
   position: relative;
   display: block;
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-lg);
   padding: 24px;
@@ -206,8 +206,8 @@ function UserPageStyles() {
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .cf-user-card:hover {
-  border-color: var(--cf-orange);
-  background: var(--cf-bg-300);
+  border-color: var(--cf-accent);
+  background: var(--cf-surface-inset);
   color: var(--cf-text);
 }
 .cf-user-card__title {
@@ -222,7 +222,7 @@ function UserPageStyles() {
   margin-bottom: 16px;
 }
 .cf-user-card__movement a { color: inherit; }
-.cf-user-card__movement a:hover { color: var(--cf-orange); }
+.cf-user-card__movement a:hover { color: var(--cf-accent); }
 
 .cf-user-card__stats {
   display: grid;
@@ -250,7 +250,7 @@ function UserPageStyles() {
   gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
-  background: var(--cf-orange);
+  background: var(--cf-accent);
   color: #FFFBF5;
   font-size: 0.75rem;
   font-weight: 500;

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -318,7 +318,7 @@ function WatchPageStyles() {
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-lg);
   overflow: hidden;
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
@@ -336,7 +336,7 @@ function WatchPageStyles() {
   gap: 16px;
   margin: 0;
   padding: 24px;
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-lg);
 }
@@ -360,7 +360,7 @@ function WatchPageStyles() {
 .cf-deviation-chart {
   width: 100%;
   height: auto;
-  background: var(--cf-bg-200);
+  background: var(--cf-surface);
   border: 1px solid var(--cf-border);
   border-radius: var(--cf-radius-lg);
 }
@@ -369,16 +369,16 @@ function WatchPageStyles() {
   stroke-width: 1;
 }
 .cf-deviation-chart__line {
-  stroke: var(--cf-orange);
+  stroke: var(--cf-accent);
   stroke-width: 2;
 }
 .cf-deviation-chart__dot {
-  fill: var(--cf-orange);
-  stroke: var(--cf-bg-200);
+  fill: var(--cf-accent);
+  stroke: var(--cf-surface);
   stroke-width: 1;
 }
 .cf-deviation-chart__dot--verified {
-  fill: var(--cf-orange-hover);
+  fill: var(--cf-accent-hover);
   stroke-width: 2;
 }
 
@@ -414,7 +414,7 @@ function WatchPageStyles() {
   gap: 4px;
   padding: 3px 10px;
   border-radius: var(--cf-radius-full);
-  background: var(--cf-orange);
+  background: var(--cf-accent);
   color: #FFFBF5;
   font-size: 0.75rem;
   font-weight: 500;

--- a/tests/e2e/auth.smoke.test.ts
+++ b/tests/e2e/auth.smoke.test.ts
@@ -38,7 +38,7 @@ test("register → redirects to dashboard → shows slug username", async ({ pag
   // Expect the post-register redirect. `waitForURL` is a hard assertion.
   await page.waitForURL("**/app/dashboard", { timeout: 15_000 });
 
-  // Dashboard shows `Logged in as @<slug>`. `.text-cf-orange` is the
+  // Dashboard shows `Logged in as @<slug>`. `.text-cf-accent` is the
   // span wrapping the slug; grab it by the on-screen copy so we're not
   // coupled to CSS.
   const loggedInLine = page.getByText(/^Logged in as @/);

--- a/tests/integration/spa-shell.test.ts
+++ b/tests/integration/spa-shell.test.ts
@@ -62,8 +62,8 @@ describe("SPA shell — /app/*", () => {
     // Canonical palette hex values — asserted via the @theme tokens
     // registered in src/app/styles.css. If someone regresses the theme
     // block or drops the import, this fires.
-    // Palette v3 (cool-neutral zinc). Token names still reference
-    // "orange" but the hex values are zinc-family.
+    // Palette v3 (cool-neutral zinc). Token names are semantic
+    // (`cf-accent`, `cf-bg`, …); hex values are zinc-family.
     expect(css).toContain("#3f3f46"); // CTA accent (zinc-700, light)
     expect(css).toContain("#fafafa"); // page bg (zinc-50, light)
     expect(css).toContain("#09090b"); // page bg (zinc-950, dark)


### PR DESCRIPTION
## Summary

After palette v3 (#51) swapped the hex values to a cool-neutral zinc scale, the old token names became lies — `cf-orange` is no longer orange (it's zinc-700 light / zinc-200 dark charcoal), `cf-bg-100/200/300` don't describe what they are (page / card / inset). Rename to semantic names so the code stops misdirecting readers.

**Hex values are unchanged.** This is a pure rename.

## Mapping

| Old | New | Meaning |
|---|---|---|
| `cf-orange` | `cf-accent` | Primary CTA color |
| `cf-orange-hover` | `cf-accent-hover` | CTA hover state |
| `cf-bg-100` | `cf-bg` | Main page background |
| `cf-bg-200` | `cf-surface` | Lifted card surface |
| `cf-bg-300` | `cf-surface-inset` | Inset areas (stats panels, input fills) |
| `cf-bg-page` | `cf-shell` | Outer shell background |
| `cf-text`, `cf-text-muted`, `cf-text-subtle`, `cf-border` | unchanged | already semantic |

## What was touched

- **`src/app/styles.css`** — renamed every `--color-cf-*` custom property in the `@theme` block, dark-mode override, and `html, body { background: ... }` at the bottom. Also freshened the file header comment which still promised a "future cleanup" to rename these.
- **`src/public/components/tokens.ts`** — renamed the object keys (`orange → accent`, `orangeHover → accentHover`, `bg100 → bg`, `bg200 → surface`, `bg300 → surfaceInset`, `bgPage → shell`). TS literal-type inference from `as const` means callers type-check automatically. Added one explicit comment line noting the historical rename so `git blame` readers aren't confused.
- **`src/public/components/layout.tsx`** — updated the `<DesignTokensStyle />` inline CSS template to emit the new `--cf-*` custom property names; updated the `:root` → `@media dark` overrides; updated every `var(--cf-*)` reference in the built-in component CSS (`.cf-btn`, `.cf-card`, `.cf-brackets`, `.cf-logo__accent`, etc.); updated the `<meta name="theme-color" content={tokens.light.bg}>` / dark variant to use the new `.bg` key.
- **All `.tsx` under `src/app/**` and `src/public/**`** — Tailwind utility class renames: `text-cf-orange` → `text-cf-accent`, `bg-cf-orange` → `bg-cf-accent`, `border-cf-orange` → `border-cf-accent`, `focus:ring-cf-orange` → `focus:ring-cf-accent`, `hover:bg-cf-orange-hover` → `hover:bg-cf-accent-hover`, `bg-cf-bg-100` → `bg-cf-bg`, `bg-cf-bg-200` → `bg-cf-surface`, `bg-cf-bg-300` → `bg-cf-surface-inset`, plus every opacity variant (`/10`, `/20`, `/40`, etc.).
- **Comments** — freshened prose in `src/public/components/button.tsx` ("orange fill" → "accent fill"), `src/app/watches/SessionStatsPanel.tsx` ("warm CF orange" → "accent color"), and `tests/integration/spa-shell.test.ts` (token-name note in the palette-hex assertion block).
- **`tests/e2e/auth.smoke.test.ts`** — single comment reference to `.text-cf-orange` updated to `.text-cf-accent`.

## Counts

- **27 files** changed: 1 CSS, 1 TS source (tokens), 1 TSX (layout), 18 SPA `.tsx`, 4 public `.tsx`, 2 test files.
- **+216 / −223** lines — mostly 1:1 rename; net reduction comes from the styles.css comment block being tightened.
- Zero behavioural changes. Zero hex changes. Zero new tokens.

## Verification

- `npm run typecheck` — clean on all three tsconfigs (Worker, SPA, E2E).
- `npm run build` — `dist/` rebuilds clean (19.14 kB CSS, 356.60 kB JS — within the usual range).
- `npm run test` — **352 / 352 tests passing** (unchanged count).
- `grep -rn 'cf-orange\|cf-bg-100\|cf-bg-200\|cf-bg-300\|cf-bg-page' src/ tests/` returns nothing.
- `grep -rn 'orange' src/ tests/` returns a single intentional comment in `tokens.ts` documenting the historical rename for future `git blame` readers.

## Gotchas

- `sed` ordering in the batch rename: `cf-orange-hover` had to be replaced before `cf-orange` to avoid producing `cf-accent-hover-hover`. Same care for `cf-bg-page` before `cf-bg-100/200/300`. Handled.
- `lint-staged` reformats on commit — noted in the dispatch brief; accepted as normal friction. The net diff is still a clean rename.

## Not in scope

- No hex value changes (palette v3 stays locked).
- No behaviour changes.
- No new tokens (e.g. no `cf-accent-subtle`, no `cf-bg-subtle`).
- `cf-text*` and `cf-border` were already semantic and untouched.

Closes the token-naming tidy-up on the design system.