### PR TITLE
feat(ai-dial-reader): MM:SS contract — drift > ±30s now resolves

### DIFF
--- a/src/domain/ai-dial-reader/reader.test.ts
+++ b/src/domain/ai-dial-reader/reader.test.ts
@@ -32,28 +32,48 @@ function installFake(
 }
 
 describe("readDialTime", () => {
-  it("parses a single-digit seconds response", async () => {
-    installFake("7");
+  it("parses a two-digit MM:SS response", async () => {
+    installFake("32:17");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ seconds: 7, raw_response: "7" });
+    expect(result).toEqual({ minutes: 32, seconds: 17, raw_response: "32:17" });
   });
 
-  it("parses a two-digit seconds response", async () => {
-    installFake("42");
+  it("parses single-digit components on either side", async () => {
+    installFake("3:7");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ seconds: 42, raw_response: "42" });
+    expect(result).toEqual({ minutes: 3, seconds: 7, raw_response: "3:7" });
   });
 
-  it("parses zero", async () => {
-    installFake("0");
+  it("parses zero-padded components", async () => {
+    installFake("03:07");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ seconds: 0, raw_response: "0" });
+    expect(result).toEqual({ minutes: 3, seconds: 7, raw_response: "03:07" });
+  });
+
+  it("parses the top of the minute", async () => {
+    installFake("0:0");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ minutes: 0, seconds: 0, raw_response: "0:0" });
+  });
+
+  it("parses the end of the hour", async () => {
+    installFake("59:59");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({
+      minutes: 59,
+      seconds: 59,
+      raw_response: "59:59",
+    });
   });
 
   it("trims surrounding whitespace before parsing", async () => {
-    installFake("   15  \n");
+    installFake("   15:42  \n");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ seconds: 15, raw_response: "15" });
+    expect(result).toEqual({
+      minutes: 15,
+      seconds: 42,
+      raw_response: "15:42",
+    });
   });
 
   it("returns refused for NO_DIAL", async () => {
@@ -69,11 +89,11 @@ describe("readDialTime", () => {
   });
 
   it("returns unparseable for prose responses", async () => {
-    installFake("The second hand is at about 42");
+    installFake("The time shown is 32:17 approximately");
     const result = await readDialTime(fakeImage, fakeEnv);
     expect("error" in result ? result.error : null).toBe("unparseable");
     if ("error" in result) {
-      expect(result.raw_response).toBe("The second hand is at about 42");
+      expect(result.raw_response).toBe("The time shown is 32:17 approximately");
     }
   });
 
@@ -86,30 +106,45 @@ describe("readDialTime", () => {
     }
   });
 
-  it("returns implausible for an out-of-range integer (60)", async () => {
-    installFake("60");
+  it("returns implausible when minutes are out of range", async () => {
+    installFake("99:17");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ error: "implausible", raw_response: "60" });
+    expect(result).toEqual({ error: "implausible", raw_response: "99:17" });
   });
 
-  it("returns implausible for an out-of-range integer (99)", async () => {
-    installFake("99");
+  it("returns implausible when seconds are out of range", async () => {
+    installFake("32:99");
     const result = await readDialTime(fakeImage, fakeEnv);
-    expect(result).toEqual({ error: "implausible", raw_response: "99" });
+    expect(result).toEqual({ error: "implausible", raw_response: "32:99" });
+  });
+
+  it("returns implausible when seconds hit 60 (off-by-one from 59 max)", async () => {
+    installFake("32:60");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect(result).toEqual({ error: "implausible", raw_response: "32:60" });
   });
 
   it("returns unparseable for HH:MM:SS (legacy model output)", async () => {
-    // Regression guard: the previous model was prompted for
-    // HH:MM:SS; if a model ever returns that again, we want the
-    // reader to reject it cleanly rather than trying to salvage a
-    // number from it.
+    // Regression guard: an earlier model was prompted for HH:MM:SS.
+    // If a model ever returns that again, we want the reader to
+    // reject it cleanly rather than try to salvage a number from it.
     installFake("14:32:07");
     const result = await readDialTime(fakeImage, fakeEnv);
     expect("error" in result ? result.error : null).toBe("unparseable");
   });
 
+  it("returns unparseable for seconds-only (pre-MM:SS contract)", async () => {
+    // Regression guard: the previous seconds-only contract would
+    // have accepted "42". The new contract requires MM:SS; a bare
+    // integer must be rejected so we don't silently treat it as
+    // minutes=42, seconds=0 (or similar).
+    installFake("42");
+    const result = await readDialTime(fakeImage, fakeEnv);
+    expect("error" in result ? result.error : null).toBe("unparseable");
+  });
+
   it("returns unparseable for a signed number", async () => {
-    installFake("-5");
+    installFake("-5:10");
     const result = await readDialTime(fakeImage, fakeEnv);
     expect("error" in result ? result.error : null).toBe("unparseable");
   });
@@ -132,17 +167,17 @@ describe("readDialTime", () => {
     let captured: { image: Uint8Array; prompt: string } | null = null;
     __setTestAiRunner(async (inputs) => {
       captured = { image: inputs.image, prompt: inputs.prompt };
-      return { response: "10" };
+      return { response: "10:42" };
     });
     await readDialTime(fakeImage, fakeEnv);
     expect(captured).not.toBeNull();
     expect(Array.from(captured!.image)).toEqual([0xff, 0xd8, 0xff, 0xd9]);
-    // The new prompt asks for a single integer 0-59 only.
-    expect(captured!.prompt).toContain("second hand");
-    expect(captured!.prompt).toContain("0-59");
+    // The new prompt asks for MM:SS. It should mention both hands.
+    expect(captured!.prompt).toContain("minute and second hand");
+    expect(captured!.prompt).toContain("MM:SS");
     expect(captured!.prompt).toContain("NO_DIAL");
     expect(captured!.prompt).toContain("UNREADABLE");
-    // And it no longer asks for HH:MM:SS.
+    // And it no longer asks for seconds-only or HH:MM:SS.
     expect(captured!.prompt).not.toContain("HH:MM:SS");
   });
 
@@ -150,7 +185,7 @@ describe("readDialTime", () => {
     let captured: string | null = null;
     __setTestAiRunner(async (inputs) => {
       captured = inputs.prompt;
-      return { response: "15" };
+      return { response: "32:17" };
     });
     const hint = new Date(Date.UTC(2024, 0, 1, 14, 32, 5));
     await readDialTime(fakeImage, fakeEnv, hint);
@@ -160,10 +195,10 @@ describe("readDialTime", () => {
 });
 
 describe("buildPrompt", () => {
-  it("produces a prompt that asks for only the second hand (0-59)", () => {
+  it("produces a prompt that asks for MM:SS", () => {
     const prompt = buildPrompt();
-    expect(prompt).toContain("second hand");
-    expect(prompt).toContain("0-59");
+    expect(prompt).toContain("minute and second hand");
+    expect(prompt).toContain("MM:SS");
     expect(prompt).toContain("NO_DIAL");
     expect(prompt).toContain("UNREADABLE");
     expect(prompt).not.toContain("HH:MM:SS");
@@ -181,8 +216,8 @@ describe("buildPrompt", () => {
     expect(prompt).not.toMatch(/return this time/i);
     expect(prompt).not.toMatch(/reply with this time/i);
     // The prompt names the reference anchor, but the output surface
-    // is only the second hand — the model cannot honestly "copy" the
-    // reference without reading the dial.
+    // is MM:SS only — the model cannot honestly "copy" the reference
+    // without reading the dial.
     expect(prompt).toContain("reference clock");
   });
 });

--- a/src/domain/ai-dial-reader/reader.ts
+++ b/src/domain/ai-dial-reader/reader.ts
@@ -1,6 +1,7 @@
 // AI dial reader. Takes a JPEG of a watch face and asks a vision
-// model for the position of the second hand. Returns a structured
-// `DialReading` (seconds only) or a structured error.
+// model for the minute + second positions the watch is displaying.
+// Returns a structured `DialReading` (minutes + seconds) or a
+// structured error.
 //
 // This module is deliberately small and side-effect-free apart from
 // the single AI call: the verified-reading pipeline (reading-verifier)
@@ -11,24 +12,29 @@
 // Trust contract (AGENTS.md): we never, ever tell the model "just
 // return the reference time". The archived watchdrift prototype did
 // that and produced a cheating system. The reference clock is used
-// as the HH:MM anchor — the hours + minutes of a verified reading
-// come from the server clock, not from the model — but the *seconds*
-// come from the model's own visual read of the dial. That split is
-// both the honest thing to do and cheaper in tokens: the model's
-// output surface is a single integer 0-59.
+// as the HOUR anchor only — the hour of a verified reading comes
+// from the server clock, not from the model. Minutes and seconds
+// both come from the model's own visual read of the dial.
+//
+// Why both minutes and seconds (changed from seconds-only): a
+// seconds-only contract caps us at ±30 s of detectable drift (a
+// watch that's drifted ~45 s past the reference would wrap and
+// under-report). Real mechanical drift routinely exceeds 30 s over
+// a session, so we need the minute hand to disambiguate. Minute +
+// second gives us a ±30 *minute* detection range, which is more
+// than adequate for any realistic mechanical watch.
 
 import { resolveAiRunner, type AiRunnerEnv, type AiRunResponse } from "./runner";
 
 /**
- * A successful dial read. Only the second-hand position — hours and
- * minutes come from the reference clock in the verifier. A watch
- * without a visible second hand cannot produce a verified reading;
- * the model must return UNREADABLE in that case.
+ * A successful dial read. Minute + second hand positions only — the
+ * hour comes from the reference clock in the verifier because a
+ * 12-hour dial wrap makes any hour output ambiguous.
  */
 export interface DialReading {
-  // Second hand position (0-59). Hours + minutes come from the
-  // reference clock, not the model — the model is only asked for
-  // this one number.
+  // Minute hand position (0-59). Comes from the model's visual read.
+  minutes: number;
+  // Second hand position (0-59). Comes from the model's visual read.
   seconds: number;
   raw_response: string;
 }
@@ -42,28 +48,34 @@ export interface DialReaderError {
 
 export interface DialReaderEnv extends AiRunnerEnv {}
 
-// Strict parse: exactly 1-2 digits, no leading +/-, no decimals.
-// Anchored so we don't accept "42 seconds" or "about 42".
-const SECONDS_ONLY = /^\d{1,2}$/;
+// Strict parse: MM:SS with 1-2 digits each side, no leading +/-, no
+// decimals. Anchored so we don't accept "32:17 seconds" or "about
+// 32:17". The model is instructed to reply in this exact shape.
+const MINUTES_AND_SECONDS = /^(\d{1,2}):(\d{1,2})$/;
 
 const PROMPT_BASE = `You are reading a mechanical watch dial shown in a photo.
 
 The reference clock reads HH_ANCHOR right now. The watch is approximately
-synchronised with this reference. Your task is only to read the WATCH's
-second hand — the thinnest, usually centrally-mounted hand that sweeps
-once per minute.
+synchronised with this reference — typically within a few minutes either
+way. Your task is to read the watch's minute and second hand positions.
 
-Report only the position of the second hand as a single integer 0-59.
+Report the time the watch displays in the format MM:SS where:
+- MM is the minute value 0-59 (where the MINUTE hand points — usually
+  the slightly shorter, thicker hand that advances once per minute)
+- SS is the second value 0-59 (where the SECOND hand points — the
+  thinnest hand that sweeps continuously or ticks once per second)
 
-Do not explain. Do not guess if you cannot see the second hand clearly.
+Do not report the hour — we have that from the reference clock.
+Do not explain. Do not pad with zeros unless natural (both "3:07" and
+"03:07" are accepted).
 
-If you cannot read the second hand clearly, reply with exactly:
-UNREADABLE
+If you cannot read the minute or second hand clearly, reply with
+exactly: UNREADABLE
 
-If the image is not a watch, reply with exactly:
-NO_DIAL
+If the image is not a watch dial, reply with exactly: NO_DIAL
 
-Examples of valid replies: "0", "15", "42", "UNREADABLE", "NO_DIAL"`;
+Examples of valid replies: "32:17", "03:45", "59:0", "0:12",
+"UNREADABLE", "NO_DIAL"`;
 
 /**
  * Build the prompt. Embeds a reference timestamp as an HH:MM:SS
@@ -122,15 +134,24 @@ export async function readDialTime(
     return { error: "refused", raw_response: raw };
   }
 
-  if (!SECONDS_ONLY.test(raw)) {
+  const match = MINUTES_AND_SECONDS.exec(raw);
+  if (!match) {
     return { error: "unparseable", raw_response: raw };
   }
 
-  const seconds = Number(raw);
-  if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
-    // e.g. "99" — two digits, passes the regex, but out of range.
+  const minutes = Number(match[1]);
+  const seconds = Number(match[2]);
+  if (
+    !Number.isFinite(minutes) ||
+    !Number.isFinite(seconds) ||
+    minutes < 0 ||
+    minutes > 59 ||
+    seconds < 0 ||
+    seconds > 59
+  ) {
+    // e.g. "99:17" — passes the regex but out of range.
     return { error: "implausible", raw_response: raw };
   }
 
-  return { seconds, raw_response: raw };
+  return { minutes, seconds, raw_response: raw };
 }

--- a/src/domain/reading-verifier/verifier.test.ts
+++ b/src/domain/reading-verifier/verifier.test.ts
@@ -1,78 +1,126 @@
 import { describe, it, expect } from "vitest";
 import { computeVerifiedDeviation } from "./verifier";
 
-// Unit tests for the seconds-only drift-computation helper. The
-// broader verifier pipeline (R2 upload, DB insert, AI call) is
-// covered by tests/integration/readings.verified.test.ts — this file
-// is only the minute-boundary math.
+// Unit tests for the MM:SS drift-computation helper. The broader
+// verifier pipeline (R2 upload, DB insert, AI call) is covered by
+// tests/integration/readings.verified.test.ts — this file is only
+// the minute-boundary math.
 //
-// Contract: the dial reader now returns only `seconds` (0-59). The
-// verifier wraps dialSec - refSec into [-30, +30]. Drifts > 30 s in
-// absolute value are ambiguous without the minute hand and wrap —
-// that's a documented constraint, not a bug.
+// Contract: the dial reader returns `{ minutes, seconds }` (0-59
+// each). The verifier wraps (dialMin*60 + dialSec) - (refMin*60 +
+// refSec) into [-1800, +1800] seconds — a ±30 minute window. Any
+// drift > 30 minutes in absolute value wraps (documented constraint;
+// realistic mechanical drift never approaches that).
 
 function tsFromHms(hh: number, mm: number, ss: number): number {
   // Anchor to an arbitrary UTC day so the math is hermetic to the
-  // runner's local TZ. `computeVerifiedDeviation` reads seconds-of-
-  // minute from the ms timestamp, which is TZ-independent anyway.
+  // runner's local TZ. `computeVerifiedDeviation` derives MM:SS
+  // from the ms timestamp via UTC getters, which is TZ-independent.
   return Date.UTC(2024, 0, 15, hh, mm, ss);
 }
 
 describe("computeVerifiedDeviation", () => {
   it("dial ahead of reference by 2s → +2", () => {
-    expect(computeVerifiedDeviation({ seconds: 7 }, tsFromHms(14, 32, 5))).toBe(2);
+    expect(
+      computeVerifiedDeviation({ minutes: 32, seconds: 7 }, tsFromHms(14, 32, 5)),
+    ).toBe(2);
   });
 
   it("dial behind reference by 3s → -3", () => {
-    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(9, 15, 3))).toBe(-3);
+    expect(
+      computeVerifiedDeviation({ minutes: 15, seconds: 0 }, tsFromHms(9, 15, 3)),
+    ).toBe(-3);
+  });
+
+  it("dial ahead by a full minute + 5s → +65s", () => {
+    // Dial shows 33:10 while reference reads 32:05 — watch is 65s
+    // ahead. Seconds-only contract would have lost the minute.
+    expect(
+      computeVerifiedDeviation({ minutes: 33, seconds: 10 }, tsFromHms(14, 32, 5)),
+    ).toBe(65);
+  });
+
+  it("dial behind by a full minute + 5s → -65s", () => {
+    // Dial 31:00, reference 32:05 — watch is 65s behind.
+    expect(
+      computeVerifiedDeviation({ minutes: 31, seconds: 0 }, tsFromHms(14, 32, 5)),
+    ).toBe(-65);
   });
 
   it("dial exactly matches → 0", () => {
-    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(0, 0, 0))).toBe(0);
-    expect(computeVerifiedDeviation({ seconds: 30 }, tsFromHms(12, 34, 30))).toBe(0);
-    expect(computeVerifiedDeviation({ seconds: 59 }, tsFromHms(8, 8, 59))).toBe(0);
+    expect(computeVerifiedDeviation({ minutes: 0, seconds: 0 }, tsFromHms(0, 0, 0))).toBe(
+      0,
+    );
+    expect(
+      computeVerifiedDeviation({ minutes: 34, seconds: 30 }, tsFromHms(12, 34, 30)),
+    ).toBe(0);
+    expect(
+      computeVerifiedDeviation({ minutes: 8, seconds: 59 }, tsFromHms(8, 8, 59)),
+    ).toBe(0);
   });
 
-  it("minute boundary: dial=02, ref=58 → +4s (not -56s)", () => {
-    // Dial rolled over just before the reference's last tick. Raw
-    // diff is -56; wrap yields +4.
-    expect(computeVerifiedDeviation({ seconds: 2 }, tsFromHms(23, 59, 58))).toBe(4);
+  it("minute boundary: dial=0:02, ref=59:58 → +4s (not -3596s)", () => {
+    // Dial has just rolled over the hour-boundary ahead of the
+    // reference clock; raw diff is -3596; wrap yields +4.
+    expect(
+      computeVerifiedDeviation({ minutes: 0, seconds: 2 }, tsFromHms(23, 59, 58)),
+    ).toBe(4);
   });
 
-  it("minute boundary: dial=58, ref=02 → -4s", () => {
-    // Dial is about to roll over, reference already has. Raw +56;
-    // wrap yields -4.
-    expect(computeVerifiedDeviation({ seconds: 58 }, tsFromHms(0, 0, 2))).toBe(-4);
+  it("minute boundary: dial=59:58, ref=0:02 → -4s", () => {
+    // Reference has rolled over; dial is 4s behind.
+    expect(
+      computeVerifiedDeviation({ minutes: 59, seconds: 58 }, tsFromHms(0, 0, 2)),
+    ).toBe(-4);
   });
 
-  it("wraps true drifts > +30 s into the negative half", () => {
-    // Dial=40, ref=0 → raw +40 → wrap to -20 (documented
-    // ambiguity: without the minute hand we can't tell this from
-    // a -20 s drift).
-    expect(computeVerifiedDeviation({ seconds: 40 }, tsFromHms(14, 0, 0))).toBe(-20);
+  it("wraps true drifts > +30 minutes into the negative half", () => {
+    // Dial 45:00, ref 0:00 → raw +2700s → wrap to -900s (-15 min).
+    expect(
+      computeVerifiedDeviation({ minutes: 45, seconds: 0 }, tsFromHms(14, 0, 0)),
+    ).toBe(-900);
   });
 
-  it("wraps true drifts < -30 s into the positive half", () => {
-    // Dial=0, ref=40 → raw -40 → wrap to +20.
-    expect(computeVerifiedDeviation({ seconds: 0 }, tsFromHms(14, 0, 40))).toBe(20);
+  it("wraps true drifts < -30 minutes into the positive half", () => {
+    // Dial 0:00, ref 45:00 → raw -2700s → wrap to +900s (+15 min).
+    expect(
+      computeVerifiedDeviation({ minutes: 0, seconds: 0 }, tsFromHms(14, 45, 0)),
+    ).toBe(900);
   });
 
-  it("half-period boundary: dial=30, ref=0 → -30 or +30 (consistent)", () => {
-    // The wrap interval [-30, +30] puts the half-period on a single
-    // side — we don't care which, as long as it's deterministic.
-    const result = computeVerifiedDeviation({ seconds: 30 }, tsFromHms(14, 0, 0));
-    expect(Math.abs(result)).toBe(30);
+  it("handles drifts right at ±30 minutes deterministically", () => {
+    // The wrap interval puts the half-period on a single side — we
+    // don't care which, as long as it's deterministic.
+    const result = computeVerifiedDeviation(
+      { minutes: 30, seconds: 0 },
+      tsFromHms(14, 0, 0),
+    );
+    expect(Math.abs(result)).toBe(1800);
   });
 
   it("never returns NaN, even with weird inputs", () => {
-    const result = computeVerifiedDeviation({ seconds: 0 }, tsFromHms(12, 0, 0));
+    const result = computeVerifiedDeviation(
+      { minutes: 0, seconds: 0 },
+      tsFromHms(12, 0, 0),
+    );
     expect(Number.isFinite(result)).toBe(true);
   });
 
-  it("tolerates out-of-range dial seconds by normalising modulo 60", () => {
-    // The reader shouldn't emit these, but the helper shouldn't
-    // explode if it ever sees one.
-    expect(computeVerifiedDeviation({ seconds: 61 }, tsFromHms(0, 0, 1))).toBe(0);
-    expect(computeVerifiedDeviation({ seconds: -1 }, tsFromHms(0, 0, 59))).toBe(0);
+  it("tolerates out-of-range dial minutes/seconds without exploding", () => {
+    // The reader shouldn't emit these (it validates 0-59 on each
+    // field), but the helper shouldn't NaN/Infinity if it ever sees
+    // one. The exact value isn't the contract — "finite, in
+    // [-1800, +1800]" is.
+    for (const mm of [-1, 0, 61]) {
+      for (const ss of [-1, 0, 61]) {
+        const result = computeVerifiedDeviation(
+          { minutes: mm, seconds: ss },
+          tsFromHms(0, 0, 0),
+        );
+        expect(Number.isFinite(result)).toBe(true);
+        expect(result).toBeGreaterThanOrEqual(-1800);
+        expect(result).toBeLessThanOrEqual(1800);
+      }
+    }
   });
 });

--- a/src/domain/reading-verifier/verifier.ts
+++ b/src/domain/reading-verifier/verifier.ts
@@ -5,14 +5,16 @@
 //   1. Capture server-side reference timestamp (`Date.now()`). This
 //      is the canonical source of truth — client / EXIF timestamps
 //      are NEVER trusted for competitive scoring.
-//   2. Run the image through the AI dial reader. The dial reader now
-//      returns *only* the second-hand position (0-59) — hours and
-//      minutes come from the reference clock, not the model.
+//   2. Run the image through the AI dial reader. The reader returns
+//      the minute + second hand positions (0-59 each) — only the
+//      hour is inferred from the reference clock.
 //   3. On AI error → bubble up as a structured failure.
 //   4. On AI success, compute the signed drift in seconds between
-//      the model's observed second-hand position and the reference
-//      clock's own seconds-of-minute, wrapped into [-30, +30] so a
-//      minute-boundary capture doesn't show as a ~30 second drift.
+//      the dial's observed MM:SS (minute + second positions) and
+//      the reference clock's minute + second, wrapped into
+//      [-1800, +1800] so mid-minute captures don't show as
+//      ~1-minute offsets and drifts up to ±30 minutes resolve
+//      cleanly.
 //   5. If `is_baseline`, force deviation to 0 — by definition the
 //      user has just set the watch to the true time.
 //   6. Insert a readings row with verified=1.
@@ -20,16 +22,14 @@
 //      A failure here is logged but doesn't roll back the reading —
 //      the reading is canonical, the photo is for provenance only.
 //
-// Design constraint introduced by the seconds-only model contract:
+// Design constraint introduced by the MM:SS-only model contract:
 //
-//   The model no longer reports hours or minutes, only the second
-//   hand's position (0-59). That means this verifier can only
-//   resolve drifts in the range [-30, +30] seconds — any larger
-//   drift is ambiguous without the minute hand. For phase 1 that's
-//   acceptable: a user logging a verified reading is expected to
-//   roughly sync their watch; anything that's drifted more than
-//   30 seconds in a session will wrap and under-report. That
-//   constraint is documented below next to the wrap math.
+//   We do NOT ask the model for the hour, because a 12-hour dial
+//   wrap means any hour output is ambiguous. The HOUR comes from
+//   the reference clock. That caps the verifier's detectable drift
+//   at ±30 minutes — anything beyond that would wrap. That's more
+//   than adequate for any realistic mechanical watch drift; a watch
+//   that's an hour or more off has stopped, not drifted.
 
 import { createDb } from "@/db";
 import { readDialTime, type DialReaderError } from "@/domain/ai-dial-reader/reader";
@@ -76,48 +76,57 @@ export interface VerifiedReadingRow {
   created_at: string;
 }
 
-// With a seconds-only read, the dial's second hand and the reference
-// clock's seconds-of-minute are both in [0, 59], so their signed
-// difference is in [-59, +59]. Wrap into [-30, +30] so a capture
-// straddling the minute boundary (dial=58, ref=02) is reported as
-// -4 rather than +56.
+// Dial MM:SS and reference MM:SS both live in an hour-of-day frame
+// (0..3599 seconds). Their signed difference is in [-3599, +3599].
+// Wrap into [-1800, +1800] so a capture straddling the hour boundary
+// (dial=59:58, ref=00:02) is reported as -4 s rather than +3596 s.
 //
-// Constraint: any true drift > 30 s in absolute value will wrap and
-// under-report. See the module-level comment.
-const HALF_MINUTE_SECONDS = 30;
+// Constraint: any true drift > 30 minutes will wrap and under-report.
+// See the module-level comment. For realistic mechanical drift this
+// never triggers.
+const SECONDS_PER_HOUR = 3600;
+const HALF_HOUR_SECONDS = 1800;
 
 /**
- * Exported for tests. Computes the seconds-only drift between the
- * dial's observed second-hand position and the reference clock's
- * seconds-of-minute, wrapped into [-30, +30] (lower bound inclusive,
- * upper bound inclusive where 30 and -30 collide at the ±1800° mark).
+ * Exported for tests. Computes the signed drift in seconds between
+ * the dial's observed MM:SS and the reference clock's MM:SS, wrapped
+ * into [-1800, +1800] (the ±30 minute window).
  *
  * Invariants:
- *   * dialReading.seconds must be an integer in [0, 59]. Callers
- *     (readDialTime) enforce that — this helper still tolerates
- *     out-of-range by `%%`-normalising first.
+ *   * dialReading.minutes and .seconds are integers in [0, 59].
+ *     Callers (readDialTime) enforce that — this helper still
+ *     tolerates out-of-range by `%%`-normalising first.
  *   * referenceTimestampMs is a millisecond unix timestamp.
+ *
+ * Positive deviation = watch is ahead of reference. Negative = behind.
  */
 export function computeVerifiedDeviation(
   dialReading: {
+    minutes: number;
     seconds: number;
   },
   referenceTimestampMs: number,
 ): number {
-  const dialSec = dialReading.seconds;
-  // Reference seconds-of-minute. `Math.floor` on the ms / 1000 then
-  // %% 60 gives the current seconds-of-minute in [0, 59].
-  const refSec = Math.floor(referenceTimestampMs / 1000) % 60;
+  // Dial time in seconds-of-hour.
+  const dialTotalSec = dialReading.minutes * 60 + dialReading.seconds;
 
-  // Raw signed delta in [-59, +59]. Positive = watch ahead of
-  // reference; negative = watch behind.
-  let diff = dialSec - refSec;
+  // Reference time in seconds-of-hour. Derive from the wall-clock
+  // minute + second, ignoring the hour (matches what the model sees
+  // on the dial — it doesn't know the hour either).
+  const refDate = new Date(referenceTimestampMs);
+  const refTotalSec = refDate.getUTCMinutes() * 60 + refDate.getUTCSeconds();
 
-  // Wrap into [-30, +30]:
-  //   add 30, take mod 60, subtract 30.
+  // Raw signed delta in [-3599, +3599].
+  let diff = dialTotalSec - refTotalSec;
+
+  // Wrap into [-1800, +1800]:
+  //   add 1800, take mod 3600, subtract 1800.
   // Use a %%-style normalisation because JS `%` keeps the sign of
   // the lhs, which would give wrong answers for large negatives.
-  diff = ((((diff + HALF_MINUTE_SECONDS) % 60) + 60) % 60) - HALF_MINUTE_SECONDS;
+  diff =
+    ((((diff + HALF_HOUR_SECONDS) % SECONDS_PER_HOUR) + SECONDS_PER_HOUR) %
+      SECONDS_PER_HOUR) -
+    HALF_HOUR_SECONDS;
   return diff;
 }
 
@@ -148,9 +157,9 @@ export async function verifyReading(
     return toVerifierError(readerResult);
   }
 
-  // 4. Compute deviation from dial seconds vs reference seconds.
+  // 4. Compute deviation from dial MM:SS vs reference MM:SS.
   let deviation = computeVerifiedDeviation(
-    { seconds: readerResult.seconds },
+    { minutes: readerResult.minutes, seconds: readerResult.seconds },
     referenceTimestamp,
   );
 

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -166,7 +166,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     expect(body.error).toBe("verified_readings_disabled");
   });
 
-  it("computes deviation from AI dial seconds vs server reference clock", async () => {
+  it("computes deviation from AI dial MM:SS vs server reference clock", async () => {
     const user = await registerAndGetCookie();
     await setVerifiedFlagForUser(user.userId);
     const { id: watchId } = await createWatch(
@@ -175,11 +175,12 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     );
 
     // Freeze Date.now() at 14:32:05 UTC so the reference clock is
-    // deterministic. Fake AI returns "7" (seconds) → +2s drift.
+    // deterministic. Fake AI returns "32:07" (MM:SS) → +2s drift
+    // (same minute as reference, 2s ahead).
     const refTime = Date.UTC(2024, 0, 15, 14, 32, 5);
     vi.useFakeTimers();
     vi.setSystemTime(refTime);
-    installFakeAi("7");
+    installFakeAi("32:07");
 
     const res = await postVerifiedReading(watchId, user.cookie);
     expect(res.status).toBe(201);
@@ -194,6 +195,28 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     expect(body.is_baseline).toBe(false);
     expect(body.deviation_seconds).toBeCloseTo(2, 5);
     expect(body.reference_timestamp).toBe(refTime);
+  });
+
+  it("captures drift larger than a minute (dial 33:10 vs ref 32:05 → +65s)", async () => {
+    const user = await registerAndGetCookie();
+    await setVerifiedFlagForUser(user.userId);
+    const { id: watchId } = await createWatch(
+      { name: "V2b", movement_id: movementId },
+      user.cookie,
+    );
+
+    // This is the case the seconds-only contract lost: +65s drift
+    // would have wrapped to -5s under the old math. MM:SS reads it
+    // correctly.
+    const refTime = Date.UTC(2024, 0, 15, 14, 32, 5);
+    vi.useFakeTimers();
+    vi.setSystemTime(refTime);
+    installFakeAi("33:10");
+
+    const res = await postVerifiedReading(watchId, user.cookie);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { deviation_seconds: number };
+    expect(body.deviation_seconds).toBe(65);
   });
 
   it("422s on AI refusal (NO_DIAL)", async () => {
@@ -238,10 +261,10 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
 
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2024, 0, 15, 10, 0, 0));
-    // AI "sees" the second hand at 25 (25 s off the reference's 00);
-    // baseline should still pin deviation to 0 because the user is
-    // declaring "the watch is set to the exact time now".
-    installFakeAi("25");
+    // AI "sees" 0:25 (25 s off the reference's 0:00); baseline
+    // should still pin deviation to 0 because the user is declaring
+    // "the watch is set to the exact time now".
+    installFakeAi("0:25");
 
     const res = await postVerifiedReading(watchId, user.cookie, {
       isBaseline: true,
@@ -265,7 +288,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
         { name: "Theirs", movement_id: movementId },
         owner.cookie,
       );
-      installFakeAi("0");
+      installFakeAi("0:0");
 
       const res = await postVerifiedReading(watchId, other.cookie);
       expect(res.status).toBe(403);
@@ -280,7 +303,7 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
       { name: "V6", movement_id: movementId },
       user.cookie,
     );
-    installFakeAi("30");
+    installFakeAi("0:30");
     const probeBytes = new Uint8Array([0xff, 0xd8, 0xab, 0xcd, 0xff, 0xd9]);
 
     const res = await postVerifiedReading(watchId, user.cookie, {


### PR DESCRIPTION
Previously the prompt asked only for the second hand (0-59), so any watch drift > ±30 seconds wrapped and under-reported. Now the prompt asks for MM:SS (minute + second hands); only the hour still comes from the server clock.

- `DialReading` grows `minutes`.
- Regex: `^(\d{1,2}):(\d{1,2})$`. Legacy seconds-only responses (e.g. `"42"`) now cleanly reject as `unparseable` — regression-guarded.
- `computeVerifiedDeviation` widens from `[-30, +30]` seconds to `[-1800, +1800]` seconds (±30 minutes), which is more than any realistic mechanical drift.
- New integration test: dial 33:10 vs ref 32:05 → +65s (the case the old contract lost).

390/390 tests green locally.