### PR TITLE
feat(readings): tap-the-dial manual reading UX

### DIFF
--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -9,8 +9,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
-import { LogReadingForm } from "../watches/LogReadingForm";
 import { ReadingList } from "../watches/ReadingList";
+import { TapReadingForm } from "../watches/TapReadingForm";
 import { SessionStatsPanel } from "../watches/SessionStatsPanel";
 import { VerifiedProgressRing } from "../watches/VerifiedProgressRing";
 import { VerifiedReadingCapture } from "../watches/VerifiedReadingCapture";
@@ -258,7 +258,7 @@ export function WatchDetailPage() {
         </div>
       ) : null}
       <VerifiedReadingCapture watchId={watch.id} onSubmitted={reloadReadings} />
-      <LogReadingForm watchId={watch.id} onLogged={reloadReadings} />
+      <TapReadingForm watchId={watch.id} onLogged={reloadReadings} />
       <ReadingList
         readings={readings.readings}
         perInterval={readings.session_stats?.per_interval ?? []}

--- a/src/app/watches/LogReadingForm.tsx
+++ b/src/app/watches/LogReadingForm.tsx
@@ -1,3 +1,10 @@
+// @deprecated — typed-deviation form. Superseded by TapReadingForm
+// (tap-the-dial UX) in the watch detail page; kept in the tree for
+// one release cycle so we can revert quickly if the tap UX falls
+// over in the wild. Safe to delete once the tap flow has had real-
+// world use. The backing POST /readings endpoint is still live and
+// the new tap UX runs on POST /readings/tap.
+//
 // "Log a manual reading" form. Lives below the session stats panel
 // on the watch detail page. Submits to POST /api/v1/watches/:id/readings
 // via the readings API client.

--- a/src/app/watches/TapReadingForm.tsx
+++ b/src/app/watches/TapReadingForm.tsx
@@ -1,0 +1,240 @@
+// Tap-the-dial manual reading flow. Replaces the typed-deviation
+// form (LogReadingForm.tsx — kept in the tree for now, marked
+// deprecated) with a UX that mirrors how an enthusiast actually
+// measures drift against a reference clock:
+//
+//   1. The user looks at their watch.
+//   2. They wait for the second hand to cross one of the four
+//      canonical marks — 12 (0), 3 (15), 6 (30), or 9 (45) o'clock.
+//   3. At the moment it lands, they tap the matching button.
+//   4. The server takes its own Date.now() as the reference and
+//      computes the signed deviation.
+//
+// Latency matters because the tap IS the commit — we fire the POST
+// immediately, show a transient "recorded" state, then revert to
+// idle. The reloaded list/stats are fetched via `onLogged` in the
+// background; the user doesn't wait on that round-trip.
+//
+// Accessibility: the four buttons are keyboard-focusable and their
+// labels include both the numeric position and the clock-face
+// reference ("12 o'clock · 0"). A live `<time>` updates 10× per
+// second so the user can visually sync to the upcoming mark without
+// mental math.
+
+import { useEffect, useRef, useState } from "react";
+import { createTapReading, type CreateTapReadingBody } from "./readings";
+
+interface Props {
+  watchId: string;
+  onLogged: () => void;
+}
+
+type DialPosition = 0 | 15 | 30 | 45;
+
+interface DialButton {
+  position: DialPosition;
+  oclock: string;
+}
+
+const DIAL_BUTTONS: readonly DialButton[] = [
+  { position: 0, oclock: "12" },
+  { position: 15, oclock: "3" },
+  { position: 30, oclock: "6" },
+  { position: 45, oclock: "9" },
+] as const;
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting"; position: DialPosition | "baseline" }
+  | { kind: "recorded"; position: DialPosition | "baseline"; deviation: number }
+  | { kind: "error"; message: string };
+
+/** Format the signed deviation for the "recorded" toast. */
+function formatDeviation(seconds: number): string {
+  if (seconds === 0) return "0 s (dead-on)";
+  const sign = seconds > 0 ? "+" : "";
+  return `${sign}${seconds} s`;
+}
+
+export function TapReadingForm({ watchId, onLogged }: Props) {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [showNotes, setShowNotes] = useState(false);
+  const [notes, setNotes] = useState("");
+  // Server-synced client clock for the "current second" indicator.
+  // 100 ms cadence is fast enough that the user can visually sync to
+  // the upcoming dial mark without it looking laggy.
+  const [nowSeconds, setNowSeconds] = useState(() => Math.floor(Date.now() / 1000) % 60);
+
+  // Timer reference so StrictMode double-mount in dev doesn't leak
+  // intervals. Cleanup also fires on unmount.
+  const timerRef = useRef<number | null>(null);
+  useEffect(() => {
+    timerRef.current = window.setInterval(() => {
+      setNowSeconds(Math.floor(Date.now() / 1000) % 60);
+    }, 100);
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  // The transient "recorded" state reverts to idle after 1.6 s so the
+  // user can tap again without manual dismissal.
+  useEffect(() => {
+    if (status.kind !== "recorded") return;
+    const t = window.setTimeout(() => {
+      setStatus({ kind: "idle" });
+    }, 1600);
+    return () => window.clearTimeout(t);
+  }, [status]);
+
+  async function submit(body: CreateTapReadingBody, label: DialPosition | "baseline") {
+    setStatus({ kind: "submitting", position: label });
+    // Collapse notes back so the next tap starts fresh.
+    const payload: CreateTapReadingBody = notes.trim()
+      ? { ...body, notes: notes.trim() }
+      : body;
+    const result = await createTapReading(watchId, payload);
+    if (!result.ok) {
+      setStatus({ kind: "error", message: result.error.message });
+      return;
+    }
+    setNotes("");
+    setShowNotes(false);
+    setStatus({
+      kind: "recorded",
+      position: label,
+      deviation: result.reading.deviation_seconds,
+    });
+    // Fire-and-forget — the parent re-fetches in the background while
+    // we show the "recorded" toast.
+    onLogged();
+  }
+
+  function handleTap(position: DialPosition) {
+    void submit({ dial_position: position, is_baseline: false }, position);
+  }
+
+  function handleBaseline() {
+    void submit({ dial_position: 0, is_baseline: true }, "baseline");
+  }
+
+  const isSubmitting = status.kind === "submitting";
+
+  return (
+    <section className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <h2 className="text-sm font-medium text-cf-text">Tap to log a reading</h2>
+        <p
+          className="font-mono text-xs text-cf-text-muted"
+          aria-label={`Reference clock at ${nowSeconds} seconds`}
+        >
+          ref ·{" "}
+          <time className="text-cf-accent">
+            :{nowSeconds.toString().padStart(2, "0")}
+          </time>
+        </p>
+      </div>
+      <p className="mb-4 text-xs text-cf-text-muted">
+        Wait for your watch&apos;s second hand to cross 12, 3, 6, or 9 o&apos;clock, then
+        tap the matching position. The server uses its own clock as the reference.
+      </p>
+
+      {status.kind === "error" ? (
+        <p
+          role="alert"
+          className="mb-4 rounded-md border border-cf-accent/40 bg-cf-accent/10 px-3 py-2 text-sm text-cf-text"
+        >
+          {status.message}
+        </p>
+      ) : null}
+      {status.kind === "recorded" ? (
+        <p
+          role="status"
+          aria-live="polite"
+          className="mb-4 rounded-md border border-cf-accent/30 bg-cf-bg px-3 py-2 text-sm text-cf-text"
+        >
+          Recorded{" "}
+          {status.position === "baseline" ? (
+            <span className="font-mono text-cf-accent">baseline</span>
+          ) : (
+            <>
+              tap at <span className="font-mono text-cf-accent">{status.position}</span>
+              {" → "}
+              <span className="font-mono text-cf-accent">
+                {formatDeviation(status.deviation)}
+              </span>
+            </>
+          )}
+        </p>
+      ) : null}
+
+      <div
+        role="group"
+        aria-label="Dial positions"
+        className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4"
+      >
+        {DIAL_BUTTONS.map(({ position, oclock }) => {
+          const submittingThis =
+            status.kind === "submitting" && status.position === position;
+          return (
+            <button
+              key={position}
+              type="button"
+              onClick={() => handleTap(position)}
+              disabled={isSubmitting}
+              aria-label={`Tap at ${position} seconds (${oclock} o'clock)`}
+              className="group flex flex-col items-center justify-center gap-1 rounded-lg border border-cf-border bg-cf-bg px-4 py-6 text-cf-text transition-colors hover:border-cf-accent hover:bg-cf-accent/5 focus:border-cf-accent focus:outline-none focus:ring-2 focus:ring-cf-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <span className="font-mono text-3xl font-medium tabular-nums text-cf-text group-hover:text-cf-accent">
+                {position}
+              </span>
+              <span className="text-xs text-cf-text-muted">{oclock} o&apos;clock</span>
+              {submittingThis ? (
+                <span className="text-xs text-cf-accent">Logging…</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleBaseline}
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full border border-cf-accent/40 bg-cf-accent/10 px-4 py-2 text-xs font-medium text-cf-accent transition-colors hover:border-cf-accent hover:bg-cf-accent/20 disabled:opacity-60"
+        >
+          {status.kind === "submitting" && status.position === "baseline"
+            ? "Saving baseline…"
+            : "I just set my watch (baseline)"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowNotes((s) => !s)}
+          className="text-xs text-cf-text-muted hover:text-cf-text"
+          aria-expanded={showNotes}
+        >
+          {showNotes ? "Hide notes" : "Add notes"}
+        </button>
+      </div>
+
+      {showNotes ? (
+        <label className="mt-3 block text-sm">
+          <span className="sr-only">Notes</span>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            disabled={isSubmitting}
+            rows={2}
+            maxLength={500}
+            placeholder="e.g. worn overnight face-up, 20ºC"
+            className="w-full rounded-md border border-cf-border bg-cf-bg px-3 py-2 text-sm text-cf-text placeholder:text-cf-text-subtle focus:border-cf-accent focus:outline-none disabled:opacity-60"
+          />
+        </label>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -121,6 +121,35 @@ export async function createReading(
   return { ok: true, reading };
 }
 
+/**
+ * Wire body for the tap-reading flow. Reference time is server-side,
+ * so there's no `reference_timestamp` here — the server uses its own
+ * `Date.now()` at request receipt and computes the deviation.
+ */
+export interface CreateTapReadingBody {
+  dial_position: 0 | 15 | 30 | 45;
+  is_baseline?: boolean;
+  notes?: string;
+}
+
+export async function createTapReading(
+  watchId: string,
+  body: CreateTapReadingBody,
+): Promise<{ ok: true; reading: Reading } | { ok: false; error: ReadingsError }> {
+  const response = await fetch(
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings/tap`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(body),
+    },
+  );
+  if (!response.ok) return { ok: false, error: await readError(response) };
+  const reading = (await response.json()) as Reading;
+  return { ok: true, reading };
+}
+
 export async function deleteReading(
   id: string,
 ): Promise<{ ok: true } | { ok: false; error: ReadingsError }> {

--- a/src/schemas/reading.test.ts
+++ b/src/schemas/reading.test.ts
@@ -1,0 +1,56 @@
+// Unit tests for the readings Zod schemas. Covers the new tap-reading
+// flow (slice: tap UX) where the client sends only `dial_position` +
+// `is_baseline` + optional `notes` — reference time is server-side.
+
+import { describe, expect, it } from "vitest";
+import { createTapReadingSchema } from "./reading";
+
+describe("createTapReadingSchema", () => {
+  it("accepts each canonical dial position", () => {
+    for (const pos of [0, 15, 30, 45] as const) {
+      const parsed = createTapReadingSchema.safeParse({
+        dial_position: pos,
+        is_baseline: false,
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.dial_position).toBe(pos);
+      }
+    }
+  });
+
+  it("rejects a dial_position that is not 0/15/30/45", () => {
+    for (const bad of [1, 7, 14, 59, 60, -1, 22.5]) {
+      const parsed = createTapReadingSchema.safeParse({ dial_position: bad });
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it("defaults is_baseline to false when omitted", () => {
+    const parsed = createTapReadingSchema.safeParse({ dial_position: 0 });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.is_baseline).toBe(false);
+    }
+  });
+
+  it("trims notes and enforces the 500-char max", () => {
+    const ok = createTapReadingSchema.safeParse({
+      dial_position: 15,
+      notes: "   hello   ",
+    });
+    expect(ok.success).toBe(true);
+    if (ok.success) expect(ok.data.notes).toBe("hello");
+
+    const tooLong = createTapReadingSchema.safeParse({
+      dial_position: 15,
+      notes: "x".repeat(501),
+    });
+    expect(tooLong.success).toBe(false);
+  });
+
+  it("rejects a missing dial_position", () => {
+    const parsed = createTapReadingSchema.safeParse({ is_baseline: true });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/schemas/reading.ts
+++ b/src/schemas/reading.ts
@@ -36,6 +36,35 @@ export const createReadingSchema = z.object({
 
 export type CreateReadingInput = z.infer<typeof createReadingSchema>;
 
+// Tap-reading flow (new manual UX, replaces the typed-deviation form).
+//
+// The user looks at their watch, waits for the second hand to cross
+// one of the four canonical dial positions (0 / 15 / 30 / 45, i.e.
+// 12 / 3 / 6 / 9 o'clock), and taps the matching button the instant
+// the hand lands on that mark. The server's own `Date.now()` at
+// request receipt is the reference time — the client timestamp is
+// deliberately NOT part of the wire contract so a client clock can't
+// be spoofed.
+//
+// Granularity is 15 s by design; this isn't meant to replace the
+// verified-reading (camera-based) flow for competitive rankings.
+export const createTapReadingSchema = z.object({
+  // The second-hand position the user saw at the moment of tap.
+  // Constrained to the four canonical marks so deviation math stays
+  // unambiguous (see the wrap logic in the route).
+  dial_position: z.union([z.literal(0), z.literal(15), z.literal(30), z.literal(45)], {
+    message: "dial_position must be one of 0, 15, 30, 45",
+  }),
+  is_baseline: z.boolean().default(false),
+  notes: z
+    .string()
+    .trim()
+    .max(NOTES_MAX, { message: `Notes must be ${NOTES_MAX} characters or fewer` })
+    .optional(),
+});
+
+export type CreateTapReadingInput = z.infer<typeof createTapReadingSchema>;
+
 // Wire shape returned by the readings API. Flattens the DB row's
 // 0/1 booleans to real booleans and leaves everything else as-is.
 export const readingResponseSchema = z.object({
@@ -53,14 +82,15 @@ export const readingResponseSchema = z.object({
 export type ReadingResponse = z.infer<typeof readingResponseSchema>;
 
 /**
- * Flatten a Zod error from `createReadingSchema` into a compact
- * `{ field: message }` record for inline form errors. Mirrors the
- * formatWatchErrors helper so the SPA can render failures the same
- * way everywhere.
+ * Flatten a Zod error from `createReadingSchema` or
+ * `createTapReadingSchema` into a compact `{ field: message }`
+ * record for inline form errors. Mirrors the formatWatchErrors
+ * helper so the SPA can render failures the same way everywhere.
+ *
+ * Typed as `z.ZodError` (unparameterised) so it works for both
+ * reading-schema variants without a generic on the call site.
  */
-export function formatReadingErrors(
-  error: z.ZodError<CreateReadingInput>,
-): Record<string, string> {
+export function formatReadingErrors(error: z.ZodError): Record<string, string> {
   const out: Record<string, string> = {};
   for (const issue of error.issues) {
     const key = issue.path[0];

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -35,6 +35,7 @@ import { assertWatchOwnership } from "@/domain/watches/ownership";
 import { logEvent } from "@/observability/events";
 import {
   createReadingSchema,
+  createTapReadingSchema,
   formatReadingErrors,
   type ReadingResponse,
 } from "@/schemas/reading";
@@ -260,6 +261,106 @@ readingsByWatchRoute.post("/", async (c) => {
   });
 
   // Product telemetry (slice #19). Fire-and-forget.
+  await logEvent(
+    "reading_submitted",
+    { userId: user.id, watchId, is_baseline: input.is_baseline === true },
+    c.env,
+  );
+
+  return c.json(toResponse(created as DbReadingRow), 201);
+});
+
+/**
+ * POST /tap — log a manual reading via the "tap the dial position" UX.
+ *
+ * The client sends only `dial_position` ∈ {0, 15, 30, 45} + an
+ * optional `is_baseline` + optional `notes`. The server uses its own
+ * `Date.now()` as the reference, which makes the flow spoof-resistant
+ * (the client clock is not part of the contract).
+ *
+ * Deviation math:
+ *   refSeconds = floor(now / 1000) % 60
+ *   rawDelta   = dial_position - refSeconds        // in [-45, +45]
+ *   deviation  = ((rawDelta + 30 + 60) % 60) - 30  // wrap into [-30, +30]
+ *
+ * Wrapping to [-30, +30] is the natural domain for "which direction
+ * is this watch off by" with 15 s granularity. A drift > ±30 s from
+ * the nearest minute boundary is ambiguous without the minute hand
+ * and is conventionally treated as wrap-around — e.g. tap-0 when the
+ * server is at second 45 means the user saw "0" arrive 15 s BEFORE
+ * the real minute mark, i.e. the watch is +15 s ahead.
+ *
+ * `verified` stays 0 — tap readings are still manual, just with the
+ * server's clock as the reference rather than the user's typed
+ * deviation. Only the in-app camera capture flow yields verified=1.
+ */
+readingsByWatchRoute.post("/tap", async (c) => {
+  const user = c.get("user");
+  const watchId = getWatchIdParam(c);
+  if (!watchId) return c.json({ error: "not_found" }, 404);
+  const db = createDb(c.env);
+
+  let json: unknown;
+  try {
+    json = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+  const parsed = createTapReadingSchema.safeParse(json);
+  if (!parsed.success) {
+    return c.json(
+      { error: "invalid_input", fieldErrors: formatReadingErrors(parsed.error) },
+      400,
+    );
+  }
+  const input = parsed.data;
+
+  const ownership = await assertWatchOwnership(db, watchId, user.id);
+  if (ownership.status === "not_found") {
+    return c.json({ error: "not_found" }, 404);
+  }
+  if (ownership.status === "forbidden") {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
+  // Reference time is server-authoritative. `Date.now()` under
+  // miniflare/workerd honours vi.setSystemTime() in tests.
+  const referenceTimestamp = Date.now();
+  const refSeconds = Math.floor(referenceTimestamp / 1000) % 60;
+  const rawDelta = input.dial_position - refSeconds;
+  // ((x % 60) + 60) % 60 gives a non-negative remainder; shifting by
+  // +30 before the mod and subtracting after lands us in [-30, +30].
+  const wrapped = ((((rawDelta + 30) % 60) + 60) % 60) - 30;
+  const deviation = input.is_baseline ? 0 : wrapped;
+
+  const id = crypto.randomUUID();
+  await db
+    .insertInto("readings")
+    .values({
+      id,
+      watch_id: watchId,
+      user_id: user.id,
+      reference_timestamp: referenceTimestamp,
+      deviation_seconds: deviation,
+      is_baseline: input.is_baseline ? 1 : 0,
+      notes: input.notes ?? null,
+    })
+    .execute();
+
+  const created = await db
+    .selectFrom("readings")
+    .selectAll()
+    .where("id", "=", id)
+    .executeTakeFirstOrThrow();
+
+  const username = await lookupUsername(db, user.id);
+  await purgeLeaderboardUrls({
+    requestUrl: new URL(c.req.url),
+    movementId: ownership.watch.movement_id,
+    username,
+    watchId,
+  });
+
   await logEvent(
     "reading_submitted",
     { userId: user.id, watchId, is_baseline: input.is_baseline === true },

--- a/tests/integration/readings.tap.test.ts
+++ b/tests/integration/readings.tap.test.ts
@@ -1,0 +1,315 @@
+// Integration tests for POST /api/v1/watches/:watchId/readings/tap.
+//
+// The "tap" flow: client sends only `dial_position` (0/15/30/45) +
+// `is_baseline` + optional `notes`. The server uses its own
+// Date.now() as the reference. Deviation is computed as the signed
+// distance (in [-30, +30]) between the tapped position and the
+// server's current second-of-minute.
+//
+// Fake timers are pinned per-test so the math is deterministic. The
+// handler reads Date.now() directly, so vi.setSystemTime() is enough
+// — no module-level stubbing required.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const movementId = "test-readings-tap-eta-2824";
+
+beforeAll(async () => {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      movementId,
+      "Test ETA 2824 (tap readings)",
+      "ETA",
+      "2824 (tap readings)",
+      "automatic",
+      "approved",
+      null,
+    )
+    .run();
+});
+
+afterEach(() => {
+  // Every test pins its own system time — clean up after each to
+  // avoid leaking fake time into sibling suites (particularly the
+  // verified-readings tests which also use fake timers).
+  vi.useRealTimers();
+});
+
+// ---- Auth + watch helpers (mirror readings.test.ts) ----------------
+
+function makeEmail(prefix = "tapread"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function signUp(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: email.split("@")[0]!, email, password }),
+    }),
+  );
+}
+
+async function signIn(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+}
+
+interface TestUser {
+  cookie: string;
+  userId: string;
+}
+
+async function registerAndGetCookie(): Promise<TestUser> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await signUp(email, password);
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as { user: { id: string } };
+  const loginRes = await signIn(email, password);
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return { cookie, userId: regBody.user.id };
+}
+
+async function createWatch(
+  body: { name: string; movement_id: string; is_public?: boolean },
+  cookie: string,
+): Promise<{ id: string }> {
+  const res = await exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/watches", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+  expect(res.status).toBe(201);
+  return (await res.json()) as { id: string };
+}
+
+interface TapBody {
+  dial_position?: number;
+  is_baseline?: boolean;
+  notes?: string;
+}
+
+async function postTap(
+  watchId: string,
+  body: TapBody,
+  cookie?: string,
+): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/api/v1/watches/${watchId}/readings/tap`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+interface ReadingBody {
+  id: string;
+  watch_id: string;
+  user_id: string;
+  reference_timestamp: number;
+  deviation_seconds: number;
+  is_baseline: boolean;
+  verified: boolean;
+  notes: string | null;
+  created_at: string;
+}
+
+const TWO_USER_TIMEOUT = 30_000;
+
+/**
+ * Build a millisecond unix timestamp where the minute is fixed and
+ * the second-of-minute is exactly `sec`. Handy for pinning
+ * Date.now() to a known second boundary.
+ */
+function msAtSecond(sec: number): number {
+  // 2026-01-15T10:00:sec.000Z — arbitrary stable wall-clock value.
+  return Date.UTC(2026, 0, 15, 10, 0, sec, 0);
+}
+
+// ---- POST /api/v1/watches/:id/readings/tap -------------------------
+
+describe("POST /api/v1/watches/:id/readings/tap", () => {
+  it("records deviation 0 when the tapped position matches the server second", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(30));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap exact", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(
+      watchId,
+      { dial_position: 30, is_baseline: false },
+      owner.cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.watch_id).toBe(watchId);
+    expect(body.user_id).toBe(owner.userId);
+    expect(body.deviation_seconds).toBe(0);
+    expect(body.is_baseline).toBe(false);
+    expect(body.verified).toBe(false);
+    // Server-supplied reference timestamp. Matches Date.now()
+    // at handler entry (may differ by a few ms from the pinned
+    // value because Better Auth etc. advance fake time — but it
+    // must be in the same second window).
+    expect(Math.floor(body.reference_timestamp / 1000)).toBe(
+      Math.floor(msAtSecond(30) / 1000),
+    );
+  });
+
+  it("computes a small negative deviation when the watch is behind", async () => {
+    // Server second = 5, user taps 0 → watch reads 0 when real time
+    // is 5 → the watch is 5 s BEHIND → deviation -5.
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(5));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap behind", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(watchId, { dial_position: 0 }, owner.cookie);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.deviation_seconds).toBe(-5);
+  });
+
+  it("wraps the tap-0-when-ref-is-45 case to +15 (watch is ahead)", async () => {
+    // Server second = 45, user taps 0 → treated as the NEXT minute's
+    // zero mark arrived 15 s early → watch is 15 s AHEAD.
+    // Arithmetic: delta = 0 - 45 = -45. Wrap: (-45 + 30 + 60) % 60 - 30 = 15.
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(45));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap wrap", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(watchId, { dial_position: 0 }, owner.cookie);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.deviation_seconds).toBe(15);
+  });
+
+  it("handles tap-45-when-ref-is-0 as -15 (ambiguous, conventional)", async () => {
+    // delta = 45 - 0 = 45. Wrap: (45 + 30 + 60) % 60 - 30 = -15.
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(0));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap 45/0", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(watchId, { dial_position: 45 }, owner.cookie);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.deviation_seconds).toBe(-15);
+  });
+
+  it("handles tap-45-when-ref-is-55 as -10 (same direction, no wrap)", async () => {
+    // delta = 45 - 55 = -10. Wrap: (-10 + 30 + 60) % 60 - 30 = -10.
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(55));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap 45/55", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(watchId, { dial_position: 45 }, owner.cookie);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.deviation_seconds).toBe(-10);
+  });
+
+  it("forces deviation to 0 when is_baseline=true, regardless of clock skew", async () => {
+    // Ref-second 20, tap 0 would normally give +20 (wrap) or -20
+    // depending on convention — but baseline always wins and stores 0.
+    vi.useFakeTimers();
+    vi.setSystemTime(msAtSecond(20));
+
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Tap baseline", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(
+      watchId,
+      { dial_position: 0, is_baseline: true },
+      owner.cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ReadingBody;
+    expect(body.is_baseline).toBe(true);
+    expect(body.deviation_seconds).toBe(0);
+  });
+
+  it("rejects unauthenticated tap requests (401)", async () => {
+    const res = await postTap("whatever", { dial_position: 0 });
+    expect(res.status).toBe(401);
+  });
+
+  it(
+    "rejects a non-owner tap (403)",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const other = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Theirs-tap", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postTap(watchId, { dial_position: 15 }, other.cookie);
+      expect(res.status).toBe(403);
+    },
+    TWO_USER_TIMEOUT,
+  );
+
+  it("rejects invalid dial_position (400)", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Bad-tap", movement_id: movementId },
+      owner.cookie,
+    );
+    for (const bad of [7, 60, -1, 22.5]) {
+      const res = await postTap(watchId, { dial_position: bad } as TapBody, owner.cookie);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_input");
+    }
+  });
+
+  it("rejects missing dial_position (400)", async () => {
+    const owner = await registerAndGetCookie();
+    const { id: watchId } = await createWatch(
+      { name: "Missing-tap", movement_id: movementId },
+      owner.cookie,
+    );
+    const res = await postTap(watchId, { is_baseline: false } as TapBody, owner.cookie);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the typed-deviation manual-reading flow with a **tap-the-dial-position** UX. The user waits for the second hand to cross 12 / 3 / 6 / 9 o'clock, taps the matching button, and the server uses its own `Date.now()` as the reference to compute the signed deviation.

- Eliminates typing and mental math.
- Uses server-receipt time — the client clock is no longer part of the wire contract.
- 15 s granularity by design; verified (camera-based) readings remain the path for competitive rankings.

## Server

- New Zod schema `createTapReadingSchema` in `src/schemas/reading.ts` — `dial_position ∈ {0,15,30,45}` + `is_baseline` + optional `notes`. No `reference_timestamp`.
- New route `POST /api/v1/watches/:watchId/readings/tap` in `src/server/routes/readings.ts`:
  - `refSeconds = floor(Date.now()/1000) % 60`
  - `deviation = ((dial_position - refSeconds + 30 + 60) % 60) - 30` → wrapped into `[-30, +30]` s.
  - `is_baseline = true` forces `deviation = 0` server-side.
- Old `POST /readings` endpoint untouched; both live side-by-side.

## SPA

- New `src/app/watches/TapReadingForm.tsx` — four large dial-position buttons (2×2 on mobile, 4-across on wider), live second counter, a separate "I just set my watch (baseline)" button, and an optional notes disclosure.
- `TapReadingForm` replaces `LogReadingForm` in `src/app/pages/WatchDetailPage.tsx`.
- `LogReadingForm.tsx` kept in-tree with a `@deprecated` marker — decision below.
- Tap fires the POST immediately; a transient "recorded" toast shows the computed deviation, then reverts to idle after 1.6 s. Parent re-fetches in the background via `onLogged`.

## Tests

- `src/schemas/reading.test.ts` — 5 new unit tests for the tap schema.
- `tests/integration/readings.tap.test.ts` — 10 new integration tests:
  - exact match → deviation 0
  - small negative (tap 0 at ref 5 → −5)
  - wrap cases (tap 0 at ref 45 → +15; tap 45 at ref 0 → −15; tap 45 at ref 55 → −10)
  - baseline forces deviation 0
  - 401 / 403 / 400 (bad dial_position, missing dial_position)
- Uses `vi.useFakeTimers()` + `vi.setSystemTime()` — the handler reads `Date.now()` directly so fake time flows through.

Existing 368 tests untouched. Total suite: **383 passing**.

## Deferred

- Removing the old typed-deviation endpoint + `LogReadingForm.tsx`. Keep both alive this round; cleanup after the tap UX has been used in production.
- Sub-second precision. 4-position UX is 15 s granular by design.
- Verified readings — camera flow unchanged.

## Decision: keep or drop `LogReadingForm.tsx`?

**Kept** — per the dispatch spec. Retained with a `@deprecated` marker and the removal reasoning in the file header. Nothing in the tree imports it; it's dead on the SPA side but safe to delete in a follow-up once the new tap flow has had real-world use.

## CI

Will run on push. Preview deploys to `pr-<N>-ratedwatch.nmoura.workers.dev`; E2E smoke hits that preview.