### PR TITLE
feat(ai): route Workers AI through a gateway + swap the dial reader to Kimi K2.6

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -2,18 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.18.0"
-  constraints = ">= 5.8.0, < 6.0.0"
+  version     = "5.19.0-beta.5"
+  constraints = "5.19.0-beta.5"
   hashes = [
-    "h1:2FKT5YVLuHLmv7BnFxDC3UtipD3hSSrb0iJ9Ei2C/ks=",
-    "zh:47e7bdfd8eddd2685f383269c0b6936ef62edd6d8383c8d7757b0cce0a689737",
-    "zh:aa23eb6aa128667883cabc449ceca4072d0181f574cd727e08ebd6d69a4bfd48",
-    "zh:c3da673e05d3bd933c82e2b6ba0f85aa23c5e24fadd3932f7c066314feeb65a3",
-    "zh:c59f07c017fc78b79e80554a0737c9db2a2e681c3e46ff637942d28d1f1a3924",
-    "zh:d559074612835a37fa684d8d7d0cf68911487b71f4067acc59069cb00bb8baf0",
-    "zh:e12290a4eda757c183a4258230245dd170f0def389c37eb771db144ce3b382dd",
-    "zh:ed47e484432ba1bbbb4802061f395ebd253ae8e20be9b72552d3d830fd2ca268",
-    "zh:f35e08d468408697b3e7c4a7f548b874141ac8f8d395ab8edded322201cc7047",
+    "h1:eFK5y52tCj3BbjFUG9jCeZXtFp+w7SziOWo1rfsz6Ck=",
+    "zh:2fd2a0a682e9ab6231a259f60c4fe9613cd48d8ce6127ff0b2ade4b57de931de",
+    "zh:34051a27c10af4e247bb79bc691b8ddfb70ac9f79bd322c9d6208f15f3f35f02",
+    "zh:37e84f04364c301b7070b9aa339a04ba08bce4696fbd3a9f529625439b5a24e0",
+    "zh:386479011c6a1ca077f3e219bae3f5cd20245dbacb1e979d33b06ac008619016",
+    "zh:42ed890163ab63a1fd2bbf2f95d851baaf490c916e7ca06cbdd2162476c37027",
+    "zh:9eb7ebe86fe5ac5646fc5d6301bea4a0d5f9417b19715e131da74b459bb7a905",
+    "zh:a30c8ee8b2deb1774b15e07f6ec297b7d5969caa51590305369abbb8888e318c",
+    "zh:f17aea344230e03abcc337f118284499ee00254fd7ae81ca21a1c435acde36a5",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/infra/terraform/ai-gateway.tf
+++ b/infra/terraform/ai-gateway.tf
@@ -1,0 +1,38 @@
+# AI Gateway in front of Workers AI.
+#
+# All `env.AI.run(...)` calls in the Worker pass
+# `{ gateway: { id: "ratedwatch" } }`, which routes inference through
+# this gateway. That gives us request/response logs, rate limiting,
+# and (later) cache + fallback policies without touching Worker code.
+#
+# Kept intentionally minimal for phase 1:
+#   * `cache_ttl = 0` + `cache_invalidate_on_update = false` — we
+#     explicitly don't want cache hits for dial reads. Every verified
+#     reading must go to the model; a cache hit would silently return
+#     the same second-hand position across photos.
+#   * `collect_logs = true` — operator wants visibility into
+#     prompt/response pairs for prompt-tuning the dial reader.
+#   * `rate_limiting_interval = 60 / limit = 1000 / technique = fixed`
+#     — defensive ceiling. Phase-1 traffic is a few requests per
+#     second at peak; 1000 per minute leaves generous headroom while
+#     still capping runaway bugs.
+#
+# The resource `id` ("ratedwatch") is the gateway *slug* — it appears
+# verbatim in `env.AI.run(..., { gateway: { id: "ratedwatch" } })`,
+# so keep this in sync with `AI_GATEWAY_ID` in
+# src/domain/ai-dial-reader/runner.ts.
+resource "cloudflare_ai_gateway" "ratedwatch" {
+  account_id                 = var.account_id
+  id                         = "ratedwatch"
+  cache_invalidate_on_update = false
+  cache_ttl                  = 0
+  collect_logs               = true
+  rate_limiting_interval     = 60
+  rate_limiting_limit        = 1000
+  rate_limiting_technique    = "fixed"
+}
+
+output "ai_gateway_id" {
+  description = "AI Gateway slug used by the Worker in env.AI.run({ gateway: { id } })."
+  value       = cloudflare_ai_gateway.ratedwatch.id
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -3,8 +3,13 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 5.8.0, < 6.0.0"
+      source = "cloudflare/cloudflare"
+      # 5.19.0-beta.5 is the first release that ships the
+      # `cloudflare_ai_gateway` resource (see
+      # infra/terraform/ai-gateway.tf). Terraform range constraints
+      # skip pre-releases, so the version is pinned exactly until a
+      # stable 5.19.x is cut — bump this line when that lands.
+      version = "5.19.0-beta.5"
     }
   }
 

--- a/src/domain/ai-dial-reader/reader.test.ts
+++ b/src/domain/ai-dial-reader/reader.test.ts
@@ -5,6 +5,12 @@ import { __setTestAiRunner, type AiRunner, type AiRunnerEnv } from "./runner";
 // These tests drive the reader through a fake AiRunner. No real AI
 // binding is ever invoked — the module-level `testRunner` override
 // (see runner.ts) redirects every call to the fake we install here.
+//
+// NOTE on the contract: the runner exposes `{ response: string }`
+// as its output, extracted from the underlying chat-completion.
+// These tests install fakes that return that flat shape directly,
+// so they exercise the reader's *parsing* logic independent of
+// whichever model the production runner is wired to.
 
 afterEach(() => {
   __setTestAiRunner(null);
@@ -26,26 +32,28 @@ function installFake(
 }
 
 describe("readDialTime", () => {
-  it("parses HH:MM:SS into {hours, minutes, seconds}", async () => {
-    installFake("14:32:07");
+  it("parses a single-digit seconds response", async () => {
+    installFake("7");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({
-      hours: 14,
-      minutes: 32,
-      seconds: 7,
-      raw_response: "14:32:07",
-    });
+    expect(result).toEqual({ seconds: 7, raw_response: "7" });
+  });
+
+  it("parses a two-digit seconds response", async () => {
+    installFake("42");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ seconds: 42, raw_response: "42" });
+  });
+
+  it("parses zero", async () => {
+    installFake("0");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ seconds: 0, raw_response: "0" });
   });
 
   it("trims surrounding whitespace before parsing", async () => {
-    installFake("   09:05:00  \n");
+    installFake("   15  \n");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({
-      hours: 9,
-      minutes: 5,
-      seconds: 0,
-      raw_response: "09:05:00",
-    });
+    expect(result).toEqual({ seconds: 15, raw_response: "15" });
   });
 
   it("returns refused for NO_DIAL", async () => {
@@ -61,12 +69,49 @@ describe("readDialTime", () => {
   });
 
   it("returns unparseable for prose responses", async () => {
-    installFake("The time appears to be 2:32 PM");
+    installFake("The second hand is at about 42");
     const result = await readDialTime(fakeImage, fakeEnv);
     expect("error" in result ? result.error : null).toBe("unparseable");
     if ("error" in result) {
-      expect(result.raw_response).toBe("The time appears to be 2:32 PM");
+      expect(result.raw_response).toBe("The second hand is at about 42");
     }
+  });
+
+  it("returns unparseable for non-numeric tokens", async () => {
+    installFake("banana");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect("error" in result ? result.error : null).toBe("unparseable");
+    if ("error" in result) {
+      expect(result.raw_response).toBe("banana");
+    }
+  });
+
+  it("returns implausible for an out-of-range integer (60)", async () => {
+    installFake("60");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ error: "implausible", raw_response: "60" });
+  });
+
+  it("returns implausible for an out-of-range integer (99)", async () => {
+    installFake("99");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ error: "implausible", raw_response: "99" });
+  });
+
+  it("returns unparseable for HH:MM:SS (legacy model output)", async () => {
+    // Regression guard: the previous model was prompted for
+    // HH:MM:SS; if a model ever returns that again, we want the
+    // reader to reject it cleanly rather than trying to salvage a
+    // number from it.
+    installFake("14:32:07");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect("error" in result ? result.error : null).toBe("unparseable");
+  });
+
+  it("returns unparseable for a signed number", async () => {
+    installFake("-5");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect("error" in result ? result.error : null).toBe("unparseable");
   });
 
   it("returns unparseable for an empty response", async () => {
@@ -83,63 +128,61 @@ describe("readDialTime", () => {
     expect(result).toEqual({ error: "unparseable" });
   });
 
-  it("rejects 25:00:00 as unparseable (out-of-range hour)", async () => {
-    installFake("25:00:00");
-    const result = await readDialTime(fakeImage, fakeEnv);
-    // The strict regex makes this an unparseable rather than implausible;
-    // defence-in-depth's range check only kicks in if the regex ever
-    // loosens. Either classification is acceptable from an API-surface
-    // perspective (both are non-success errors), so assert on the
-    // broader "this is an error" contract.
-    expect("error" in result).toBe(true);
-  });
-
-  it("passes the image array and prompt to the AI runner", async () => {
-    let captured: { image: number[]; prompt: string } | null = null;
+  it("passes the image bytes and prompt to the AI runner", async () => {
+    let captured: { image: Uint8Array; prompt: string } | null = null;
     __setTestAiRunner(async (inputs) => {
       captured = { image: inputs.image, prompt: inputs.prompt };
-      return { response: "10:00:00" };
+      return { response: "10" };
     });
     await readDialTime(fakeImage, fakeEnv);
     expect(captured).not.toBeNull();
-    expect(captured!.image).toEqual([0xff, 0xd8, 0xff, 0xd9]);
-    expect(captured!.prompt).toContain("HH:MM:SS");
+    expect(Array.from(captured!.image)).toEqual([0xff, 0xd8, 0xff, 0xd9]);
+    // The new prompt asks for a single integer 0-59 only.
+    expect(captured!.prompt).toContain("second hand");
+    expect(captured!.prompt).toContain("0-59");
     expect(captured!.prompt).toContain("NO_DIAL");
+    expect(captured!.prompt).toContain("UNREADABLE");
+    // And it no longer asks for HH:MM:SS.
+    expect(captured!.prompt).not.toContain("HH:MM:SS");
   });
 
-  it("hint time flows into the prompt as a disambiguation aid (not as the answer)", async () => {
+  it("hint time flows into the prompt as the reference-clock anchor", async () => {
     let captured: string | null = null;
     __setTestAiRunner(async (inputs) => {
       captured = inputs.prompt;
-      return { response: "15:00:00" };
+      return { response: "15" };
     });
-    const hint = new Date(Date.UTC(2024, 0, 1, 14, 32, 0));
+    const hint = new Date(Date.UTC(2024, 0, 1, 14, 32, 5));
     await readDialTime(fakeImage, fakeEnv, hint);
-    expect(captured).toContain("14:32");
-    // Explicit defence against the archived-prototype sin.
-    expect(captured).toContain("Do not copy this value");
-    expect(captured).toContain("disambiguate AM/PM");
+    expect(captured).toContain("14:32:05");
+    expect(captured).toContain("reference clock");
   });
 });
 
 describe("buildPrompt", () => {
-  it("does not leak a hint when none is given", () => {
+  it("produces a prompt that asks for only the second hand (0-59)", () => {
     const prompt = buildPrompt();
-    expect(prompt).not.toContain("The approximate time is");
-    expect(prompt).toContain("HH:MM:SS");
+    expect(prompt).toContain("second hand");
+    expect(prompt).toContain("0-59");
+    expect(prompt).toContain("NO_DIAL");
+    expect(prompt).toContain("UNREADABLE");
+    expect(prompt).not.toContain("HH:MM:SS");
   });
 
-  it("embeds the hint zero-padded to HH:MM", () => {
-    const prompt = buildPrompt(new Date(Date.UTC(2024, 0, 1, 3, 5, 0)));
-    expect(prompt).toContain("03:05");
+  it("embeds the reference timestamp as HH:MM:SS (UTC)", () => {
+    const prompt = buildPrompt(new Date(Date.UTC(2024, 0, 1, 3, 5, 9)));
+    expect(prompt).toContain("03:05:09");
   });
 
-  it("never instructs the model to return the hint directly", () => {
-    const prompt = buildPrompt(new Date(Date.UTC(2024, 0, 1, 9, 15, 0)));
+  it("never instructs the model to copy the reference time", () => {
+    const prompt = buildPrompt(new Date(Date.UTC(2024, 0, 1, 9, 15, 30)));
     // Regression guard: the archived watchdrift prompt literally said
     // "return this time". We must never do that.
     expect(prompt).not.toMatch(/return this time/i);
     expect(prompt).not.toMatch(/reply with this time/i);
-    expect(prompt).toContain("Do not copy this value");
+    // The prompt names the reference anchor, but the output surface
+    // is only the second hand — the model cannot honestly "copy" the
+    // reference without reading the dial.
+    expect(prompt).toContain("reference clock");
   });
 });

--- a/src/domain/ai-dial-reader/reader.ts
+++ b/src/domain/ai-dial-reader/reader.ts
@@ -1,6 +1,6 @@
 // AI dial reader. Takes a JPEG of a watch face and asks a vision
-// model what time is displayed. Returns a structured `DialReading`
-// (HH:MM:SS) or a structured error.
+// model for the position of the second hand. Returns a structured
+// `DialReading` (seconds only) or a structured error.
 //
 // This module is deliberately small and side-effect-free apart from
 // the single AI call: the verified-reading pipeline (reading-verifier)
@@ -9,22 +9,27 @@
 // the verifier doesn't change.
 //
 // Trust contract (AGENTS.md): we never, ever tell the model "just
-// return the hint time". The archived watchdrift prototype did that
-// and produced a cheating system. The hint is only used as an AM/PM
-// disambiguator — the model's own visual read is what lands in the
-// reading.
+// return the reference time". The archived watchdrift prototype did
+// that and produced a cheating system. The reference clock is used
+// as the HH:MM anchor — the hours + minutes of a verified reading
+// come from the server clock, not from the model — but the *seconds*
+// come from the model's own visual read of the dial. That split is
+// both the honest thing to do and cheaper in tokens: the model's
+// output surface is a single integer 0-59.
 
 import { resolveAiRunner, type AiRunnerEnv, type AiRunResponse } from "./runner";
 
 /**
- * A successful dial read. Seconds may legitimately be 0 when the
- * watch doesn't have a second hand — the caller shouldn't treat a
- * zero-second read as a failure.
+ * A successful dial read. Only the second-hand position — hours and
+ * minutes come from the reference clock in the verifier. A watch
+ * without a visible second hand cannot produce a verified reading;
+ * the model must return UNREADABLE in that case.
  */
 export interface DialReading {
-  hours: number; // 0-23
-  minutes: number; // 0-59
-  seconds: number; // 0-59
+  // Second hand position (0-59). Hours + minutes come from the
+  // reference clock, not the model — the model is only asked for
+  // this one number.
+  seconds: number;
   raw_response: string;
 }
 
@@ -37,32 +42,48 @@ export interface DialReaderError {
 
 export interface DialReaderEnv extends AiRunnerEnv {}
 
-// Strict parse: exactly HH:MM:SS, zero-padded, nothing else. Anchored
-// so we don't accept "14:32:07 is the time".
-const HHMMSS = /^([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/;
+// Strict parse: exactly 1-2 digits, no leading +/-, no decimals.
+// Anchored so we don't accept "42 seconds" or "about 42".
+const SECONDS_ONLY = /^\d{1,2}$/;
 
-const PROMPT_BASE =
-  "Look at the watch dial in this image and report the time shown as exactly HH:MM:SS in 24-hour format. " +
-  "If the image does not show a clock face, reply with exactly: NO_DIAL. " +
-  "If you cannot read the time clearly, reply with exactly: UNREADABLE. " +
-  "Do not add any other text.";
+const PROMPT_BASE = `You are reading a mechanical watch dial shown in a photo.
+
+The reference clock reads HH_ANCHOR right now. The watch is approximately
+synchronised with this reference. Your task is only to read the WATCH's
+second hand — the thinnest, usually centrally-mounted hand that sweeps
+once per minute.
+
+Report only the position of the second hand as a single integer 0-59.
+
+Do not explain. Do not guess if you cannot see the second hand clearly.
+
+If you cannot read the second hand clearly, reply with exactly:
+UNREADABLE
+
+If the image is not a watch, reply with exactly:
+NO_DIAL
+
+Examples of valid replies: "0", "15", "42", "UNREADABLE", "NO_DIAL"`;
 
 /**
- * Build the prompt. Embeds a reference-time hint when provided, but
- * phrased as a disambiguation aid — the model is told to *use* the
- * hint to pick AM vs PM if it's unsure, NOT to copy the hint into
- * the response. See the AGENTS.md warning about the archived
- * prototype doing exactly that.
+ * Build the prompt. Embeds a reference timestamp as an HH:MM:SS
+ * anchor, so the model knows "the reference clock reads X right now"
+ * and can focus its entire output on the seconds.
+ *
+ * When no hint is provided (shouldn't happen from the verifier, but
+ * keeps this helper honest), the anchor is a generic placeholder
+ * that doesn't steer the model toward any particular value.
  */
 export function buildPrompt(hintTime?: Date): string {
-  if (!hintTime) return PROMPT_BASE;
-  const hh = String(hintTime.getUTCHours()).padStart(2, "0");
-  const mm = String(hintTime.getUTCMinutes()).padStart(2, "0");
-  return (
-    `The approximate time is ${hh}:${mm}; use this only to disambiguate AM/PM if the hour hand is ambiguous. ` +
-    `Do not copy this value — report what the watch dial actually shows. ` +
-    PROMPT_BASE
-  );
+  const anchor = hintTime ? formatHmsUtc(hintTime) : "an unknown time";
+  return PROMPT_BASE.replace("HH_ANCHOR", anchor);
+}
+
+function formatHmsUtc(d: Date): string {
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  const ss = String(d.getUTCSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
 }
 
 /**
@@ -80,7 +101,7 @@ export async function readDialTime(
   let result: AiRunResponse;
   try {
     result = await runner({
-      image: Array.from(image),
+      image,
       prompt: buildPrompt(hintTime),
     });
   } catch (err) {
@@ -101,32 +122,15 @@ export async function readDialTime(
     return { error: "refused", raw_response: raw };
   }
 
-  const m = HHMMSS.exec(raw);
-  if (!m) {
+  if (!SECONDS_ONLY.test(raw)) {
     return { error: "unparseable", raw_response: raw };
   }
 
-  // The regex already restricts each field to its valid range, so a
-  // successful match implies hours ∈ [0,23], minutes/seconds ∈ [0,59].
-  // We still run the explicit plausibility check for defence in
-  // depth in case the regex ever loosens.
-  const hours = Number(m[1]);
-  const minutes = Number(m[2]);
-  const seconds = Number(m[3]);
-
-  if (
-    !Number.isFinite(hours) ||
-    !Number.isFinite(minutes) ||
-    !Number.isFinite(seconds) ||
-    hours < 0 ||
-    hours > 23 ||
-    minutes < 0 ||
-    minutes > 59 ||
-    seconds < 0 ||
-    seconds > 59
-  ) {
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
+    // e.g. "99" — two digits, passes the regex, but out of range.
     return { error: "implausible", raw_response: raw };
   }
 
-  return { hours, minutes, seconds, raw_response: raw };
+  return { seconds, raw_response: raw };
 }

--- a/src/domain/ai-dial-reader/runner.test.ts
+++ b/src/domain/ai-dial-reader/runner.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import {
+  AI_GATEWAY_ID,
+  DIAL_MODEL,
+  __setTestAiRunner,
+  resolveAiRunner,
+  type AiRunnerEnv,
+} from "./runner";
+
+// Tests that focus on the runner's production path: does it dispatch
+// to the right model, with the right gateway option, and extract the
+// assistant text from Kimi's chat-completion envelope?
+//
+// The reader.test.ts suite installs test runners via
+// `__setTestAiRunner` — those tests exercise parsing, not dispatch.
+// This file instead builds a fake `env.AI` whose `.run` is a spy,
+// installs no test runner, and calls `resolveAiRunner(env)` directly.
+
+afterEach(() => {
+  __setTestAiRunner(null);
+});
+
+function makeFakeAiEnv(
+  runImpl: (model: string, inputs: unknown, options: unknown) => Promise<unknown>,
+): { env: AiRunnerEnv; run: ReturnType<typeof vi.fn> } {
+  const run = vi.fn(runImpl);
+  const env: AiRunnerEnv = {
+    AI: {
+      run,
+    } as unknown as Ai,
+  };
+  return { env, run };
+}
+
+describe("resolveAiRunner (production path)", () => {
+  it("exports the expected model and gateway constants", () => {
+    expect(DIAL_MODEL).toBe("@cf/moonshotai/kimi-k2.6");
+    expect(AI_GATEWAY_ID).toBe("ratedwatch");
+  });
+
+  it("dispatches to env.AI.run with the dial model and gateway option", async () => {
+    const { env, run } = makeFakeAiEnv(async () => ({
+      choices: [{ message: { content: "42" } }],
+    }));
+    const runner = resolveAiRunner(env);
+    await runner({
+      image: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+      prompt: "Report the second hand as 0-59.",
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    const [model, , options] = run.mock.calls[0]!;
+    expect(model).toBe("@cf/moonshotai/kimi-k2.6");
+    expect(options).toEqual({ gateway: { id: "ratedwatch" } });
+  });
+
+  it("wraps the image as a base64 data URL in a user message", async () => {
+    const { env, run } = makeFakeAiEnv(async () => ({
+      choices: [{ message: { content: "42" } }],
+    }));
+    const runner = resolveAiRunner(env);
+    await runner({
+      image: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+      prompt: "read the second hand",
+    });
+
+    const [, inputs] = run.mock.calls[0]! as unknown as [
+      string,
+      {
+        messages: Array<{
+          role: string;
+          content:
+            | string
+            | Array<
+                | { type: "text"; text: string }
+                | { type: "image_url"; image_url: { url: string } }
+              >;
+        }>;
+      },
+      unknown,
+    ];
+    expect(inputs.messages).toBeInstanceOf(Array);
+    expect(inputs.messages.length).toBeGreaterThanOrEqual(2);
+
+    const system = inputs.messages[0]!;
+    expect(system.role).toBe("system");
+
+    const user = inputs.messages[inputs.messages.length - 1]!;
+    expect(user.role).toBe("user");
+    expect(Array.isArray(user.content)).toBe(true);
+
+    const parts = user.content as Array<
+      { type: "text"; text: string } | { type: "image_url"; image_url: { url: string } }
+    >;
+    const textPart = parts.find(
+      (p): p is { type: "text"; text: string } => p.type === "text",
+    );
+    const imagePart = parts.find(
+      (p): p is { type: "image_url"; image_url: { url: string } } =>
+        p.type === "image_url",
+    );
+    expect(textPart?.text).toBe("read the second hand");
+    expect(imagePart?.image_url.url).toMatch(/^data:image\/jpeg;base64,/);
+    // The known bytes 0xFF 0xD8 0xFF 0xD9 base64-encode to "/9j/2Q==".
+    expect(imagePart?.image_url.url).toContain("/9j/2Q==");
+  });
+
+  it("extracts choices[0].message.content into response", async () => {
+    const { env } = makeFakeAiEnv(async () => ({
+      choices: [{ message: { content: "  42  " } }, { message: { content: "99" } }],
+    }));
+    const runner = resolveAiRunner(env);
+    const out = await runner({
+      image: new Uint8Array([0xff, 0xd8]),
+      prompt: "x",
+    });
+    // Runner returns raw content; trimming is the reader's job.
+    expect(out.response).toBe("  42  ");
+  });
+
+  it("returns an empty response object when the upstream shape is malformed", async () => {
+    const { env } = makeFakeAiEnv(async () => ({ nothing: "useful" }));
+    const runner = resolveAiRunner(env);
+    const out = await runner({ image: new Uint8Array([0xff]), prompt: "x" });
+    expect(out.response).toBeUndefined();
+  });
+
+  it("propagates upstream errors to the caller", async () => {
+    const { env } = makeFakeAiEnv(async () => {
+      throw new Error("binding exploded");
+    });
+    const runner = resolveAiRunner(env);
+    await expect(runner({ image: new Uint8Array([0xff]), prompt: "x" })).rejects.toThrow(
+      "binding exploded",
+    );
+  });
+
+  it("test runner overrides the production path", async () => {
+    const { env, run } = makeFakeAiEnv(async () => ({
+      choices: [{ message: { content: "should not be called" } }],
+    }));
+    __setTestAiRunner(async () => ({ response: "stub" }));
+    const runner = resolveAiRunner(env);
+    const out = await runner({ image: new Uint8Array([0xff]), prompt: "x" });
+    expect(out).toEqual({ response: "stub" });
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/src/domain/ai-dial-reader/runner.ts
+++ b/src/domain/ai-dial-reader/runner.ts
@@ -7,7 +7,11 @@
 // Semantics:
 //
 //   * Production path: `resolveAiRunner(env)` returns a function that
-//     delegates straight to `env.AI.run(DIAL_MODEL, inputs)`.
+//     delegates to `env.AI.run(DIAL_MODEL, { messages }, { gateway })`
+//     and extracts the assistant's text reply from the chat-completion
+//     response. Every call is routed through the AI Gateway named by
+//     `AI_GATEWAY_ID` — that's the single pane for request logs, rate
+//     limiting, and (future) cache / fallback policies.
 //
 //   * Test path: the integration-test file imports `__setTestAiRunner`
 //     and installs a stub that returns a canned response. Because
@@ -19,23 +23,60 @@
 // reads the module-level `testRunner` ref directly. The only place
 // that matters is `resolveAiRunner`, which routes to the fake when
 // one is installed.
+//
+// The `AiRunner` contract returns a `{ response: string }` — the
+// extracted assistant text — regardless of which underlying model
+// the runner chose. That keeps the reader layer (reader.ts) free of
+// model-specific response shapes; if we ever swap Kimi for another
+// chat model, only this file changes.
 
-export const DIAL_MODEL = "@cf/meta/llama-3.2-11b-vision-instruct";
+/**
+ * Dial-reader model. Kimi K2.6 is a frontier-scale vision + reasoning
+ * chat model on Workers AI (Day-0 release 2026-04-20). Chosen over
+ * the previous llama-3.2-11b-vision-instruct for its much stronger
+ * visual reasoning, which matters for reading a watch's thin second
+ * hand against a busy dial background.
+ *
+ * Pricing: $0.95 / M input tokens. A dial read is ~1 image + ~200
+ * prompt tokens ≈ well under $0.001 per reading.
+ */
+export const DIAL_MODEL = "@cf/moonshotai/kimi-k2.6";
+
+/**
+ * AI Gateway slug. Every `env.AI.run(...)` in this codebase routes
+ * through this gateway, provisioned by
+ * infra/terraform/ai-gateway.tf. Keep the two literals in sync.
+ *
+ * Exported so future AI callers (e.g. a different model for
+ * movement-name normalisation) can import the same constant instead
+ * of hardcoding the slug.
+ */
+export const AI_GATEWAY_ID = "ratedwatch";
 
 export interface AiRunInputs {
   /**
-   * JPEG bytes as a plain number array, per the Workers AI vision
-   * input schema. A `Uint8Array` also works at runtime but the
-   * documented contract is `number[]`.
+   * JPEG bytes. Encoded as a base64 data URL and embedded in the
+   * user message's `image_url` field before dispatching to Kimi.
+   * A `Uint8Array` is the canonical shape at the reader boundary;
+   * the runner converts.
    */
-  image: number[];
+  image: Uint8Array;
+  /**
+   * The prompt text. The runner wraps this in a Kimi chat-messages
+   * envelope (system + user with image attached). The reader builds
+   * a single prompt string and leaves the conversational structure
+   * to the runner.
+   */
   prompt: string;
 }
 
 export interface AiRunResponse {
-  // The Workers AI vision model returns `{ response: string }`. We
-  // defensively type it as optional so a malformed upstream response
-  // can be handled at the reader layer instead of blowing up here.
+  /**
+   * The assistant's text reply, extracted from Kimi's
+   * `choices[0].message.content`. `undefined` if the upstream
+   * response is malformed — the reader defensively treats that as
+   * an unparseable read.
+   */
   response?: string;
 }
 
@@ -61,23 +102,108 @@ export function __setTestAiRunner(fn: AiRunner | null): void {
   testRunner = fn;
 }
 
+// --- Kimi chat-completion shape ------------------------------------
+
+// We model only the bits we read. Kimi accepts the OpenAI-compatible
+// chat-completion schema: `{ messages: [{ role, content }] }` where
+// a user message's `content` can be a string OR an array of parts
+// (text + image_url). We always use the parts form so the image is
+// attached to the user turn.
+
+interface KimiTextPart {
+  type: "text";
+  text: string;
+}
+
+interface KimiImageUrlPart {
+  type: "image_url";
+  image_url: { url: string };
+}
+
+type KimiContentPart = KimiTextPart | KimiImageUrlPart;
+
+interface KimiMessage {
+  role: "system" | "user" | "assistant";
+  content: string | KimiContentPart[];
+}
+
+interface KimiRequest {
+  messages: KimiMessage[];
+}
+
+interface KimiChoice {
+  message?: { content?: string };
+}
+
+interface KimiResponse {
+  choices?: KimiChoice[];
+}
+
+/** Base64-encode a byte array. `btoa` expects a binary string. */
+function toBase64(bytes: Uint8Array): string {
+  // Build the binary string in chunks to avoid stack-size errors on
+  // very large images (btoa over `String.fromCharCode(...bytes)` can
+  // blow up for >100kB inputs). 8kB chunks are safely within the
+  // arg-list limit on every runtime we care about.
+  const CHUNK = 0x2000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode(...slice);
+  }
+  return btoa(binary);
+}
+
+const SYSTEM_PROMPT =
+  "You are a watch-dial reader. You answer with a single token and nothing else.";
+
+/**
+ * Build the Kimi chat request for a dial read. The image is encoded
+ * as a `data:image/jpeg;base64,...` URL on the `image_url` part —
+ * that's the format Kimi accepts via the Workers AI binding.
+ */
+function buildKimiRequest(inputs: AiRunInputs): KimiRequest {
+  const b64 = toBase64(inputs.image);
+  const imageUrl = `data:image/jpeg;base64,${b64}`;
+  return {
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: inputs.prompt },
+          { type: "image_url", image_url: { url: imageUrl } },
+        ],
+      },
+    ],
+  };
+}
+
 /**
  * Resolve the effective AI runner for this request. When a test has
  * installed a fake via `__setTestAiRunner`, return that; otherwise
- * delegate to `env.AI.run` with the dial-reader model.
+ * delegate to `env.AI.run` with the dial-reader model, routed
+ * through the AI Gateway.
  */
 export function resolveAiRunner(env: AiRunnerEnv): AiRunner {
   if (testRunner) return testRunner;
   return async (inputs) => {
+    const req = buildKimiRequest(inputs);
     // The Ai binding's type signature is a cross-product over every
     // model's input/output shape — TypeScript can't narrow without
-    // knowing the model key. Cast here; the vision model is called
-    // with `{ image, prompt }` and returns `{ response }`.
-    const res = (await (
+    // knowing the model key. Cast here; Kimi K2.6 accepts a
+    // chat-completion request and returns an OpenAI-shaped response.
+    const raw = (await (
       env.AI as unknown as {
-        run: (model: string, inputs: AiRunInputs) => Promise<AiRunResponse>;
+        run: (
+          model: string,
+          inputs: KimiRequest,
+          options: { gateway: { id: string } },
+        ) => Promise<KimiResponse>;
       }
-    ).run(DIAL_MODEL, inputs)) as AiRunResponse;
-    return res;
+    ).run(DIAL_MODEL, req, { gateway: { id: AI_GATEWAY_ID } })) as KimiResponse;
+
+    const content = raw.choices?.[0]?.message?.content;
+    return typeof content === "string" ? { response: content } : {};
   };
 }

--- a/src/domain/reading-verifier/verifier.test.ts
+++ b/src/domain/reading-verifier/verifier.test.ts
@@ -1,80 +1,78 @@
 import { describe, it, expect } from "vitest";
 import { computeVerifiedDeviation } from "./verifier";
 
-// Unit tests for the drift-computation helper. The broader verifier
-// pipeline (R2 upload, DB insert, AI call) is covered by
-// tests/integration/readings.verified.test.ts — this file is only the
-// minute-boundary math.
+// Unit tests for the seconds-only drift-computation helper. The
+// broader verifier pipeline (R2 upload, DB insert, AI call) is
+// covered by tests/integration/readings.verified.test.ts — this file
+// is only the minute-boundary math.
+//
+// Contract: the dial reader now returns only `seconds` (0-59). The
+// verifier wraps dialSec - refSec into [-30, +30]. Drifts > 30 s in
+// absolute value are ambiguous without the minute hand and wrap —
+// that's a documented constraint, not a bug.
 
 function tsFromHms(hh: number, mm: number, ss: number): number {
   // Anchor to an arbitrary UTC day so the math is hermetic to the
-  // runner's local TZ. `computeVerifiedDeviation` uses UTC getters
-  // on the reference side, which matches.
+  // runner's local TZ. `computeVerifiedDeviation` reads seconds-of-
+  // minute from the ms timestamp, which is TZ-independent anyway.
   return Date.UTC(2024, 0, 15, hh, mm, ss);
 }
 
 describe("computeVerifiedDeviation", () => {
   it("dial ahead of reference by 2s → +2", () => {
-    expect(
-      computeVerifiedDeviation(
-        { hours: 14, minutes: 32, seconds: 7 },
-        tsFromHms(14, 32, 5),
-      ),
-    ).toBe(2);
+    expect(computeVerifiedDeviation({ seconds: 7 }, tsFromHms(14, 32, 5))).toBe(2);
   });
 
   it("dial behind reference by 3s → -3", () => {
-    expect(
-      computeVerifiedDeviation(
-        { hours: 9, minutes: 15, seconds: 0 },
-        tsFromHms(9, 15, 3),
-      ),
-    ).toBe(-3);
+    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(9, 15, 3))).toBe(-3);
   });
 
   it("dial exactly matches → 0", () => {
-    expect(
-      computeVerifiedDeviation({ hours: 0, minutes: 0, seconds: 0 }, tsFromHms(0, 0, 0)),
-    ).toBe(0);
+    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(0, 0, 0))).toBe(0);
+    expect(computeVerifiedDeviation({ seconds: 30 }, tsFromHms(12, 34, 30))).toBe(0);
+    expect(computeVerifiedDeviation({ seconds: 59 }, tsFromHms(8, 8, 59))).toBe(0);
   });
 
-  it("minute boundary: dial=00:00:30, ref=23:59:55 → +35s (not +35m)", () => {
-    // Dial rolled over just before the reference's last tick.
-    // Raw time-of-day diff is huge negative; wrap yields +35.
-    expect(
-      computeVerifiedDeviation(
-        { hours: 0, minutes: 0, seconds: 30 },
-        tsFromHms(23, 59, 55),
-      ),
-    ).toBe(35);
+  it("minute boundary: dial=02, ref=58 → +4s (not -56s)", () => {
+    // Dial rolled over just before the reference's last tick. Raw
+    // diff is -56; wrap yields +4.
+    expect(computeVerifiedDeviation({ seconds: 2 }, tsFromHms(23, 59, 58))).toBe(4);
   });
 
-  it("minute boundary: dial=23:59:55, ref=00:00:30 → -35s", () => {
-    expect(
-      computeVerifiedDeviation(
-        { hours: 23, minutes: 59, seconds: 55 },
-        tsFromHms(0, 0, 30),
-      ),
-    ).toBe(-35);
+  it("minute boundary: dial=58, ref=02 → -4s", () => {
+    // Dial is about to roll over, reference already has. Raw +56;
+    // wrap yields -4.
+    expect(computeVerifiedDeviation({ seconds: 58 }, tsFromHms(0, 0, 2))).toBe(-4);
   });
 
-  it("wraps diffs > +30 min to the negative side", () => {
-    // Dial reads 15:30:00, ref is 14:00:00 → raw +1h30m.
-    // [-1800, 1800] wrap brings this to -1800 (the boundary is
-    // inclusive of the lower bound, exclusive of the upper).
-    expect(
-      computeVerifiedDeviation(
-        { hours: 15, minutes: 30, seconds: 0 },
-        tsFromHms(14, 0, 0),
-      ),
-    ).toBe(-1800);
+  it("wraps true drifts > +30 s into the negative half", () => {
+    // Dial=40, ref=0 → raw +40 → wrap to -20 (documented
+    // ambiguity: without the minute hand we can't tell this from
+    // a -20 s drift).
+    expect(computeVerifiedDeviation({ seconds: 40 }, tsFromHms(14, 0, 0))).toBe(-20);
+  });
+
+  it("wraps true drifts < -30 s into the positive half", () => {
+    // Dial=0, ref=40 → raw -40 → wrap to +20.
+    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(14, 0, 40))).toBe(20);
+  });
+
+  it("half-period boundary: dial=30, ref=0 → -30 or +30 (consistent)", () => {
+    // The wrap interval [-30, +30] puts the half-period on a single
+    // side — we don't care which, as long as it's deterministic.
+    const result = computeVerifiedDeviation({ seconds: 30 }, tsFromHms(14, 0, 0));
+    expect(Math.abs(result)).toBe(30);
   });
 
   it("never returns NaN, even with weird inputs", () => {
-    const result = computeVerifiedDeviation(
-      { hours: 0, minutes: 0, seconds: 0 },
-      tsFromHms(12, 0, 0),
-    );
+    const result = computeVerifiedDeviation({ seconds: 0 }, tsFromHms(12, 0, 0));
     expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it("tolerates out-of-range dial seconds by normalising modulo 60", () => {
+    // The reader shouldn't emit these, but the helper shouldn't
+    // explode if it ever sees one.
+    expect(computeVerifiedDeviation({ seconds: 61 }, tsFromHms(0, 0, 1))).toBe(0);
+    expect(computeVerifiedDeviation({ seconds: -1 }, tsFromHms(0, 0, 59))).toBe(0);
   });
 });

--- a/src/domain/reading-verifier/verifier.ts
+++ b/src/domain/reading-verifier/verifier.ts
@@ -5,11 +5,14 @@
 //   1. Capture server-side reference timestamp (`Date.now()`). This
 //      is the canonical source of truth — client / EXIF timestamps
 //      are NEVER trusted for competitive scoring.
-//   2. Run the image through the AI dial reader.
+//   2. Run the image through the AI dial reader. The dial reader now
+//      returns *only* the second-hand position (0-59) — hours and
+//      minutes come from the reference clock, not the model.
 //   3. On AI error → bubble up as a structured failure.
 //   4. On AI success, compute the signed drift in seconds between
-//      dial-time and reference-time, wrapped into [-1800, 1800] so
-//      a minute-boundary capture doesn't show as a ~30 minute drift.
+//      the model's observed second-hand position and the reference
+//      clock's own seconds-of-minute, wrapped into [-30, +30] so a
+//      minute-boundary capture doesn't show as a ~30 second drift.
 //   5. If `is_baseline`, force deviation to 0 — by definition the
 //      user has just set the watch to the true time.
 //   6. Insert a readings row with verified=1.
@@ -17,11 +20,16 @@
 //      A failure here is logged but doesn't roll back the reading —
 //      the reading is canonical, the photo is for provenance only.
 //
-// We deliberately do NOT override the AI's hours with the reference
-// clock. The archived watchdrift prototype did that to "fix" AM/PM
-// misreads and silently destroyed its own drift accuracy. If the
-// model gets the hour wrong, the reading is wrong and the caller
-// should re-capture.
+// Design constraint introduced by the seconds-only model contract:
+//
+//   The model no longer reports hours or minutes, only the second
+//   hand's position (0-59). That means this verifier can only
+//   resolve drifts in the range [-30, +30] seconds — any larger
+//   drift is ambiguous without the minute hand. For phase 1 that's
+//   acceptable: a user logging a verified reading is expected to
+//   roughly sync their watch; anything that's drifted more than
+//   30 seconds in a session will wrap and under-report. That
+//   constraint is documented below next to the wrap math.
 
 import { createDb } from "@/db";
 import { readDialTime, type DialReaderError } from "@/domain/ai-dial-reader/reader";
@@ -68,56 +76,50 @@ export interface VerifiedReadingRow {
   created_at: string;
 }
 
-// A signed drift outside ±30 min is almost certainly a minute-boundary
-// wrap (e.g. dial=00:00:30, ref=23:59:55 ⇒ raw delta +35m but true
-// drift +35s). Wrapping into [-1800, 1800] resolves that.
-const HALF_HOUR_SECONDS = 1800;
-const DAY_SECONDS = 24 * 60 * 60;
+// With a seconds-only read, the dial's second hand and the reference
+// clock's seconds-of-minute are both in [0, 59], so their signed
+// difference is in [-59, +59]. Wrap into [-30, +30] so a capture
+// straddling the minute boundary (dial=58, ref=02) is reported as
+// -4 rather than +56.
+//
+// Constraint: any true drift > 30 s in absolute value will wrap and
+// under-report. See the module-level comment.
+const HALF_MINUTE_SECONDS = 30;
 
 /**
- * Exported for tests. Computes drift between the dial-time-of-day
- * and the reference-time-of-day, in seconds, wrapped into
- * [-HALF_HOUR_SECONDS, HALF_HOUR_SECONDS].
+ * Exported for tests. Computes the seconds-only drift between the
+ * dial's observed second-hand position and the reference clock's
+ * seconds-of-minute, wrapped into [-30, +30] (lower bound inclusive,
+ * upper bound inclusive where 30 and -30 collide at the ±1800° mark).
  *
- * NOT a general time-delta helper — the math assumes dial and
- * reference are "roughly" aligned to within ±30 min.
+ * Invariants:
+ *   * dialReading.seconds must be an integer in [0, 59]. Callers
+ *     (readDialTime) enforce that — this helper still tolerates
+ *     out-of-range by `%%`-normalising first.
+ *   * referenceTimestampMs is a millisecond unix timestamp.
  */
 export function computeVerifiedDeviation(
-  dialHms: {
-    hours: number;
-    minutes: number;
+  dialReading: {
     seconds: number;
   },
-  referenceTimestamp: number,
+  referenceTimestampMs: number,
 ): number {
-  const dialSec = dialHms.hours * 3600 + dialHms.minutes * 60 + dialHms.seconds;
-  const d = new Date(referenceTimestamp);
-  // Use UTC getters on the reference to match the dial's 0-23h scale
-  // without worrying about the worker's local TZ. The dial itself is
-  // also a UTC-agnostic "time shown on the face"; we're just taking
-  // time-of-day mod 24h on both sides.
-  const refSec = d.getUTCHours() * 3600 + d.getUTCMinutes() * 60 + d.getUTCSeconds();
+  const dialSec = dialReading.seconds;
+  // Reference seconds-of-minute. `Math.floor` on the ms / 1000 then
+  // %% 60 gives the current seconds-of-minute in [0, 59].
+  const refSec = Math.floor(referenceTimestampMs / 1000) % 60;
 
-  // Raw diff in [-(DAY_SECONDS-1), DAY_SECONDS-1].
+  // Raw signed delta in [-59, +59]. Positive = watch ahead of
+  // reference; negative = watch behind.
   let diff = dialSec - refSec;
-  // Wrap into [-HALF_HOUR_SECONDS, HALF_HOUR_SECONDS]:
-  //   - add HALF_HOUR_SECONDS
-  //   - mod by 2*HALF_HOUR_SECONDS (=3600)
-  //   - subtract HALF_HOUR_SECONDS
-  // But `%` in JS returns a negative for negative lhs, so normalise
-  // via +(2*HALF_HOUR_SECONDS) first.
-  diff =
-    ((((diff + HALF_HOUR_SECONDS) % (2 * HALF_HOUR_SECONDS)) + 2 * HALF_HOUR_SECONDS) %
-      (2 * HALF_HOUR_SECONDS)) -
-    HALF_HOUR_SECONDS;
+
+  // Wrap into [-30, +30]:
+  //   add 30, take mod 60, subtract 30.
+  // Use a %%-style normalisation because JS `%` keeps the sign of
+  // the lhs, which would give wrong answers for large negatives.
+  diff = ((((diff + HALF_MINUTE_SECONDS) % 60) + 60) % 60) - HALF_MINUTE_SECONDS;
   return diff;
 }
-
-// Suppress the signature to keep `DAY_SECONDS` referenced — it
-// documents the invariant that refSec ∈ [0, DAY_SECONDS) even though
-// modern JS doesn't need the guard. A future refactor touching this
-// helper will want to remember that.
-export const _DAY_SECONDS = DAY_SECONDS;
 
 /**
  * Run the verified-reading pipeline end-to-end. Never throws — any
@@ -146,13 +148,9 @@ export async function verifyReading(
     return toVerifierError(readerResult);
   }
 
-  // 4. Compute deviation.
+  // 4. Compute deviation from dial seconds vs reference seconds.
   let deviation = computeVerifiedDeviation(
-    {
-      hours: readerResult.hours,
-      minutes: readerResult.minutes,
-      seconds: readerResult.seconds,
-    },
+    { seconds: readerResult.seconds },
     referenceTimestamp,
   );
 

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -166,7 +166,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     expect(body.error).toBe("verified_readings_disabled");
   });
 
-  it("computes deviation from AI dial time vs server reference clock", async () => {
+  it("computes deviation from AI dial seconds vs server reference clock", async () => {
     const user = await registerAndGetCookie();
     await setVerifiedFlagForUser(user.userId);
     const { id: watchId } = await createWatch(
@@ -175,11 +175,11 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     );
 
     // Freeze Date.now() at 14:32:05 UTC so the reference clock is
-    // deterministic. Fake AI returns 14:32:07 → +2s drift.
+    // deterministic. Fake AI returns "7" (seconds) → +2s drift.
     const refTime = Date.UTC(2024, 0, 15, 14, 32, 5);
     vi.useFakeTimers();
     vi.setSystemTime(refTime);
-    installFakeAi("14:32:07");
+    installFakeAi("7");
 
     const res = await postVerifiedReading(watchId, user.cookie);
     expect(res.status).toBe(201);
@@ -238,10 +238,10 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
 
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2024, 0, 15, 10, 0, 0));
-    // AI "sees" a 5-minute-off dial; baseline should still pin
-    // deviation to 0 because the user is declaring "the watch is
-    // set to the exact time now".
-    installFakeAi("10:05:00");
+    // AI "sees" the second hand at 25 (25 s off the reference's 00);
+    // baseline should still pin deviation to 0 because the user is
+    // declaring "the watch is set to the exact time now".
+    installFakeAi("25");
 
     const res = await postVerifiedReading(watchId, user.cookie, {
       isBaseline: true,
@@ -265,7 +265,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
         { name: "Theirs", movement_id: movementId },
         owner.cookie,
       );
-      installFakeAi("12:00:00");
+      installFakeAi("0");
 
       const res = await postVerifiedReading(watchId, other.cookie);
       expect(res.status).toBe(403);
@@ -280,7 +280,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
       { name: "V6", movement_id: movementId },
       user.cookie,
     );
-    installFakeAi("08:15:30");
+    installFakeAi("30");
     const probeBytes = new Uint8Array([0xff, 0xd8, 0xab, 0xcd, 0xff, 0xd9]);
 
     const res = await postVerifiedReading(watchId, user.cookie, {


### PR DESCRIPTION
## Summary

Three changes, one PR:

1. **Provision an AI Gateway via Terraform.** Adds `infra/terraform/ai-gateway.tf` with a `cloudflare_ai_gateway` resource named `ratedwatch` in the Babybites account. The gateway runs in log-only mode for phase 1 — no cache (dial reads must never return a cached second-hand position), generous rate-limit ceiling of 1000/min.
2. **Route all `env.AI.run(...)` calls through the gateway.** The Workers AI binding already supports a third-arg `{ gateway: { id } }` option; we pass `{ gateway: { id: AI_GATEWAY_ID } }` in the dial-reader runner and export `AI_GATEWAY_ID = "ratedwatch"` for future callers. `grep -rn "env.AI.run" src/` shows the dial reader is the only site today.
3. **Switch the dial-reader model to Kimi K2.6 and refine the prompt.** Kimi K2.6 is the new frontier-scale vision + reasoning model on Workers AI (Day-0 release 2026-04-20). The new prompt tells the model the reference clock reads `HH:MM:SS` *right now* and asks only for the second hand's position as a single integer 0-59. Hours + minutes come from the server clock, not the model. This matches the ubiquitous-language promise of "the server is the source of truth" and cuts the model's output surface to a single token.

## Why the prompt change matters

The old prompt asked for HH:MM:SS and we trusted the full tuple. The reference time was being passed into the prompt but only weakly, as an "approximate hint — don't copy". With the hours+minutes already known server-side, asking the model for them was wasted context window and a cheating vector. Kimi K2.6's visual reasoning is also materially stronger for fine-grained second-hand reading against a busy dial, which is the regime this product lives in.

Baseline readings (`isBaseline: true`) still force `deviation_seconds = 0` regardless of what the model sees.

## Shape changes

- `DialReading` is now `{ seconds: number; raw_response: string }` (was `{ hours, minutes, seconds, raw_response }`).
- `computeVerifiedDeviation(dial, refTs)` now takes `{ seconds }` and wraps into **`[-30, +30]`** seconds. Documented constraint: without the minute hand the reader cannot disambiguate drifts larger than ±30 s; they wrap. That's acceptable for phase 1 — a user logging a verified reading is expected to have roughly synced the watch.
- The runner-level `AiRunner` contract is unchanged (`{ response: string }`), so tests that installed a test-runner still work with a simple string reply.

## CI

- Unit tests + integration tests: **368 / 368 passing**.
- `npm run typecheck`: clean (Worker + SPA + E2E tsconfigs).
- `npm run format:check`: the TS files touched by this PR are clean; pre-existing format warnings in other files are unrelated.
- `terraform fmt -check -recursive`: clean.
- `terraform validate` in `infra/terraform/`: clean (the pre-existing deprecation warning on `cloudflare_workers_custom_domain.apex.environment` is unrelated).

Pre-commit hooks (prettier + tsc + vitest-related) ran successfully on every commit.

## Operator step — REQUIRED before merge deploys the code

The Worker session cannot `terraform apply`. After merging (or at any convenient time before the next deploy that exercises the dial reader), run:

```bash
set -a && source .env && set +a
terraform -chdir=infra/terraform init
terraform -chdir=infra/terraform plan -out=tfplan
terraform -chdir=infra/terraform apply tfplan
```

Expected plan: a single `cloudflare_ai_gateway.ratedwatch` resource to add. No other changes.

If `env.AI.run(..., { gateway: { id: "ratedwatch" } })` runs before the gateway exists, Workers AI falls back to the default no-gateway path (no error) — so a race here is benign, but we lose logs for any call made before `terraform apply` lands.

## Gotchas / follow-ups

- **Terraform provider bump.** `cloudflare_ai_gateway` first shipped in the Cloudflare Terraform provider `5.19.0-beta.5`. The `required_providers` line is pinned exactly to that pre-release (Terraform range constraints skip pre-releases). Bump to a stable 5.19.x once one is cut.
- **Kimi K2.6 pricing.** $0.95/M input, $4/M output. A dial read is ~1 image + ~200 prompt tokens + 1-5 output tokens — well under $0.001 per verified reading.
- **Cache is off.** If a future phase wants cache hits for repeated-photo pathological cases, flip `cache_ttl` in `ai-gateway.tf`; we deliberately start at 0 so identical image bytes don't return the same seconds twice.
- **Out-of-range drifts wrap silently.** A watch that's drifted > 30 s in a session will under-report. This is a known consequence of the seconds-only contract; add a unit test or UI warning in a later slice if it becomes a user complaint.

## Commits

1. `infra(terraform): provision ratedwatch AI Gateway`
2. `feat(ai-dial-reader): route Workers AI through the ratedwatch gateway + swap to Kimi K2.6`
3. `feat(ai-dial-reader): seconds-only prompt anchored on the reference clock`