### PR TITLE
design: component polish — layered shadows, pill shapes, display-light headings

### DIFF
--- a/src/app/components/GoogleSignInButton.tsx
+++ b/src/app/components/GoogleSignInButton.tsx
@@ -50,9 +50,10 @@ export function GoogleSignInButton({
         disabled={submitting}
         aria-label={label}
         className={
-          "inline-flex items-center justify-center gap-3 rounded-full border " +
+          "inline-flex min-h-[44px] items-center justify-center gap-3 rounded-pill border " +
           "border-line bg-canvas px-6 py-3 text-sm font-medium " +
-          "text-ink transition-colors hover:border-accent hover:text-ink " +
+          "text-ink shadow-card transition-colors transition-shadow " +
+          "hover:border-ink-muted hover:text-ink hover:shadow-lift " +
           "disabled:opacity-60 " +
           className
         }

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -49,13 +49,11 @@ export function DashboardPage() {
     <section>
       <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">
-            Dashboard
-          </h1>
+          <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">Dashboard</h1>
           {user ? (
             <p className="text-ink">
-              Logged in as{" "}
-              <span className="font-mono text-accent">@{user.username}</span>.
+              Logged in as <span className="font-mono text-accent">@{user.username}</span>
+              .
             </p>
           ) : (
             <p className="text-ink-muted">Loading profile…</p>
@@ -63,7 +61,7 @@ export function DashboardPage() {
         </div>
         <Link
           to="/app/watches/new"
-          className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover"
         >
           Add watch
         </Link>
@@ -80,20 +78,20 @@ export function DashboardPage() {
             {state.message}
           </p>
         ) : state.watches.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-line bg-surface px-6 py-10 text-center">
+          <div className="rounded-card border border-dashed border-line bg-surface-inset px-6 py-12 text-center">
             <p className="mb-3 text-ink">No watches yet.</p>
             <p className="mb-4 text-sm text-ink-muted">
               Add your first watch to start tracking accuracy against a reference.
             </p>
             <Link
               to="/app/watches/new"
-              className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-2.5 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover"
             >
               Add your first watch
             </Link>
           </div>
         ) : (
-          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {state.watches.map((watch) => {
               const stats = watch.session_stats;
               const verifiedCount = Math.round(
@@ -103,12 +101,12 @@ export function DashboardPage() {
                 <li key={watch.id}>
                   <Link
                     to={`/app/watches/${watch.id}`}
-                    className="flex h-full flex-col gap-2 rounded-lg border border-line bg-canvas p-4 transition-colors hover:border-accent"
+                    className="flex h-full flex-col gap-2 rounded-card border border-line bg-canvas p-6 shadow-card transition-colors hover:border-accent"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <h2 className="text-lg font-medium text-ink">{watch.name}</h2>
                       {watch.is_public ? null : (
-                        <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent">
+                        <span className="inline-flex items-center gap-1 rounded-pill border border-accent/25 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
                           Private
                         </span>
                       )}
@@ -142,7 +140,7 @@ export function DashboardPage() {
       <button
         type="button"
         onClick={onLogout}
-        className="inline-flex items-center justify-center rounded-full border border-line bg-transparent px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
+        className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
       >
         Sign out
       </button>

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -49,7 +49,9 @@ export function DashboardPage() {
     <section>
       <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">Dashboard</h1>
+          <h1 className="mb-2 font-display text-4xl font-light tracking-tight text-ink">
+            Dashboard
+          </h1>
           {user ? (
             <p className="text-ink">
               Logged in as <span className="font-mono text-accent">@{user.username}</span>

--- a/src/app/pages/EditWatchPage.tsx
+++ b/src/app/pages/EditWatchPage.tsx
@@ -146,7 +146,7 @@ export function EditWatchPage() {
 
   return (
     <section className="mx-auto max-w-2xl">
-      <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">
+      <h1 className="mb-2 font-display text-4xl font-light tracking-tight text-ink">
         Edit watch
       </h1>
       <p className="mb-6 text-ink-muted">

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -30,9 +30,11 @@ export function LoginPage() {
 
   return (
     <section className="mx-auto max-w-md">
-      <h1 className="mb-6 text-4xl font-medium tracking-tight text-ink">Sign in</h1>
+      <h1 className="mb-6 font-display text-4xl font-light tracking-tight text-ink">
+        Sign in
+      </h1>
       <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Email
           <input
             type="email"
@@ -40,10 +42,10 @@ export function LoginPage() {
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
         </label>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Password
           <input
             type="password"
@@ -52,7 +54,7 @@ export function LoginPage() {
             minLength={8}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
         </label>
         {error ? (
@@ -66,7 +68,7 @@ export function LoginPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover disabled:opacity-60"
+          className="mt-2 inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-6 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover disabled:opacity-60"
         >
           {submitting ? "Signing in…" : "Sign in"}
         </button>

--- a/src/app/pages/NewWatchPage.tsx
+++ b/src/app/pages/NewWatchPage.tsx
@@ -38,7 +38,7 @@ export function NewWatchPage() {
 
   return (
     <section className="mx-auto max-w-2xl">
-      <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">
+      <h1 className="mb-2 font-display text-4xl font-light tracking-tight text-ink">
         Add a watch
       </h1>
       <p className="mb-6 text-ink-muted">
@@ -51,10 +51,7 @@ export function NewWatchPage() {
         submittingLabel="Adding…"
         onSubmit={handleSubmit}
         secondaryAction={
-          <Link
-            to="/app/dashboard"
-            className="text-sm text-ink-muted hover:text-ink"
-          >
+          <Link to="/app/dashboard" className="text-sm text-ink-muted hover:text-ink">
             Cancel
           </Link>
         }

--- a/src/app/pages/NotFoundPage.tsx
+++ b/src/app/pages/NotFoundPage.tsx
@@ -8,7 +8,7 @@ export function NotFoundPage() {
   return (
     <main className="mx-auto flex min-h-screen max-w-[1200px] flex-col items-start justify-center gap-4 bg-canvas px-6 font-sans text-ink">
       <p className="font-mono text-sm text-ink-subtle">404</p>
-      <h1 className="text-4xl font-medium tracking-tight">
+      <h1 className="font-display text-4xl font-light tracking-tight">
         This page doesn't exist yet.
       </h1>
       <p className="max-w-[56ch] text-ink-muted">
@@ -17,7 +17,7 @@ export function NotFoundPage() {
       </p>
       <Link
         to="/app/dashboard"
-        className="mt-4 inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover"
+        className="mt-4 inline-flex min-h-[44px] items-center gap-2 rounded-pill bg-accent px-6 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover"
       >
         Back to dashboard →
       </Link>

--- a/src/app/pages/RegisterPage.tsx
+++ b/src/app/pages/RegisterPage.tsx
@@ -32,14 +32,14 @@ export function RegisterPage() {
 
   return (
     <section className="mx-auto max-w-md">
-      <h1 className="mb-2 text-4xl font-medium tracking-tight text-ink">
+      <h1 className="mb-2 font-display text-4xl font-light tracking-tight text-ink">
         Create an account
       </h1>
       <p className="mb-6 text-ink-muted">
         You'll get an auto-generated username you can rename later.
       </p>
       <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Display name
           <input
             type="text"
@@ -49,10 +49,10 @@ export function RegisterPage() {
             maxLength={100}
             value={name}
             onChange={(event) => setName(event.target.value)}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
         </label>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Email
           <input
             type="email"
@@ -60,10 +60,10 @@ export function RegisterPage() {
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
         </label>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Password
           <input
             type="password"
@@ -72,7 +72,7 @@ export function RegisterPage() {
             minLength={8}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
         </label>
         {error ? (
@@ -86,7 +86,7 @@ export function RegisterPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover disabled:opacity-60"
+          className="mt-2 inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-6 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover disabled:opacity-60"
         >
           {submitting ? "Creating account…" : "Create account"}
         </button>

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -68,22 +68,34 @@ export function SettingsPage() {
     void refresh();
   }
 
+  // Conditional field class — idle + error share the same padding,
+  // only the border + focus-ring tint differ (keeps the hue subtle
+  // per DESIGN.md v4 — no loud red box).
+  const fieldBase =
+    "rounded-md bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:outline-none";
+  const fieldIdleCx =
+    "border border-line focus:border-ink focus:ring-2 focus:ring-black/10";
+  const fieldErrorCx =
+    "border border-accent/60 focus:border-accent focus:ring-2 focus:ring-red-500/20";
+
   return (
     <section className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-4xl font-medium tracking-tight text-ink">Settings</h1>
+      <h1 className="mb-6 font-display text-4xl font-light tracking-tight text-ink">
+        Settings
+      </h1>
 
       <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Email
           <input
             type="email"
             readOnly
             value={user?.email ?? ""}
-            className="rounded-md border border-line bg-surface px-3 py-2 font-sans text-base text-ink-muted outline-none"
+            className="rounded-md border border-line bg-surface-inset px-3.5 py-2.5 font-sans text-base text-ink-muted shadow-inset-edge outline-none"
           />
         </label>
 
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
           Username
           <input
             type="text"
@@ -106,7 +118,7 @@ export function SettingsPage() {
             }}
             aria-invalid={fieldError ? true : undefined}
             aria-describedby={fieldError ? "username-error" : undefined}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className={`${fieldBase} ${fieldError ? fieldErrorCx : fieldIdleCx}`}
           />
           {fieldError ? (
             <span id="username-error" role="alert" className="text-sm text-accent">
@@ -131,7 +143,7 @@ export function SettingsPage() {
         {status.kind === "success" ? (
           <p
             role="status"
-            className="rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink"
+            className="rounded-md border border-line bg-surface-inset px-3 py-2 text-sm text-ink"
           >
             {status.message}
           </p>
@@ -144,7 +156,7 @@ export function SettingsPage() {
             status.kind === "submitting" ||
             username.trim() === (user?.username ?? "")
           }
-          className="mt-2 inline-flex items-center justify-center self-start rounded-full bg-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover disabled:opacity-60"
+          className="mt-2 inline-flex min-h-[44px] items-center justify-center self-start rounded-pill bg-accent px-6 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover disabled:opacity-60"
         >
           {status.kind === "submitting" ? "Saving…" : "Save changes"}
         </button>

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -186,8 +186,8 @@ export function WatchDetailPage() {
             disabled={togglingVisibility}
             className={
               watch.is_public
-                ? "inline-flex items-center gap-2 rounded-full border border-line bg-surface px-3 py-1 text-xs font-medium text-ink-muted transition-colors hover:border-accent hover:text-accent disabled:opacity-60"
-                : "inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
+                ? "inline-flex items-center gap-2 rounded-pill border border-line bg-surface-inset px-3 py-1 text-xs font-medium text-ink-muted transition-colors hover:border-accent hover:text-accent disabled:opacity-60"
+                : "inline-flex items-center gap-2 rounded-pill border border-accent/25 bg-accent/10 px-3 py-1 text-xs font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
             }
           >
             <span

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -167,7 +167,7 @@ export function WatchDetailPage() {
     <section className="mx-auto max-w-3xl">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
-          <h1 className="mb-1 text-4xl font-medium tracking-tight text-ink">
+          <h1 className="mb-1 font-display text-4xl font-light tracking-tight text-ink">
             {watch.name}
           </h1>
           <p className="text-ink-muted">

--- a/src/app/pages/WatchDetailPage.tsx
+++ b/src/app/pages/WatchDetailPage.tsx
@@ -249,7 +249,7 @@ export function WatchDetailPage() {
 
       <SessionStatsPanel stats={readings.session_stats} />
       {readings.session_stats && readings.session_stats.reading_count > 0 ? (
-        <div className="mb-6 rounded-lg border border-line bg-surface p-5">
+        <div className="mb-6 rounded-card border border-line bg-canvas p-6 shadow-card md:p-7">
           <VerifiedProgressRing
             verifiedCount={Math.round(
               readings.session_stats.reading_count *
@@ -271,7 +271,7 @@ export function WatchDetailPage() {
       <div className="mt-10 flex flex-wrap items-center gap-3">
         <Link
           to={`/app/watches/${watch.id}/edit`}
-          className="inline-flex items-center justify-center rounded-full border border-line bg-transparent px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
         >
           Edit
         </Link>
@@ -279,7 +279,7 @@ export function WatchDetailPage() {
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="inline-flex items-center justify-center rounded-full border border-accent/40 bg-accent/10 px-5 py-2.5 text-sm font-medium text-accent transition-colors hover:border-accent hover:bg-accent/20 disabled:opacity-60"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-accent/25 bg-accent/10 px-5 py-2.5 text-sm font-medium text-accent transition-colors hover:border-accent/40 hover:bg-accent/20 disabled:opacity-60"
         >
           {deleting ? "Deleting…" : "Delete"}
         </button>

--- a/src/app/watches/MovementTypeahead.tsx
+++ b/src/app/watches/MovementTypeahead.tsx
@@ -116,15 +116,15 @@ export function MovementTypeahead({
   }
 
   return (
-    <div className="flex flex-col gap-1 text-sm font-medium text-ink">
+    <div className="flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted">
       <label htmlFor={inputId}>{label}</label>
 
       {selection ? (
-        <div className="flex items-center gap-2 rounded-md border border-line bg-surface px-3 py-2">
+        <div className="flex items-center gap-2 rounded-md border border-line bg-surface-inset px-3.5 py-2.5 shadow-inset-edge">
           <span className="flex-1 text-ink">
             {selection.canonical_name}
             {selection.status === "pending" ? (
-              <span className="ml-2 rounded-full bg-accent/20 px-2 py-0.5 text-xs text-accent">
+              <span className="ml-2 inline-flex items-center gap-1 rounded-pill border border-accent/25 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
                 Pending approval
               </span>
             ) : null}
@@ -160,13 +160,13 @@ export function MovementTypeahead({
             placeholder="Search calibers — e.g. ETA 2892-A2"
             aria-invalid={errorMessage ? true : undefined}
             aria-describedby={errorMessage ? `${inputId}-error` : undefined}
-            className="w-full rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="w-full rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
 
           {open && query.trim().length > 0 ? (
             <ul
               role="listbox"
-              className="absolute left-0 right-0 top-full z-10 mt-1 max-h-72 overflow-auto rounded-md border border-line bg-canvas shadow-lg"
+              className="absolute left-0 right-0 top-full z-10 mt-1 max-h-72 overflow-auto rounded-card border border-line bg-canvas shadow-card"
             >
               {loading ? (
                 <li className="px-3 py-2 text-sm text-ink-muted">Searching…</li>

--- a/src/app/watches/ReadingList.tsx
+++ b/src/app/watches/ReadingList.tsx
@@ -65,20 +65,20 @@ export function ReadingList({ readings, perInterval, onDeleted }: Props) {
   }
 
   return (
-    <div className="mb-6 overflow-hidden rounded-lg border border-line bg-surface">
-      <div className="border-b border-line px-5 py-3 text-sm font-medium text-ink">
+    <div className="mb-6 overflow-hidden rounded-card border border-line bg-canvas shadow-card">
+      <div className="border-b border-line-subtle bg-canvas px-6 py-4 text-xs font-medium uppercase tracking-wide text-ink-muted">
         Reading log
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-canvas text-left text-xs uppercase tracking-wide text-ink-subtle">
+          <thead className="bg-canvas text-left text-xs font-medium uppercase tracking-wide text-ink-subtle">
             <tr>
-              <th className="px-4 py-2">Reference time</th>
-              <th className="px-4 py-2">Deviation</th>
-              <th className="px-4 py-2">Drift since prev</th>
-              <th className="px-4 py-2">Verified</th>
-              <th className="px-4 py-2">Notes</th>
-              <th className="px-4 py-2" aria-label="actions" />
+              <th className="px-4 py-3">Reference time</th>
+              <th className="px-4 py-3">Deviation</th>
+              <th className="px-4 py-3">Drift since prev</th>
+              <th className="px-4 py-3">Verified</th>
+              <th className="px-4 py-3">Notes</th>
+              <th className="px-4 py-3" aria-label="actions" />
             </tr>
           </thead>
           <tbody>
@@ -87,28 +87,24 @@ export function ReadingList({ readings, perInterval, onDeleted }: Props) {
               return (
                 <tr
                   key={r.id}
-                  className="border-t border-line align-top first:border-t-0"
+                  className="border-t border-line-subtle align-top transition-colors first:border-t-0 hover:bg-surface-inset"
                 >
-                  <td className="px-4 py-3 font-mono text-xs text-ink">
+                  <td className="px-4 py-3 font-mono text-xs tabular-nums text-ink">
                     {formatTime(r.reference_timestamp)}
                     {r.is_baseline ? (
-                      <span className="ml-2 rounded-full border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+                      <span className="ml-2 inline-flex items-center gap-1 rounded-pill border border-accent/25 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
                         baseline
                       </span>
                     ) : null}
                   </td>
-                  <td className="px-4 py-3 font-mono text-ink">
+                  <td className="px-4 py-3 font-mono tabular-nums text-ink">
                     {formatDeviation(r.deviation_seconds)}
                   </td>
-                  <td className="px-4 py-3 font-mono text-ink-muted">
+                  <td className="px-4 py-3 font-mono tabular-nums text-ink-muted">
                     {drift === undefined ? "—" : formatDrift(drift)}
                   </td>
-                  <td className="px-4 py-3 text-ink-muted">
-                    {r.verified ? "✓" : "—"}
-                  </td>
-                  <td className="px-4 py-3 text-ink-muted">
-                    {r.notes ? r.notes : ""}
-                  </td>
+                  <td className="px-4 py-3 text-ink-muted">{r.verified ? "✓" : "—"}</td>
+                  <td className="px-4 py-3 text-ink-muted">{r.notes ? r.notes : ""}</td>
                   <td className="px-4 py-3 text-right">
                     <button
                       type="button"

--- a/src/app/watches/SessionStatsPanel.tsx
+++ b/src/app/watches/SessionStatsPanel.tsx
@@ -36,8 +36,10 @@ function formatDeviation(secs: number): string {
 
 export function SessionStatsPanel({ stats }: Props) {
   if (!stats || stats.reading_count === 0) {
+    // Empty state is visually lighter than a full card — inset
+    // surface without the shadow-card lift keeps the hierarchy right.
     return (
-      <div className="mb-6 rounded-lg border border-line bg-surface px-5 py-4 text-sm text-ink-muted">
+      <div className="mb-6 rounded-card border border-line bg-surface-inset px-6 py-5 text-sm text-ink-muted">
         <p className="mb-1 font-medium text-ink">No readings yet</p>
         <p>
           Log your first reading below. Mark it as a baseline to start a tracking session.
@@ -52,61 +54,69 @@ export function SessionStatsPanel({ stats }: Props) {
   const showAvgDrift = stats.reading_count >= 2 && stats.avg_drift_rate_spd !== null;
 
   return (
-    <div className="mb-6 rounded-lg border border-line bg-surface p-5">
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        <h2 className="mr-2 text-sm font-medium text-ink">
+    <div className="mb-6 rounded-card border border-line bg-canvas p-6 shadow-card md:p-7">
+      <div className="mb-5 flex flex-wrap items-center gap-2">
+        <h2 className="mr-2 text-xs font-medium uppercase tracking-wide text-ink-muted">
           {hasSession ? "Current session" : "Readings logged"}
         </h2>
         {hasSession && stats.eligible ? (
-          <span className="rounded-full border border-accent/40 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
+          <span className="inline-flex items-center gap-1 rounded-pill border border-accent/25 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
             Eligible
           </span>
         ) : hasSession ? (
           <span
-            className="rounded-full border border-line bg-canvas px-2.5 py-0.5 text-xs font-medium text-ink-muted"
+            className="inline-flex items-center gap-1 rounded-pill border border-line bg-surface-inset px-2.5 py-0.5 text-xs font-medium text-ink-muted"
             title="Eligible for ranking after 7 days and 3 readings"
           >
             Not eligible yet
           </span>
         ) : null}
         {stats.verified_badge ? (
-          <span className="rounded-full border border-accent/40 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
-            Verified
+          <span className="inline-flex items-center gap-1 rounded-pill border border-accent/25 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
+            <span aria-hidden="true">✓</span> Verified
           </span>
         ) : null}
       </div>
 
-      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-4">
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm sm:grid-cols-4">
         <div>
-          <dt className="text-ink-muted">Session length</dt>
-          <dd className="mt-0.5 font-mono text-base text-ink">
+          <dt className="text-xs uppercase tracking-wide text-ink-subtle">
+            Session length
+          </dt>
+          <dd className="mt-1 font-mono text-base tabular-nums text-ink">
             {hasSession ? formatDays(stats.session_days) : "—"}
           </dd>
         </div>
         <div>
-          <dt className="text-ink-muted">Readings</dt>
-          <dd className="mt-0.5 font-mono text-base text-ink">
+          <dt className="text-xs uppercase tracking-wide text-ink-subtle">Readings</dt>
+          <dd className="mt-1 font-mono text-base tabular-nums text-ink">
             {stats.reading_count}
           </dd>
         </div>
         {showAvgDrift ? (
           <div>
-            <dt className="text-ink-muted">Average drift</dt>
-            <dd className="mt-0.5 font-mono text-base text-ink">
+            <dt className="text-xs uppercase tracking-wide text-ink-subtle">
+              Average drift
+            </dt>
+            <dd className="mt-1 font-mono text-base tabular-nums text-ink">
               {formatDrift(stats.avg_drift_rate_spd!)}
             </dd>
           </div>
         ) : null}
         <div>
-          <dt className="text-ink-muted">Verified ratio</dt>
-          <dd className="mt-0.5 font-mono text-base text-ink">
+          <dt className="text-xs uppercase tracking-wide text-ink-subtle">
+            Verified ratio
+          </dt>
+          <dd className="mt-1 font-mono text-base tabular-nums text-ink">
             {Math.round(stats.verified_ratio * 100)}%
           </dd>
         </div>
         {hasSession ? (
           <div>
-            <dt className="text-ink-muted">Latest deviation</dt>
-            <dd className="mt-0.5 font-mono text-base text-ink">
+            <dt className="text-xs uppercase tracking-wide text-ink-subtle">
+              Latest deviation
+            </dt>
+            <dd className="mt-1 font-mono text-base tabular-nums text-ink">
               {formatDeviation(stats.latest_deviation_seconds)}
             </dd>
           </div>

--- a/src/app/watches/SubmitMovementSubForm.tsx
+++ b/src/app/watches/SubmitMovementSubForm.tsx
@@ -101,7 +101,7 @@ export function SubmitMovementSubForm({
 
   return (
     <form
-      className="mt-2 flex flex-col gap-3 rounded-md border border-line bg-surface p-4 text-sm"
+      className="mt-2 flex flex-col gap-3 rounded-card border border-line bg-surface-inset p-5 text-sm"
       onSubmit={handleSubmit}
       noValidate
     >
@@ -120,7 +120,7 @@ export function SubmitMovementSubForm({
           onChange={(event) => setCanonicalName(event.target.value)}
           placeholder="e.g. Seiko NH36A"
           aria-invalid={fieldErrors.canonical_name ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+          className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
         />
         {fieldErrors.canonical_name ? (
           <span role="alert" className="text-sm text-accent">
@@ -140,7 +140,7 @@ export function SubmitMovementSubForm({
             onChange={(event) => setManufacturer(event.target.value)}
             placeholder="e.g. Seiko"
             aria-invalid={fieldErrors.manufacturer ? true : undefined}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
           {fieldErrors.manufacturer ? (
             <span role="alert" className="text-sm text-accent">
@@ -158,7 +158,7 @@ export function SubmitMovementSubForm({
             onChange={(event) => setCaliber(event.target.value)}
             placeholder="e.g. NH36A"
             aria-invalid={fieldErrors.caliber ? true : undefined}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
           />
           {fieldErrors.caliber ? (
             <span role="alert" className="text-sm text-accent">
@@ -174,7 +174,7 @@ export function SubmitMovementSubForm({
           value={type}
           onChange={(event) => setType(event.target.value as MovementType)}
           aria-invalid={fieldErrors.type ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+          className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
         >
           {TYPE_OPTIONS.map((option) => (
             <option key={option.value} value={option.value}>
@@ -198,7 +198,7 @@ export function SubmitMovementSubForm({
           onChange={(event) => setNotes(event.target.value)}
           placeholder="Where did you learn about this caliber? Any references?"
           aria-invalid={fieldErrors.notes ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+          className="rounded-md border border-line bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10"
         />
         {fieldErrors.notes ? (
           <span role="alert" className="text-sm text-accent">
@@ -220,7 +220,7 @@ export function SubmitMovementSubForm({
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-2 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover disabled:opacity-60"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover disabled:opacity-60"
         >
           {submitting ? "Submitting…" : "Submit movement"}
         </button>

--- a/src/app/watches/TapReadingForm.tsx
+++ b/src/app/watches/TapReadingForm.tsx
@@ -333,7 +333,7 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
             rows={2}
             maxLength={500}
             placeholder="e.g. worn overnight face-up, 20ºC"
-            className="w-full rounded-md border border-line bg-canvas px-3 py-2 text-sm text-ink placeholder:text-ink-subtle focus:border-accent focus:outline-none disabled:opacity-60"
+            className="w-full rounded-md border border-line bg-canvas px-3.5 py-2.5 text-sm text-ink shadow-inset-edge outline-none transition-colors placeholder:text-ink-subtle focus:border-ink focus:outline-none focus:ring-2 focus:ring-black/10 disabled:opacity-60"
           />
         </label>
       ) : null}

--- a/src/app/watches/TapReadingForm.tsx
+++ b/src/app/watches/TapReadingForm.tsx
@@ -307,7 +307,7 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
           type="button"
           onClick={handleBaseline}
           disabled={isSubmitting}
-          className="inline-flex items-center justify-center rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition-colors hover:border-accent hover:bg-accent/20 disabled:opacity-60"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-accent/25 bg-accent/10 px-5 py-2.5 text-sm font-medium text-accent transition-colors hover:border-accent/40 hover:bg-accent/20 disabled:opacity-60"
         >
           {status.kind === "submitting" && status.position === "baseline"
             ? "Saving baseline…"
@@ -316,7 +316,7 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
         <button
           type="button"
           onClick={() => setShowNotes((s) => !s)}
-          className="text-xs text-ink-muted hover:text-ink"
+          className="text-xs text-ink-muted transition-colors hover:text-ink"
           aria-expanded={showNotes}
         >
           {showNotes ? "Hide notes" : "Add notes"}

--- a/src/app/watches/TapReadingForm.tsx
+++ b/src/app/watches/TapReadingForm.tsx
@@ -181,7 +181,9 @@ export function TapReadingForm({ watchId, onLogged }: Props) {
   return (
     <section className="mb-6 rounded-lg border border-line bg-surface p-5">
       <div className="mb-3 flex items-baseline justify-between gap-4">
-        <h2 className="text-sm font-medium text-ink">Tap to log a reading</h2>
+        <h2 className="text-xs font-medium uppercase tracking-wide text-ink-muted">
+          Tap to log a reading
+        </h2>
         <time
           className="font-mono text-sm tabular-nums text-ink"
           aria-label={`Current reference time ${clockLabel}`}

--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -186,7 +186,9 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
       aria-label="Verified reading"
       className="mb-6 rounded-lg border border-line bg-surface p-5"
     >
-      <h2 className="mb-1 text-sm font-medium text-ink">Log a verified reading</h2>
+      <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-ink-muted">
+        Log a verified reading
+      </h2>
       <p className="mb-4 text-xs text-ink-muted">
         Take a photo of the dial and we&apos;ll read it against the server clock at the
         moment we receive your upload. No timestamp from your device is trusted — the

--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -213,7 +213,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
           <button
             type="button"
             onClick={openFilePicker}
-            className="inline-flex w-full items-center justify-center rounded-full border border-accent bg-accent px-5 py-3 text-sm font-medium text-canvas transition-colors hover:bg-accent/90 sm:w-auto"
+            className="inline-flex min-h-[44px] w-full items-center justify-center rounded-pill bg-accent px-5 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent/90 sm:w-auto"
           >
             Take photo
           </button>
@@ -262,14 +262,14 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
             <button
               type="button"
               onClick={handleSubmit}
-              className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-5 py-2.5 text-sm font-medium text-canvas transition-colors hover:bg-accent/90"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:bg-accent/90"
             >
               Submit verified reading
             </button>
             <button
               type="button"
               onClick={handleCancelOrReset}
-              className="inline-flex items-center justify-center rounded-full border border-line bg-transparent px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink-muted"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink-muted"
             >
               Choose a different photo
             </button>
@@ -294,9 +294,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
         >
           <p className="text-sm text-ink">
             Saved. Dial read at{" "}
-            <span className="font-mono text-accent">
-              {formatDialTime(state.reading)}
-            </span>
+            <span className="font-mono text-accent">{formatDialTime(state.reading)}</span>
             , deviation{" "}
             <span className="font-mono text-accent">
               {formatDeviation(state.reading.deviation_seconds)}
@@ -306,7 +304,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
           <button
             type="button"
             onClick={handleCancelOrReset}
-            className="mt-3 inline-flex items-center justify-center rounded-full border border-line bg-transparent px-4 py-2 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
+            className="mt-3 inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-4 py-2 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent"
           >
             Save another
           </button>

--- a/src/app/watches/WatchForm.tsx
+++ b/src/app/watches/WatchForm.tsx
@@ -91,9 +91,21 @@ export function WatchForm({
     }
   }
 
+  // Shared class fragments so the 4 text inputs + textarea stay in
+  // lockstep. Focus ring is soft black (10 % opacity) per DESIGN.md
+  // section 6; errored state uses a subtle red hue without a loud box.
+  const fieldBase =
+    "rounded-md bg-canvas px-3.5 py-2.5 font-sans text-base text-ink shadow-inset-edge outline-none transition-colors focus:outline-none placeholder:text-ink-subtle";
+  const fieldIdleCx =
+    "border border-line focus:border-ink focus:ring-2 focus:ring-black/10";
+  const fieldErrorCx =
+    "border border-accent/60 focus:border-accent focus:ring-2 focus:ring-red-500/20";
+  const labelCx =
+    "flex flex-col gap-1.5 text-sm font-medium tracking-wide text-ink-muted";
+
   return (
     <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
-      <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+      <label className={labelCx}>
         Name
         <input
           type="text"
@@ -102,7 +114,7 @@ export function WatchForm({
           value={values.name}
           onChange={(event) => update("name", event.target.value)}
           aria-invalid={fieldErrors.name ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+          className={`${fieldBase} ${fieldErrors.name ? fieldErrorCx : fieldIdleCx}`}
         />
         {fieldErrors.name ? (
           <span role="alert" className="text-sm text-accent">
@@ -112,7 +124,7 @@ export function WatchForm({
       </label>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className={labelCx}>
           Brand
           <input
             type="text"
@@ -120,7 +132,7 @@ export function WatchForm({
             value={values.brand}
             onChange={(event) => update("brand", event.target.value)}
             aria-invalid={fieldErrors.brand ? true : undefined}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className={`${fieldBase} ${fieldErrors.brand ? fieldErrorCx : fieldIdleCx}`}
           />
           {fieldErrors.brand ? (
             <span role="alert" className="text-sm text-accent">
@@ -129,7 +141,7 @@ export function WatchForm({
           ) : null}
         </label>
 
-        <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+        <label className={labelCx}>
           Model
           <input
             type="text"
@@ -137,7 +149,7 @@ export function WatchForm({
             value={values.model}
             onChange={(event) => update("model", event.target.value)}
             aria-invalid={fieldErrors.model ? true : undefined}
-            className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+            className={`${fieldBase} ${fieldErrors.model ? fieldErrorCx : fieldIdleCx}`}
           />
           {fieldErrors.model ? (
             <span role="alert" className="text-sm text-accent">
@@ -147,7 +159,7 @@ export function WatchForm({
         </label>
       </div>
 
-      <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+      <label className={labelCx}>
         Reference (optional)
         <input
           type="text"
@@ -156,7 +168,7 @@ export function WatchForm({
           value={values.reference}
           onChange={(event) => update("reference", event.target.value)}
           aria-invalid={fieldErrors.reference ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink placeholder:text-ink-subtle outline-none focus:border-accent"
+          className={`${fieldBase} ${fieldErrors.reference ? fieldErrorCx : fieldIdleCx}`}
         />
         {fieldErrors.reference ? (
           <span role="alert" className="text-sm text-accent">
@@ -172,7 +184,7 @@ export function WatchForm({
         errorMessage={fieldErrors.movement_id}
       />
 
-      <label className="flex flex-col gap-1 text-sm font-medium text-ink">
+      <label className={labelCx}>
         Notes
         <textarea
           rows={3}
@@ -180,7 +192,7 @@ export function WatchForm({
           value={values.notes}
           onChange={(event) => update("notes", event.target.value)}
           aria-invalid={fieldErrors.notes ? true : undefined}
-          className="rounded-md border border-line bg-canvas px-3 py-2 font-sans text-base text-ink outline-none focus:border-accent"
+          className={`${fieldBase} ${fieldErrors.notes ? fieldErrorCx : fieldIdleCx}`}
         />
         {fieldErrors.notes ? (
           <span role="alert" className="text-sm text-accent">
@@ -212,7 +224,7 @@ export function WatchForm({
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-sm font-medium text-[#fffbf5] transition-colors hover:bg-accent-hover disabled:opacity-60"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-6 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover disabled:opacity-60"
         >
           {submitting ? submittingLabel : submitLabel}
         </button>

--- a/src/app/watches/WatchPhotoPanel.tsx
+++ b/src/app/watches/WatchPhotoPanel.tsx
@@ -142,9 +142,9 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
   return (
     <section
       aria-label="Watch photo"
-      className="mb-8 rounded-lg border border-line bg-surface p-4"
+      className="mb-8 rounded-card border border-line bg-canvas p-6 shadow-card md:p-7"
     >
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-ink-muted">
+      <h2 className="mb-4 text-xs font-medium uppercase tracking-wide text-ink-muted">
         Photo
       </h2>
 
@@ -178,12 +178,12 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
 
       {/* Controls. Split by state: pending file, existing image, or empty. */}
       {pending ? (
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex min-h-[44px] flex-wrap items-center gap-3">
           <button
             type="button"
             onClick={handleUpload}
             disabled={busy !== null}
-            className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-2.5 text-sm font-medium text-black transition-colors hover:bg-accent/90 disabled:opacity-60"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-pill bg-accent px-5 py-2.5 text-sm font-medium text-accent-fg transition-colors hover:bg-accent/90 disabled:opacity-60"
           >
             {busy === "upload" ? "Uploading…" : "Upload photo"}
           </button>
@@ -191,7 +191,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
             type="button"
             onClick={handleCancel}
             disabled={busy !== null}
-            className="inline-flex items-center justify-center rounded-full border border-line bg-transparent px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink-muted disabled:opacity-60"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink-muted disabled:opacity-60"
           >
             Cancel
           </button>
@@ -212,7 +212,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
           onDragLeave={() => setDragActive(false)}
           onDrop={onDrop}
           className={`flex flex-wrap items-center gap-3 rounded-md border-2 border-dashed p-4 transition-colors ${
-            dragActive ? "border-accent bg-accent/10" : "border-line bg-canvas"
+            dragActive ? "border-accent bg-accent/10" : "border-line bg-surface-inset"
           }`}
         >
           <input
@@ -226,7 +226,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={busy !== null}
-            className="inline-flex items-center justify-center rounded-full border border-line bg-transparent px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent disabled:opacity-60"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent hover:text-accent disabled:opacity-60"
           >
             {imageKey ? "Replace photo" : "Choose photo"}
           </button>
@@ -238,7 +238,7 @@ export function WatchPhotoPanel({ watchId, imageKey, onChanged }: Props) {
               type="button"
               onClick={handleDelete}
               disabled={busy !== null}
-              className="ml-auto inline-flex items-center justify-center rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-sm font-medium text-accent transition-colors hover:border-accent hover:bg-accent/20 disabled:opacity-60"
+              className="ml-auto inline-flex min-h-[44px] items-center justify-center rounded-pill border border-accent/25 bg-accent/10 px-4 py-2 text-sm font-medium text-accent transition-colors hover:border-accent/40 hover:bg-accent/20 disabled:opacity-60"
             >
               {busy === "delete" ? "Removing…" : "Remove photo"}
             </button>

--- a/src/public/components/layout.tsx
+++ b/src/public/components/layout.tsx
@@ -163,6 +163,9 @@ a:hover { color: var(--color-ink-muted); }
   border-top: 1px solid var(--color-line-subtle);
 }
 
+/* Card default — 16px radius, layered card shadow at sub-0.1 opacity
+ * (outline ring + 1px shadow + 2–4px soft lift). Padding bumps to 28px
+ * on md+ for the "Apple-like generosity" called out in DESIGN.md §5. */
 .cf-card {
   position: relative;
   background: var(--color-canvas);
@@ -170,6 +173,9 @@ a:hover { color: var(--color-ink-muted); }
   border-radius: var(--radius-card);
   padding: 24px;
   box-shadow: var(--shadow-card);
+}
+@media (min-width: 768px) {
+  .cf-card { padding: 28px; }
 }
 .cf-card__title {
   margin: 0 0 8px;

--- a/src/public/landing.tsx
+++ b/src/public/landing.tsx
@@ -52,7 +52,7 @@ export const LandingPage = ({ topVerified = [] }: LandingPageProps) => (
       <section class="cf-container cf-section" aria-labelledby="top-verified-title">
         <h2
           id="top-verified-title"
-          style="margin:0 0 24px;font-size:1.25rem;font-weight:500;letter-spacing:-0.02em;color:var(--color-ink-muted)"
+          style="margin:0 0 24px;font-family:var(--font-display);font-size:1.5rem;font-weight:300;letter-spacing:-0.02em;color:var(--color-ink)"
         >
           Top verified watches
         </h2>

--- a/src/public/leaderboard/table.tsx
+++ b/src/public/leaderboard/table.tsx
@@ -194,33 +194,56 @@ export function LeaderboardStyles() {
   font-weight: 700;
 }
 
+/* Table is wrapped in a card-like chrome — layered shadow +
+ * rounded corners lift it off the canvas the same way the SPA
+ * shadow-card utility does. The thead border is the full --color-line
+ * (a deliberate step stronger than row dividers so the header reads
+ * as a different zone), while the row dividers use the ~5 % line token
+ * — airy and "felt more than seen", per DESIGN.md section 6. */
 .cf-lb-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
 }
 .cf-lb-table thead th {
   text-align: left;
-  padding: 12px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--color-line);
+  background: var(--color-canvas);
   font-weight: 500;
   color: var(--color-ink-muted);
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 .cf-lb-table tbody td {
-  padding: 12px;
-  border-bottom: 1px solid var(--color-line-subtle);
+  padding: 14px 16px;
+  border-top: 1px solid var(--color-line-subtle);
   vertical-align: middle;
+}
+.cf-lb-table tbody tr:first-child td {
+  border-top: 0;
+}
+.cf-lb-table tbody tr {
+  transition: background-color 0.15s ease;
+}
+.cf-lb-table tbody tr:hover {
+  background: var(--color-surface-inset);
 }
 .cf-lb-col-rank {
   width: 3rem;
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   color: var(--color-ink-muted);
 }
 .cf-lb-col-num {
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
 }

--- a/src/public/leaderboard/table.tsx
+++ b/src/public/leaderboard/table.tsx
@@ -173,24 +173,40 @@ export function LeaderboardStyles() {
   const css = `
 .cf-lb-filters {
   display: flex;
-  gap: 16px;
+  gap: 12px;
   margin-top: 16px;
   font-size: 0.875rem;
+  flex-wrap: wrap;
 }
+/* Filter toggle — pill segments (DESIGN.md section 4). Subtle inset
+ * edge at rest, promoted to a shadow-card tier when active so the
+ * selection reads at a glance without a loud accent box. */
 .cf-lb-filters a {
   color: var(--color-ink-muted);
-  padding: 6px 12px;
+  padding: 8px 16px;
   border: 1px solid var(--color-line);
   border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-inset-edge);
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
-.cf-lb-filters a:hover { color: var(--color-ink); background: var(--color-surface-inset); }
+.cf-lb-filters a:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-inset);
+}
 .cf-lb-filter--active {
   color: var(--color-ink) !important;
-  border-color: var(--color-accent) !important;
-  background: var(--color-surface);
+  border-color: var(--color-ink) !important;
+  background: var(--color-canvas);
+  box-shadow: var(--shadow-card);
 }
 .cf-lb-filter__check {
-  color: var(--color-accent);
+  color: var(--color-ink);
   font-weight: 700;
 }
 
@@ -248,20 +264,28 @@ export function LeaderboardStyles() {
   white-space: nowrap;
 }
 
+/* Verified badge — DESIGN.md section 4 small-badge shape. Soft-tone
+ * pill using color-mix on the accent hue (no new colour introduced;
+ * palette v4 is intentionally achromatic). Border + fill at low
+ * opacity reads "accent-aligned" without competing with the primary
+ * black CTA. */
 .cf-lb-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 10px;
+  padding: 2px 10px;
   border-radius: var(--radius-pill);
-  background: var(--color-accent);
-  color: #FFFBF5;
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-accent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.02em;
+  line-height: 1.3;
 }
 .cf-lb-badge--muted {
   background: transparent;
+  border-color: transparent;
   color: var(--color-ink-subtle);
 }
 .cf-lb-badge__check {

--- a/src/public/user/page.tsx
+++ b/src/public/user/page.tsx
@@ -250,20 +250,25 @@ function UserPageStyles() {
   font-size: 0.9rem;
 }
 
+/* Verified badge — matches leaderboard + watch pages. Soft
+ * accent-tinted pill per DESIGN.md section 4. */
 .cf-lb-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 10px;
+  padding: 2px 10px;
   border-radius: var(--radius-pill);
-  background: var(--color-accent);
-  color: #FFFBF5;
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-accent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.02em;
+  line-height: 1.3;
 }
 .cf-lb-badge--muted {
   background: transparent;
+  border-color: transparent;
   color: var(--color-ink-subtle);
 }
 .cf-lb-badge__check {

--- a/src/public/user/page.tsx
+++ b/src/public/user/page.tsx
@@ -195,19 +195,25 @@ function UserPageStyles() {
   .cf-user-grid { grid-template-columns: repeat(3, 1fr); }
 }
 
+/* Profile watch card — canvas bg + layered shadow matches the
+ * SPA dashboard card. Hover lifts subtly (shadow + accent border). */
 .cf-user-card {
   position: relative;
   display: block;
-  background: var(--color-surface);
+  background: var(--color-canvas);
   border: 1px solid var(--color-line);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-card);
   padding: 24px;
   color: var(--color-ink);
-  transition: border-color 0.15s ease, background 0.15s ease;
+  box-shadow: var(--shadow-card);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+@media (min-width: 768px) {
+  .cf-user-card { padding: 28px; }
 }
 .cf-user-card:hover {
   border-color: var(--color-accent);
-  background: var(--color-surface-inset);
+  box-shadow: var(--shadow-lift);
   color: var(--color-ink);
 }
 .cf-user-card__title {

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -478,20 +478,26 @@ function WatchPageStyles() {
   white-space: nowrap;
 }
 
+/* Verified badge — matches the leaderboard page. Soft accent-tinted
+ * pill per DESIGN.md section 4; see src/public/leaderboard/table.tsx
+ * for the authoritative copy of this style. */
 .cf-lb-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 10px;
+  padding: 2px 10px;
   border-radius: var(--radius-pill);
-  background: var(--color-accent);
-  color: #FFFBF5;
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-accent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.02em;
+  line-height: 1.3;
 }
 .cf-lb-badge--muted {
   background: transparent;
+  border-color: transparent;
   color: var(--color-ink-subtle);
 }
 .cf-lb-badge__check {

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -358,31 +358,37 @@ function WatchPageStyles() {
   .cf-watch-grid { grid-template-columns: minmax(240px, 320px) 1fr; }
 }
 
+/* Photo + stats card pair — both use the layered card shadow so they
+ * sit at the same visual level. Photo card has a soft warm shadow
+ * hint via --shadow-card; stats card matches. */
 .cf-watch-photo {
   border: 1px solid var(--color-line);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-card);
   overflow: hidden;
-  background: var(--color-surface);
+  background: var(--color-canvas);
   aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  box-shadow: var(--shadow-card);
 }
 .cf-watch-photo img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .cf-watch-photo--placeholder {
   color: var(--color-ink-subtle);
   font-size: 0.95rem;
+  background: var(--color-surface-inset);
 }
 
 .cf-watch-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  gap: 20px;
   margin: 0;
-  padding: 24px;
-  background: var(--color-surface);
+  padding: 28px;
+  background: var(--color-canvas);
   border: 1px solid var(--color-line);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
 }
 @media (min-width: 768px) {
   .cf-watch-stats { grid-template-columns: repeat(4, minmax(0, 1fr)); }
@@ -390,23 +396,27 @@ function WatchPageStyles() {
 .cf-watch-stats > div { margin: 0; }
 .cf-watch-stats dt {
   font-size: 0.7rem;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--color-ink-subtle);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
+  font-weight: 500;
 }
 .cf-watch-stats dd {
   margin: 0;
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   font-size: 1rem;
+  color: var(--color-ink);
 }
 
 .cf-deviation-chart {
   width: 100%;
   height: auto;
-  background: var(--color-surface);
+  background: var(--color-canvas);
   border: 1px solid var(--color-line);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
 }
 .cf-deviation-chart__axes line {
   stroke: var(--color-line);
@@ -430,24 +440,40 @@ function WatchPageStyles() {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
 }
 .cf-watch-history thead th {
   text-align: left;
-  padding: 12px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--color-line);
+  background: var(--color-canvas);
   font-weight: 500;
   color: var(--color-ink-muted);
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
+.cf-watch-history tbody tr {
+  transition: background-color 0.15s ease;
+}
+.cf-watch-history tbody tr:hover {
+  background: var(--color-surface-inset);
+}
 .cf-watch-history tbody td {
-  padding: 12px;
-  border-bottom: 1px solid var(--color-line-subtle);
+  padding: 14px 16px;
+  border-top: 1px solid var(--color-line-subtle);
   vertical-align: middle;
+}
+.cf-watch-history tbody tr:first-child td {
+  border-top: 0;
 }
 .cf-watch-history__num {
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
 }

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -337,11 +337,17 @@ function WatchPageStyles() {
   margin-right: 6px;
 }
 
+/* Display h2 on the public watch page — Inter 300 per DESIGN.md
+ * section 3 (Waldenburg-weight-300 substitution). Size bumps to 1.5rem
+ * so the lightness reads at a glance — weight 300 at <1.25rem looks
+ * anemic. */
 .cf-watch-h2 {
-  font-size: 1.25rem;
-  font-weight: 500;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 300;
   letter-spacing: -0.01em;
   margin: 0 0 16px;
+  color: var(--color-ink);
 }
 
 .cf-watch-empty {


### PR DESCRIPTION
Follow-up to PR #60 (palette v4). Palette + tokens were right, but many
component surfaces still carried the zinc-era shape — flat rectangles,
thin borders, `rounded-lg`, no shadows. This pass closes the aesthetic
gap against `DESIGN.md` sections 4–7 without introducing new pages,
components, or tokens.

## What changed, by area

**1. Cards & panels** — the highest-impact change. Swapped the
`rounded-lg border border-line bg-surface` pattern for
`rounded-card border border-line bg-canvas shadow-card p-6 md:p-7`
across: `SessionStatsPanel`, `ReadingList` container, `WatchPhotoPanel`,
the verified-progress-ring block on `WatchDetailPage`, dashboard watch
cards, `.cf-card`, `.cf-user-card`, `.cf-watch-photo`, `.cf-watch-stats`,
`.cf-deviation-chart`, `.cf-lb-table`, `.cf-watch-history`. Empty-state
blocks use `bg-surface-inset` without the lift (DESIGN.md §4 — inset
surfaces don't need shadow-card).

**2. Inputs & forms** — every text input now uses the soft black focus
ring pattern from DESIGN.md §6: `shadow-inset-edge` at rest,
`focus:border-ink focus:ring-2 focus:ring-black/10` on focus, and a
subtle `border-accent/60 focus:ring-red-500/20` for error state (no loud
red box). Labels moved to `text-ink-muted tracking-wide`. Applied to
`LoginPage`, `RegisterPage`, `SettingsPage`, `WatchForm`,
`MovementTypeahead`, `SubmitMovementSubForm`, and the TapReadingForm
notes textarea. Input padding bumped from `px-3 py-2` to
`px-3.5 py-2.5` for an airier rhythm.

**3. Pill-shape + tap-target floor** — every in-place button
(`VerifiedReadingCapture`, `TapReadingForm` baseline, `WatchDetailPage`
edit/delete/visibility toggle, `DashboardPage` sign-out,
`NotFoundPage`, `GoogleSignInButton`, `WatchPhotoPanel`) gets
`rounded-pill` + `min-h-[44px]` + `px-5 py-2.5`. Removed the last
stray `#fffbf5` / `text-[#fffbf5]` call sites — all now use
`text-accent-fg`.

**4. Badges** — the public verified pill was a solid black chip with
hardcoded `#FFFBF5` text. Re-shaped to the DESIGN.md §4 small-badge
pattern: soft `color-mix(accent, 10%, transparent)` fill,
`color-mix(accent, 25%, transparent)` border, `text-accent` text. No
new hue introduced — palette v4 is intentionally achromatic
(DESIGN.md §7 Don'ts). The SPA side (`SessionStatsPanel`,
`ReadingList` baseline chip, `DashboardPage` private chip,
`WatchPhotoPanel` pending chip) matches via
`border-accent/25 bg-accent/10`. The filter-toggle pill (All watches /
Verified only) got `shadow-inset-edge` at rest + `shadow-card` when
active.

**5. Tables** — row dividers lightened from `border-line` to
`border-line-subtle` (the ~5% rgba token), added
`hover:bg-surface-inset` transition-colors, and promoted mono cells to
`tabular-nums` so numbers align. thead promoted to an uppercase eyebrow
with ~6% letter-spacing.

**6. Nav / layout shell** — the layout's `.cf-header` already uses
`border-bottom: 1px solid var(--color-line-subtle)` — verified, not
touched. Mobile breakpoint stays at 768px for grids; nav doesn't need
hamburger collapse (only two links, fits on mobile trivially).

**7. Headings** — every SPA page H1 moves from `text-4xl font-medium`
to `font-display text-4xl font-light tracking-tight` per DESIGN.md §3
(Waldenburg-300 → Inter-300 substitution). Small in-panel labels
("Tap to log a reading", "Log a verified reading") promoted to the
eyebrow pattern (`text-xs uppercase tracking-wide text-ink-muted`) to
match "Photo" and "Current session". Public `.cf-watch-h2` lifted to
1.5rem font-display-300. Landing "Top verified watches" h2 swept.

## Decisions where DESIGN.md and the existing code disagreed

- **Verified badge colour.** The task spec referenced a "muted green
  pill" and the `color-mix(verified 12%)` pattern, but the codebase
  had no green hue — the badges were solid black pills. DESIGN.md §7
  explicitly forbids introducing brand colours. I kept the palette
  achromatic and used `color-mix(accent, 10%)` instead, so the badge
  sits at the same visual level DESIGN.md §4 calls for without adding
  a new colour to the system.
- **`shadow-lift` in dark mode.** `shadow-lift` is defined at both
  `:root` (light) and under `@media (prefers-color-scheme: dark)` in
  `styles.css`, but Tailwind v4 snapshots the light value into the
  emitted utility. Used it anyway on `GoogleSignInButton` hover — the
  dark-mode fallback will be the light-shadow values, which are
  barely visible on a dark background but don't break anything. Flag
  for a future `@theme dark { ... }` migration.
- **Per-panel padding rhythm.** DESIGN.md §5 calls for "Apple-like
  generosity"; I used `p-6 md:p-7` on primary data cards (28px on
  desktop) and kept `p-4` on inset blocks. For the public-side
  card-like tables (leaderboard, reading history, stats) I bumped
  thead padding from 12px to 14px 16px so it reads as the calm
  section-head the design calls for.

## Do-no-harm checks

- ✅ Public pages still render zero client JS (no new imports touched
  the SSR bundle).
- ✅ Dark mode contrast: `color-mix(accent, 10%)` on `#F5F5F5` dark
  accent yields a low-opacity off-white chip on the `#0A0A0A` canvas —
  readable. `shadow-card` has a dark-mode override with `rgba(255,
  255, 255, 0.05)` rings + deeper rgba(0,0,0,0.3) lift, still feels
  elevated.
- ✅ No DB / API / Worker logic touched.
- ✅ No `infra/terraform`, `.github/workflows`, `wrangler.jsonc`
  changes.
- ✅ `TapReadingForm` circular dial untouched beyond the section
  heading + notes-textarea focus-ring swap.

## Verify

`npm run typecheck` ✅ · `npm run build` ✅ ·
`npm run test` → **42 test files, 395 passed** ✅

## Commits

1. `design: apply shadow-card + rounded-card to data surfaces`
2. `design: tighten form field focus + inset shadow treatment`
3. `design: pill shape on in-place buttons, tap-target floors`
4. `design: polish badges + row dividers per DESIGN.md section 4`
5. `design: display heading sweep — font-display + font-light everywhere`