### PR TITLE
feat(watches): reference field + circular tap dial + full-time display

### DIFF
--- a/migrations/0006_watch_reference.sql
+++ b/migrations/0006_watch_reference.sql
@@ -1,0 +1,18 @@
+-- Slice (issue #57): reference field on watches.
+--
+-- The "reference" of a watch is its manufacturer-assigned reference
+-- number — e.g. "3570.50" for an Omega Speedmaster, "126610LN" for a
+-- Rolex Submariner. Collectors use it as the primary identifier of
+-- a specific model variant, so surfacing it on the watch record (and
+-- on the public /w/:id page) makes the site meaningful to the
+-- audience.
+--
+-- Design notes:
+--   * Optional — plenty of watches have no official reference
+--     (vintage, microbrands, one-offs).
+--   * No index: always queried together with the watch row by id.
+--   * Max length is enforced at the Zod layer (50 chars). References
+--     run the gamut from "2824" to "IW3777-14" to "M79030B-0001" but
+--     50 handily covers all real-world formats.
+
+ALTER TABLE watches ADD COLUMN reference TEXT;

--- a/src/app/pages/EditWatchPage.tsx
+++ b/src/app/pages/EditWatchPage.tsx
@@ -50,6 +50,7 @@ async function hydrateInitialValues(watch: Watch): Promise<WatchFormValues> {
     name: watch.name,
     brand: watch.brand ?? "",
     model: watch.model ?? "",
+    reference: watch.reference ?? "",
     notes: watch.notes ?? "",
     is_public: watch.is_public,
     movement,
@@ -99,10 +100,14 @@ export function EditWatchPage() {
         },
       };
     }
+    // Trim every free-text field; for `reference` we send the trimmed
+    // value directly (even empty string) so the PATCH handler can map
+    // "" → NULL and clear a previously-set reference.
     const body = {
       name: values.name.trim(),
       brand: values.brand.trim() || undefined,
       model: values.model.trim() || undefined,
+      reference: values.reference.trim(),
       movement_id: values.movement.id,
       notes: values.notes.trim() || undefined,
       is_public: values.is_public,

--- a/src/app/pages/NewWatchPage.tsx
+++ b/src/app/pages/NewWatchPage.tsx
@@ -25,6 +25,7 @@ export function NewWatchPage() {
       name: values.name.trim(),
       brand: values.brand.trim() || undefined,
       model: values.model.trim() || undefined,
+      reference: values.reference.trim() || undefined,
       movement_id: values.movement.id,
       notes: values.notes.trim() || undefined,
       is_public: values.is_public,

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -216,6 +216,9 @@ export function WatchDetailPage() {
         <dt className="text-sm font-medium text-cf-text-muted">Movement</dt>
         <dd className="text-sm text-cf-text">{movementLabel}</dd>
 
+        <dt className="text-sm font-medium text-cf-text-muted">Reference</dt>
+        <dd className="font-mono text-sm text-cf-text">{watch.reference ?? "—"}</dd>
+
         {watch.notes ? (
           <>
             <dt className="text-sm font-medium text-cf-text-muted">Notes</dt>

--- a/src/app/watches/TapReadingForm.tsx
+++ b/src/app/watches/TapReadingForm.tsx
@@ -6,7 +6,8 @@
 //   1. The user looks at their watch.
 //   2. They wait for the second hand to cross one of the four
 //      canonical marks — 12 (0), 3 (15), 6 (30), or 9 (45) o'clock.
-//   3. At the moment it lands, they tap the matching button.
+//   3. At the moment it lands, they tap the matching position on a
+//      circular dial that mirrors the watch face.
 //   4. The server takes its own Date.now() as the reference and
 //      computes the signed deviation.
 //
@@ -15,11 +16,19 @@
 // idle. The reloaded list/stats are fetched via `onLogged` in the
 // background; the user doesn't wait on that round-trip.
 //
-// Accessibility: the four buttons are keyboard-focusable and their
-// labels include both the numeric position and the clock-face
-// reference ("12 o'clock · 0"). A live `<time>` updates 10× per
-// second so the user can visually sync to the upcoming mark without
-// mental math.
+// The dial is an SVG (faint circle + 12 tick marks) with four
+// round buttons absolutely positioned at the 12/3/6/9 o'clock
+// positions of that circle. The button positions match where the
+// user's second hand is pointing, so the layout is self-explanatory
+// without verbose helper text. See `DIAL_DIAMETER` / `BUTTON_SIZE`
+// for the layout constants; the container shrinks on narrow screens
+// via the `min()` expression.
+//
+// Accessibility: each button carries an `aria-label` naming the
+// o'clock position it represents so screen readers convey what a
+// sighted user would read off the positions. The live wall-clock in
+// the header uses `aria-label` so assistive tech reads the full
+// time, not just the numeric monospace text.
 
 import { useEffect, useRef, useState } from "react";
 import { createTapReading, type CreateTapReadingBody } from "./readings";
@@ -34,13 +43,15 @@ type DialPosition = 0 | 15 | 30 | 45;
 interface DialButton {
   position: DialPosition;
   oclock: string;
+  /** Angle (degrees) on the dial where 0° is 12 o'clock and 90° is 3. */
+  angleDeg: number;
 }
 
 const DIAL_BUTTONS: readonly DialButton[] = [
-  { position: 0, oclock: "12" },
-  { position: 15, oclock: "3" },
-  { position: 30, oclock: "6" },
-  { position: 45, oclock: "9" },
+  { position: 0, oclock: "12", angleDeg: 0 },
+  { position: 15, oclock: "3", angleDeg: 90 },
+  { position: 30, oclock: "6", angleDeg: 180 },
+  { position: 45, oclock: "9", angleDeg: 270 },
 ] as const;
 
 type Status =
@@ -56,21 +67,64 @@ function formatDeviation(seconds: number): string {
   return `${sign}${seconds} s`;
 }
 
+/** Zero-pad to two digits. Replaces `.padStart(2, "0")` inline noise. */
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+/** Current wall-clock HH:MM:SS in the browser's local time. */
+function formatLocalClock(ms: number): string {
+  const d = new Date(ms);
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+// Dial layout. Responsive: the container uses `min(...)` so the
+// dial shrinks on very narrow screens. These defaults target the
+// ~256px baseline that the design spec calls for; the SVG scales
+// via `viewBox`, and the buttons are positioned in % of the
+// container so percentages hold regardless of actual pixel size.
+const DIAL_MIN_PX = 220;
+const DIAL_DEFAULT_PX = 260;
+const BUTTON_SIZE_PX = 56;
+
+/**
+ * Compute the {left, top} CSS offsets (as % strings) for a tap
+ * button at a given angle on the dial. Angle 0 = 12 o'clock.
+ *
+ * We place buttons along a circle slightly inside the dial's own
+ * outer edge so their centers land on the outer ring rather than
+ * spilling past it. The ratio below (0.38 of container) is the
+ * button-center radius — tuned so a 56px button on a 260px dial
+ * reads as sitting "on" the ring, not balanced on top of it.
+ */
+function buttonOffset(angleDeg: number): { left: string; top: string } {
+  const angleRad = (angleDeg * Math.PI) / 180;
+  // Center of container is (50%, 50%); button center sits at radius
+  // 0.38 * containerWidth.
+  const rFraction = 0.38;
+  const dx = Math.sin(angleRad) * rFraction;
+  const dy = -Math.cos(angleRad) * rFraction;
+  return {
+    left: `${(0.5 + dx) * 100}%`,
+    top: `${(0.5 + dy) * 100}%`,
+  };
+}
+
 export function TapReadingForm({ watchId, onLogged }: Props) {
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   const [showNotes, setShowNotes] = useState(false);
   const [notes, setNotes] = useState("");
-  // Server-synced client clock for the "current second" indicator.
-  // 100 ms cadence is fast enough that the user can visually sync to
-  // the upcoming dial mark without it looking laggy.
-  const [nowSeconds, setNowSeconds] = useState(() => Math.floor(Date.now() / 1000) % 60);
+  // Wall-clock millis for the header's HH:MM:SS display. 100 ms
+  // cadence is fast enough that the user can sync visually to the
+  // upcoming dial mark without it looking laggy.
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   // Timer reference so StrictMode double-mount in dev doesn't leak
   // intervals. Cleanup also fires on unmount.
   const timerRef = useRef<number | null>(null);
   useEffect(() => {
     timerRef.current = window.setInterval(() => {
-      setNowSeconds(Math.floor(Date.now() / 1000) % 60);
+      setNowMs(Date.now());
     }, 100);
     return () => {
       if (timerRef.current !== null) {
@@ -122,24 +176,21 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
   }
 
   const isSubmitting = status.kind === "submitting";
+  const clockLabel = formatLocalClock(nowMs);
 
   return (
     <section className="mb-6 rounded-lg border border-cf-border bg-cf-surface p-5">
-      <div className="mb-4 flex items-baseline justify-between gap-4">
+      <div className="mb-3 flex items-baseline justify-between gap-4">
         <h2 className="text-sm font-medium text-cf-text">Tap to log a reading</h2>
-        <p
-          className="font-mono text-xs text-cf-text-muted"
-          aria-label={`Reference clock at ${nowSeconds} seconds`}
+        <time
+          className="font-mono text-sm tabular-nums text-cf-text"
+          aria-label={`Current reference time ${clockLabel}`}
         >
-          ref ·{" "}
-          <time className="text-cf-accent">
-            :{nowSeconds.toString().padStart(2, "0")}
-          </time>
-        </p>
+          {clockLabel}
+        </time>
       </div>
-      <p className="mb-4 text-xs text-cf-text-muted">
-        Wait for your watch&apos;s second hand to cross 12, 3, 6, or 9 o&apos;clock, then
-        tap the matching position. The server uses its own clock as the reference.
+      <p className="mb-5 text-xs text-cf-text-muted">
+        Tap the matching position as your second hand passes over it.
       </p>
 
       {status.kind === "error" ? (
@@ -171,30 +222,81 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
         </p>
       ) : null}
 
+      {/* Circular dial. `min(...)` keeps the layout legible on very
+          narrow viewports — the dial shrinks from 260 to ~220px and
+          the SVG scales with its container. */}
       <div
         role="group"
         aria-label="Dial positions"
-        className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4"
+        className="relative mx-auto mb-6"
+        style={{
+          width: `min(${DIAL_DEFAULT_PX}px, 100%)`,
+          aspectRatio: "1 / 1",
+          minWidth: `${DIAL_MIN_PX}px`,
+        }}
       >
-        {DIAL_BUTTONS.map(({ position, oclock }) => {
+        {/* Background face: faint border ring + tick marks at the
+            12 cardinal positions. The SVG uses `viewBox` so it
+            scales automatically to the container size. */}
+        <svg
+          viewBox="0 0 100 100"
+          className="absolute inset-0 h-full w-full"
+          aria-hidden="true"
+          role="img"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            r="47"
+            className="fill-cf-bg stroke-cf-border"
+            strokeWidth="0.6"
+          />
+          {/* 12 tick marks — long at 12/3/6/9 (cardinals), short
+              for the rest. Rotated around the center of the dial. */}
+          {Array.from({ length: 12 }, (_, i) => {
+            const angle = i * 30;
+            const cardinal = i % 3 === 0;
+            return (
+              <line
+                key={i}
+                x1="50"
+                y1={cardinal ? 5 : 7}
+                x2="50"
+                y2={cardinal ? 11 : 10}
+                transform={`rotate(${angle} 50 50)`}
+                className="stroke-cf-border"
+                strokeWidth={cardinal ? 1.2 : 0.6}
+                strokeLinecap="round"
+              />
+            );
+          })}
+        </svg>
+
+        {DIAL_BUTTONS.map(({ position, oclock, angleDeg }) => {
           const submittingThis =
             status.kind === "submitting" && status.position === position;
+          const { left, top } = buttonOffset(angleDeg);
           return (
             <button
               key={position}
               type="button"
               onClick={() => handleTap(position)}
               disabled={isSubmitting}
-              aria-label={`Tap at ${position} seconds (${oclock} o'clock)`}
-              className="group flex flex-col items-center justify-center gap-1 rounded-lg border border-cf-border bg-cf-bg px-4 py-6 text-cf-text transition-colors hover:border-cf-accent hover:bg-cf-accent/5 focus:border-cf-accent focus:outline-none focus:ring-2 focus:ring-cf-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label={`Tap when second hand is at ${oclock} o'clock (${position} seconds)`}
+              className="absolute flex items-center justify-center rounded-full border border-cf-border bg-cf-surface font-mono text-xl font-medium tabular-nums text-cf-text shadow-sm transition-colors hover:border-cf-accent hover:bg-cf-accent/10 hover:text-cf-accent focus:border-cf-accent focus:outline-none focus:ring-2 focus:ring-cf-accent focus:ring-offset-2 focus:ring-offset-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+              style={{
+                width: `${BUTTON_SIZE_PX}px`,
+                height: `${BUTTON_SIZE_PX}px`,
+                left,
+                top,
+                transform: "translate(-50%, -50%)",
+              }}
             >
-              <span className="font-mono text-3xl font-medium tabular-nums text-cf-text group-hover:text-cf-accent">
-                {position}
-              </span>
-              <span className="text-xs text-cf-text-muted">{oclock} o&apos;clock</span>
               {submittingThis ? (
-                <span className="text-xs text-cf-accent">Logging…</span>
-              ) : null}
+                <span className="text-xs text-cf-accent">…</span>
+              ) : (
+                <span aria-hidden="true">{position}</span>
+              )}
             </button>
           );
         })}

--- a/src/app/watches/WatchForm.tsx
+++ b/src/app/watches/WatchForm.tsx
@@ -15,6 +15,8 @@ export interface WatchFormValues {
   name: string;
   brand: string;
   model: string;
+  /** Slice (issue #57): manufacturer reference, e.g. "3570.50". */
+  reference: string;
   notes: string;
   is_public: boolean;
   movement: MovementOption | null;
@@ -24,6 +26,7 @@ export const EMPTY_WATCH_FORM: WatchFormValues = {
   name: "",
   brand: "",
   model: "",
+  reference: "",
   notes: "",
   is_public: true,
   movement: null,
@@ -143,6 +146,24 @@ export function WatchForm({
           ) : null}
         </label>
       </div>
+
+      <label className="flex flex-col gap-1 text-sm font-medium text-cf-text">
+        Reference (optional)
+        <input
+          type="text"
+          maxLength={50}
+          placeholder="e.g. 3570.50"
+          value={values.reference}
+          onChange={(event) => update("reference", event.target.value)}
+          aria-invalid={fieldErrors.reference ? true : undefined}
+          className="rounded-md border border-cf-border bg-cf-bg px-3 py-2 font-sans text-base text-cf-text placeholder:text-cf-text-subtle outline-none focus:border-cf-accent"
+        />
+        {fieldErrors.reference ? (
+          <span role="alert" className="text-sm text-cf-accent">
+            {fieldErrors.reference}
+          </span>
+        ) : null}
+      </label>
 
       <MovementTypeahead
         initialSelection={values.movement}

--- a/src/app/watches/api.ts
+++ b/src/app/watches/api.ts
@@ -12,6 +12,8 @@ export interface Watch {
   name: string;
   brand: string | null;
   model: string | null;
+  // Slice (issue #57): manufacturer reference (e.g. "3570.50"). Nullable.
+  reference: string | null;
   movement_id: string | null;
   movement_canonical_name: string | null;
   custom_movement_name: string | null;
@@ -112,6 +114,8 @@ export interface CreateWatchBody {
   name: string;
   brand?: string;
   model?: string;
+  /** Manufacturer reference number, e.g. "3570.50". Empty string clears on PATCH. */
+  reference?: string;
   movement_id: string;
   custom_movement_name?: string;
   notes?: string;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -101,6 +101,12 @@ export interface WatchesTable {
   // `watches/{watchId}/image`). NULL when no image is set. See
   // migrations/0005_watch_images.sql.
   image_r2_key: string | null;
+  // Slice (issue #57): manufacturer reference number, e.g. "3570.50"
+  // for an Omega Speedmaster or "126610LN" for a Rolex Submariner.
+  // Nullable because plenty of watches (vintage, microbrands,
+  // one-offs) have no official reference. Max length enforced at the
+  // Zod layer — see migrations/0006_watch_reference.sql.
+  reference: string | null;
 }
 
 // Slice 12 (issue #13): readings. Columns mirror

--- a/src/public/watch/load.ts
+++ b/src/public/watch/load.ts
@@ -24,6 +24,7 @@ export interface PublicWatch {
   name: string;
   brand: string | null;
   model: string | null;
+  reference: string | null;
   movement_id: string | null;
   movement_canonical_name: string | null;
   owner_username: string;
@@ -60,6 +61,7 @@ export async function loadPublicWatch(
       "watches.name as name",
       "watches.brand as brand",
       "watches.model as model",
+      "watches.reference as reference",
       "watches.movement_id as movement_id",
       "watches.image_r2_key as image_r2_key",
       "movements.canonical_name as movement_canonical_name",
@@ -97,6 +99,7 @@ export async function loadPublicWatch(
         name: row.name,
         brand: row.brand,
         model: row.model,
+        reference: row.reference,
         movement_id: row.movement_status === "approved" ? row.movement_id : null,
         movement_canonical_name:
           row.movement_status === "approved" ? row.movement_canonical_name : null,

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -55,9 +55,11 @@ export const WatchPage = ({ data }: WatchPageProps) => {
         <section class="cf-container cf-hero" aria-labelledby="w-title">
           <h1 id="w-title">{watch.name}</h1>
           <p class="cf-watch-sub">
-            {watch.brand ? <strong>{watch.brand}</strong> : null}
-            {watch.brand && watch.model ? " · " : null}
-            {watch.model ? <span>{watch.model}</span> : null}
+            <WatchSubtitle
+              brand={watch.brand}
+              model={watch.model}
+              reference={watch.reference}
+            />
           </p>
           <ul class="cf-watch-meta" aria-label="Watch details">
             <li>
@@ -139,6 +141,44 @@ export const WatchNotFoundPage = ({ watchId }: { watchId: string }) => (
     <Footer />
   </Layout>
 );
+
+/**
+ * Subtitle row under the watch name on the public page. Joins brand,
+ * model, and "Ref <reference>" with " · " separators, skipping parts
+ * that are null/empty so the surrounding punctuation never dangles.
+ */
+function WatchSubtitle({
+  brand,
+  model,
+  reference,
+}: {
+  brand: string | null;
+  model: string | null;
+  reference: string | null;
+}) {
+  const parts: Array<{ key: string; label: string; emphasis: boolean }> = [];
+  if (brand) parts.push({ key: "brand", label: brand, emphasis: true });
+  if (model) parts.push({ key: "model", label: model, emphasis: false });
+  if (reference) {
+    parts.push({ key: "reference", label: `Ref ${reference}`, emphasis: false });
+  }
+  return (
+    <>
+      {parts.map((p, i) => (
+        <span key={p.key}>
+          {i > 0 ? <span class="cf-watch-sub__sep"> · </span> : null}
+          {p.emphasis ? (
+            <strong>{p.label}</strong>
+          ) : p.key === "reference" ? (
+            <span class="cf-watch-sub__ref">{p.label}</span>
+          ) : (
+            <span>{p.label}</span>
+          )}
+        </span>
+      ))}
+    </>
+  );
+}
 
 function WatchPhoto({ watch }: { watch: PublicWatch }) {
   if (watch.has_image) {

--- a/src/schemas/watch.ts
+++ b/src/schemas/watch.ts
@@ -14,7 +14,22 @@ import { z } from "zod";
 
 const NAME_MAX = 100;
 const MODEL_MAX = 100;
+const REFERENCE_MAX = 50;
 const NOTES_MAX = 1000;
+
+// Reference numbers are short collector identifiers — "3570.50",
+// "IW3777-14", "M79030B-0001". They're trimmed + length-capped like
+// every other free-text field. Kept as a plain optional string so
+// `""` passes through; the route's create/update paths map empty
+// string → NULL so a user can clear a previously-set reference by
+// submitting an empty value (same pattern brand/model use).
+const optionalReference = z
+  .string()
+  .trim()
+  .max(REFERENCE_MAX, {
+    message: `Reference must be ${REFERENCE_MAX} characters or fewer`,
+  })
+  .optional();
 
 // Reused across create + update so a later switch to a single
 // "upsert"-style handler stays trivial. Partial() on update keeps
@@ -35,6 +50,7 @@ export const createWatchSchema = z.object({
     .trim()
     .max(MODEL_MAX, { message: `Model must be ${MODEL_MAX} characters or fewer` })
     .optional(),
+  reference: optionalReference,
   movement_id: z
     .string({ message: "Movement is required" })
     .trim()
@@ -68,6 +84,7 @@ export const watchResponseSchema = z.object({
   name: z.string(),
   brand: z.string().nullable(),
   model: z.string().nullable(),
+  reference: z.string().nullable(),
   movement_id: z.string().nullable(),
   movement_canonical_name: z.string().nullable(),
   custom_movement_name: z.string().nullable(),

--- a/src/server/routes/watches.ts
+++ b/src/server/routes/watches.ts
@@ -63,6 +63,7 @@ function toResponse(watch: Watch, movementCanonicalName: string | null): WatchRe
     name: watch.name,
     brand: watch.brand,
     model: watch.model,
+    reference: watch.reference,
     movement_id: watch.movement_id,
     movement_canonical_name: movementCanonicalName,
     custom_movement_name: watch.custom_movement_name,
@@ -175,6 +176,7 @@ watchesRoute.get("/", async (c) => {
       "watches.name",
       "watches.brand",
       "watches.model",
+      "watches.reference",
       "watches.movement_id",
       "watches.custom_movement_name",
       "watches.notes",
@@ -267,6 +269,9 @@ watchesRoute.post("/", async (c) => {
       name: input.name,
       brand: input.brand ?? null,
       model: input.model ?? null,
+      // Empty-string → NULL so clearing the field on edit surfaces
+      // the same value the create path stores when it's omitted.
+      reference: input.reference ? input.reference : null,
       movement_id: input.movement_id,
       custom_movement_name: input.custom_movement_name ?? null,
       notes: input.notes ?? null,
@@ -341,6 +346,7 @@ watchesRoute.patch("/:id", async (c) => {
     name: string;
     brand: string | null;
     model: string | null;
+    reference: string | null;
     movement_id: string;
     custom_movement_name: string | null;
     notes: string | null;
@@ -349,6 +355,9 @@ watchesRoute.patch("/:id", async (c) => {
   if (input.name !== undefined) patch.name = input.name;
   if (input.brand !== undefined) patch.brand = input.brand === "" ? null : input.brand;
   if (input.model !== undefined) patch.model = input.model === "" ? null : input.model;
+  if (input.reference !== undefined) {
+    patch.reference = input.reference === "" ? null : input.reference;
+  }
   if (input.movement_id !== undefined) patch.movement_id = input.movement_id;
   if (input.custom_movement_name !== undefined) {
     patch.custom_movement_name =

--- a/tests/integration/public-pages.test.ts
+++ b/tests/integration/public-pages.test.ts
@@ -47,6 +47,9 @@ const SEED = {
     name: "Gold Submariner",
     brand: "Rolex",
     model: "126610LN",
+    // Slice (issue #57): reference surfaces on the public page in
+    // the subtitle row ("Rolex · 126610LN · Ref 126610LN-0001").
+    reference: "126610LN-0001",
     is_public: 1,
   },
   privateWatch: {
@@ -55,6 +58,19 @@ const SEED = {
     brand: "Nomos",
     model: "Tangente",
     is_public: 0,
+  },
+  // Slice (issue #57): a watch with no reference set to prove the
+  // SSR output doesn't emit a dangling " · " separator when the
+  // slot is empty. Brand/model chosen to be distinct from the other
+  // fixtures so the "private watch doesn't leak" assertion elsewhere
+  // in this file keeps a unique needle to look for.
+  publicNoRef: {
+    id: id("w-public-noref"),
+    name: "Plain Worker",
+    brand: "Tissot",
+    model: "PRX",
+    reference: null,
+    is_public: 1,
   },
 };
 
@@ -85,12 +101,33 @@ async function seed() {
     )
     .run();
 
-  for (const w of [SEED.publicWatch, SEED.privateWatch]) {
+  const watchesToSeed: Array<{
+    id: string;
+    name: string;
+    brand: string;
+    model: string;
+    reference: string | null;
+    is_public: number;
+  }> = [
+    { ...SEED.publicWatch },
+    { ...SEED.privateWatch, reference: null },
+    { ...SEED.publicNoRef },
+  ];
+  for (const w of watchesToSeed) {
     await db
       .prepare(
-        "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, reference, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
       )
-      .bind(w.id, SEED.user.id, w.name, w.brand, w.model, SEED.movement.id, w.is_public)
+      .bind(
+        w.id,
+        SEED.user.id,
+        w.name,
+        w.brand,
+        w.model,
+        w.reference,
+        SEED.movement.id,
+        w.is_public,
+      )
       .run();
   }
 
@@ -267,5 +304,32 @@ describe("GET /w/:watchId — public watch page", () => {
     );
     const body = await res.text();
     expect(body).toMatch(/data-verified-badge="true"/);
+  });
+
+  // Slice (issue #57): reference shows up in the subtitle when set,
+  // and leaves no dangling separator when absent.
+  it("renders the reference in the subtitle when the watch has one", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/w/${SEED.publicWatch.id}`),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(`Ref ${SEED.publicWatch.reference}`);
+  });
+
+  it("omits the reference slot (no dangling separator) when the watch has none", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/w/${SEED.publicNoRef.id}`),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Subtitle still renders brand + model but the "Ref …" slot is absent.
+    expect(body).toContain(SEED.publicNoRef.brand);
+    expect(body).toContain(SEED.publicNoRef.model);
+    expect(body).not.toContain("Ref ");
+    // No " · · " double-separator and no trailing separator right
+    // before the closing </p> of the subtitle.
+    expect(body).not.toMatch(/·\s*·/);
+    expect(body).not.toMatch(/·\s*<\/p>/);
   });
 });

--- a/tests/integration/watches.test.ts
+++ b/tests/integration/watches.test.ts
@@ -166,6 +166,7 @@ interface WatchBody {
   name: string;
   brand: string | null;
   model: string | null;
+  reference: string | null;
   movement_id: string | null;
   movement_canonical_name: string | null;
   custom_movement_name: string | null;
@@ -263,6 +264,71 @@ describe("POST /api/v1/watches", () => {
     expect(res.status).toBe(401);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("unauthorized");
+  });
+
+  // Slice (issue #57): reference field round-trips through create +
+  // get + patch. Covers three shapes: populated, omitted-at-create
+  // (→ null), and cleared-via-patch (empty string → null).
+  it("persists `reference` through POST + GET + PATCH", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const create = await createWatch(
+      {
+        name: "Speedy",
+        brand: "Omega",
+        model: "Speedmaster Pro",
+        reference: "3570.50",
+        movement_id: approvedMovementId,
+      },
+      cookie,
+    );
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as WatchBody;
+    expect(created.reference).toBe("3570.50");
+
+    const read = await getWatch(created.id, cookie);
+    const readBody = (await read.json()) as WatchBody;
+    expect(readBody.reference).toBe("3570.50");
+
+    const patched = await patchWatch(created.id, { reference: "ST105.012" }, cookie);
+    expect(patched.status).toBe(200);
+    const after = (await patched.json()) as WatchBody;
+    expect(after.reference).toBe("ST105.012");
+
+    // Empty string clears the field (null round-trip).
+    const cleared = await patchWatch(created.id, { reference: "" }, cookie);
+    expect(cleared.status).toBe(200);
+    const clearedBody = (await cleared.json()) as WatchBody;
+    expect(clearedBody.reference).toBeNull();
+  });
+
+  it("omitted `reference` stores as null", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await createWatch(
+      { name: "Refless", movement_id: approvedMovementId },
+      cookie,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as WatchBody;
+    expect(body.reference).toBeNull();
+  });
+
+  it("rejects a reference longer than 50 chars (400)", async () => {
+    const { cookie } = await registerAndGetCookie();
+    const res = await createWatch(
+      {
+        name: "Too long",
+        reference: "X".repeat(51),
+        movement_id: approvedMovementId,
+      },
+      cookie,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      fieldErrors: Record<string, string>;
+    };
+    expect(body.error).toBe("invalid_input");
+    expect(body.fieldErrors.reference).toMatch(/50/);
   });
 });
 


### PR DESCRIPTION
Closes #57.

Two related product changes that both touch the watch detail page, shipped together.

## Part A — Reference field (optional) on watches

- New migration `migrations/0006_watch_reference.sql` adds a nullable `reference TEXT` column to the `watches` table. No index (always read alongside the watch row by id).
- `WatchesTable` schema + `createWatchSchema` / `updateWatchSchema` / `watchResponseSchema` extended with `reference` (trimmed, max 50 chars, optional).
- CRUD route: POST persists `reference` (empty or missing → NULL); PATCH allows empty string to clear; GET list + detail + public `/w/:id` loader all surface it.
- Add/edit `WatchForm`: new "Reference (optional)" text input with placeholder `e.g. 3570.50` sitting between Model and Movement.
- Authed `WatchDetailPage`: dedicated metadata row (`<dt>Reference</dt><dd>{reference ?? "—"}</dd>`).
- Public `/w/:id` SSR: subtitle now renders `<Brand> · <Model> · Ref <reference>` with the separator pattern skipping any slot that's null so no dangling " · " appears when a field is empty.

## Part B — Tap-reading UX polish on `/app/watches/:id`

- **Full wall-clock time.** The "ref · :25" pill is replaced with the full HH:MM:SS in the browser's local timezone (driven by the existing 100 ms `setInterval`).
- **Circular dial.** The 2x2 / 4-across button grid is gone. In its place: an SVG background (faint ring + 12 tick marks, cardinals at 12/3/6/9 are longer) plus four round tap buttons absolutely positioned at the 12/3/6/9 o'clock angles of that ring. Container is `min(260px, 100%)` so the dial shrinks on narrow screens but stays legible.
- **Helper copy shortened** to a single line: "Tap the matching position as your second hand passes over it." No more server-clock implementation detail.
- **Accessibility.** Each button carries `aria-label="Tap when second hand is at <N> o'clock (<pos> seconds)"`, and the focus ring is 2px cf-accent with a cf-surface offset so keyboard focus is unambiguous against the dial. The wall-clock header is a `<time>` with an `aria-label` naming the full time.
- **No API changes.** The `/api/v1/readings/tap` endpoint and its request/response shape are unchanged. `tests/integration/readings.tap.test.ts` continues to pass.

## Tests

- `tests/integration/watches.test.ts` — new assertions for `reference` round-tripping through POST/GET/PATCH, clearing via empty string, omitted field storing as null, and a 50-char length violation returning a field error.
- `tests/integration/public-pages.test.ts` — new fixture for a watch with a reference and another without. Asserts "Ref <value>" renders when set and that no dangling " · " leaks when unset.
- Full suite: **42 files / 395 tests passing** (up from 390).

## Operator post-merge step

Before the next production deploy, apply the migration against the production D1:

```bash
CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false npx wrangler d1 migrations apply rated-watch-db --remote
```

The test harness auto-applies via miniflare so nothing else needs doing for CI.

## Considered but left out

- **Reference validation beyond trim + length.** References run the gamut (numbers, dots, slashes, letters) so anything stricter than "string ≤ 50 chars" would be hostile to legitimate entries. Left to the user.
- **Reference autocomplete / lookup table.** Out of scope and would compete with the movements taxonomy for cognitive load in the add-watch flow.
- **Rearranging existing form fields.** Slotted "Reference" between Model and Movement as spec'd.
- **Client-side Vitest of the circular dial layout.** The spec explicitly said no UI snapshot tests and the E2E suite doesn't exercise the tap form either, so there was no test to extend. Behaviour is covered by the unchanged `/api/v1/readings/tap` integration tests.

## Note on PR #58 coordination

#58 touches only `wrangler.jsonc` (routing for `/images/*`). No overlap with files touched here; rebase will be trivial if #58 lands first.