### PR TITLE
infra: *.rated.watch wildcard subdomain route

### DIFF
--- a/infra/terraform/subdomain-wildcard.tf
+++ b/infra/terraform/subdomain-wildcard.tf
@@ -1,0 +1,37 @@
+# Wildcard subdomain routing for rated.watch.
+#
+# The apex rated.watch → ratedwatch Worker is handled by the Custom
+# Domain resource in workers-domain.tf. Subdomains (www.rated.watch,
+# api.rated.watch, etc.) need a different mechanism because Custom
+# Domains only accept an exact hostname, not a wildcard. Workers
+# Routes do accept wildcards — at the cost of losing the
+# Custom-Domain niceties (auto-managed TLS cert, implicit same-zone
+# fetch, etc.), which is an acceptable trade for catch-all subdomain
+# coverage.
+#
+# The DNS record below is a proxied A record at *.rated.watch
+# pointing at TEST-NET-1 (192.0.2.1 — RFC 5737 non-routable). The
+# content is irrelevant; Cloudflare's proxy layer short-circuits the
+# request and hands it to the Workers Route instead. This is a
+# standard "orange-cloud wildcard" pattern.
+
+resource "cloudflare_dns_record" "wildcard_subdomain" {
+  zone_id = var.zone_id
+  name    = "*.rated.watch"
+  type    = "A"
+  content = "192.0.2.1" # TEST-NET-1, RFC 5737 non-routable placeholder
+  proxied = true
+  ttl     = 1 # "auto" — required when proxied is true
+  comment = "Proxy-only placeholder; traffic routed by workers_route.wildcard_subdomain below"
+}
+
+resource "cloudflare_workers_route" "wildcard_subdomain" {
+  zone_id = var.zone_id
+  pattern = "*.rated.watch/*"
+  script  = var.worker_name
+}
+
+output "subdomain_wildcard_pattern" {
+  description = "Wildcard route pattern — any subdomain of rated.watch hits the Worker."
+  value       = cloudflare_workers_route.wildcard_subdomain.pattern
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,19 @@
   "compatibility_date": "2026-04-17",
   "compatibility_flags": ["nodejs_compat"],
 
+  // workers_dev is DELIBERATELY left at its default (true). An
+  // earlier attempt to flip it to false ([REVERTED commit in this
+  // same PR branch]) took down every pr-<N>-ratedwatch.*.workers.dev
+  // preview alias too — the flag is script-scoped, not
+  // version-scoped, so disabling the default hostname also kills
+  // the --preview-alias hostnames that CI relies on for E2E tests.
+  //
+  // Canonical URL is still rated.watch (via cloudflare_workers_
+  // custom_domain.apex + workers_route.wildcard_subdomain in
+  // infra/terraform/). Treat ratedwatch.nmoura.workers.dev as a
+  // fallback / admin-only hostname. If noindex matters later, add
+  // an X-Robots-Tag: noindex header on non-rated.watch hosts.
+
   // Workers Assets serves the Vite build output.
   //
   //  - The Worker owns `/` (SSR landing page), `/leaderboard` (SSR public


### PR DESCRIPTION
Adds wildcard subdomain routing for rated.watch — www, random, api, etc. subdomains now route to the ratedwatch Worker.

## What shipped

- `cloudflare_dns_record.wildcard_subdomain` — proxied A record at `*.rated.watch` pointing at 192.0.2.1 (RFC 5737 non-routable; Cloudflare proxy short-circuits it).
- `cloudflare_workers_route.wildcard_subdomain` — pattern `*.rated.watch/*` → ratedwatch Worker.

## Verified live

- https://rated.watch/ → 200
- https://www.rated.watch/ → 200
- https://random.rated.watch/leaderboard → 200
- https://ratedwatch.nmoura.workers.dev/ → 200 (unchanged)

## History note (for reviewers)

Initial version of this PR also included `workers_dev: false` in wrangler.jsonc + a two-step deploy script. That flag is SCRIPT-scoped and disables every workers.dev hostname including the `pr-<N>-*.workers.dev` aliases CI uses for E2E tests. Reverted within this PR — the comment block in wrangler.jsonc documents the reasoning so nobody re-attempts the same trap.