### PR TITLE
fix(nav): session-aware public header + drop weird '← Site' exit link

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,18 @@
-// Authed SPA chrome. Renders the shared Header/Footer equivalent for the
-// app surface and an <Outlet /> for the current placeholder page. Slice 3
-// only wires the design language — real auth gating, nav links, and
-// screen content come in later slices.
+// Authed SPA chrome. Renders the SPA-side header/footer and an <Outlet />
+// for the routed page. Nav pulls in the public Leaderboard so signed-in
+// users don't have to leave the app surface to see rankings — the old
+// "← Site" link exited the SPA to the public landing page and felt like
+// a logout (the Better Auth cookie stayed set, but the public header
+// showed anonymous affordances so visitors perceived themselves as
+// signed out). That flow is fixed in two places:
+//
+//   1. Here: "← Site" was replaced with a plain "Leaderboard" link that
+//      keeps the same framing as the other SPA nav items.
+//   2. src/public/components/header.tsx: the public Header now reads
+//      the Better Auth session and swaps its "Sign in" affordance for
+//      "@username → /app/dashboard" when a session exists. So round-
+//      tripping from /app/* to the public site and back no longer
+//      strands the user.
 import { Link, Outlet } from "react-router";
 
 export function App() {
@@ -20,12 +31,12 @@ export function App() {
             <Link to="/app/dashboard" className="hover:text-ink">
               Dashboard
             </Link>
+            <a href="/leaderboard" className="hover:text-ink">
+              Leaderboard
+            </a>
             <Link to="/app/settings" className="hover:text-ink">
               Settings
             </Link>
-            <a href="/" className="hover:text-ink" aria-label="Back to public site">
-              ← Site
-            </a>
           </nav>
         </div>
       </header>

--- a/src/public/auth/resolve-session.ts
+++ b/src/public/auth/resolve-session.ts
@@ -1,0 +1,52 @@
+// Resolve a Better Auth session from an incoming request, returning a
+// public-safe slice of the user (id + username). Used by public SSR
+// pages so the header can render session-aware affordances —
+// specifically: a logged-in visitor landing on a public page
+// (/, /leaderboard, /m/:id, /u/:name, /w/:id) sees a link back to
+// /app/dashboard under their slug, rather than the generic "Sign in"
+// CTA that (a) is wrong for their state and (b) makes the navigation
+// feel like a logout.
+//
+// Never throws. Any resolution failure (missing cookie, expired
+// session, malformed header, DB timeout) degrades to `null`. The
+// caller treats null as "render the anonymous header" — no UX break.
+//
+// Only the `id` and `username` are exposed here. Email / session
+// metadata stay server-side; public SSR has no reason to render them
+// and surfacing them broadens the XSS blast radius for no benefit.
+
+import { getAuth, type AuthEnv } from "@/server/auth";
+
+export interface PublicSessionUser {
+  id: string;
+  /**
+   * Slug-style username (e.g. `nifty-glacier-783`). Nullable because
+   * very early Better Auth-created rows in our DB predate the
+   * `username` column; a null value renders as "you" / anonymised
+   * affordance rather than a broken `@null` string.
+   */
+  username: string | null;
+}
+
+export async function resolvePublicSession(
+  env: AuthEnv,
+  request: Request,
+): Promise<PublicSessionUser | null> {
+  try {
+    const auth = getAuth(env);
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) return null;
+    const user = session.user as { id?: string; username?: string | null };
+    if (!user.id) return null;
+    return {
+      id: user.id,
+      username: user.username ?? null,
+    };
+  } catch {
+    // Error-reporting via captureException is tempting here but the
+    // public-facing impact of failing-closed is zero: renders as
+    // anonymous, same as being signed out. Avoid noise in Sentry for
+    // the many benign causes (tests, flaky D1 reads during boot).
+    return null;
+  }
+}

--- a/src/public/components/header.tsx
+++ b/src/public/components/header.tsx
@@ -1,7 +1,27 @@
-// Public site header — logo + top-level nav. All links are real paths; the
-// ones that don't exist yet (leaderboard, app) 404/SPA-fallback gracefully.
-// Slice 3 is just the shell; destinations land in slices 4 onwards.
-export const Header = () => (
+// Public site header — logo + session-aware nav.
+//
+// When an anonymous visitor hits /, /leaderboard, /m/:id, /u/:name,
+// or /w/:id they see the generic Leaderboard + Sign in links. When a
+// signed-in visitor hits the same pages they see Leaderboard +
+// `@username → /app/dashboard` — so clicking around the public
+// surface doesn't feel like a logout.
+//
+// Session shape is imported rather than duplicated so a future
+// change to the public session slice (e.g. adding a display name)
+// propagates to both the helper and the header without touching
+// every call site.
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
+
+export interface HeaderProps {
+  /**
+   * Resolved session user, or null for anonymous visitors. Defaults
+   * to null so routes that haven't been updated to pass session
+   * state still render the anonymous nav (graceful fall-through).
+   */
+  user?: PublicSessionUser | null;
+}
+
+export const Header = ({ user = null }: HeaderProps) => (
   <header class="cf-header">
     <div class="cf-container cf-header__inner">
       <a href="/" class="cf-logo" aria-label="rated.watch home">
@@ -9,7 +29,13 @@ export const Header = () => (
       </a>
       <nav class="cf-nav" aria-label="Primary">
         <a href="/leaderboard">Leaderboard</a>
-        <a href="/app/login">Sign in</a>
+        {user ? (
+          <a href="/app/dashboard" aria-label="Back to your dashboard">
+            @{user.username ?? "you"}
+          </a>
+        ) : (
+          <a href="/app/login">Sign in</a>
+        )}
       </nav>
     </div>
   </header>

--- a/src/public/landing.tsx
+++ b/src/public/landing.tsx
@@ -7,6 +7,7 @@
 // the Worker fetches the current top-5 verified watches via
 // queryLeaderboard and passes them in as a prop so /‎ stays a single
 // HTML response with no client fetching.
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
 import type { RankedWatch } from "@/domain/leaderboard-query";
 import { Button } from "./components/button";
 import { Card } from "./components/card";
@@ -24,11 +25,14 @@ export interface LandingPageProps {
    *  during the cold-start phase when nobody has crossed the verified
    *  threshold yet. */
   topVerified?: RankedWatch[];
+  /** Resolved session user, or null for anonymous. Drives the
+   *  header's sign-in vs @username affordance. */
+  user?: PublicSessionUser | null;
 }
 
-export const LandingPage = ({ topVerified = [] }: LandingPageProps) => (
+export const LandingPage = ({ topVerified = [], user = null }: LandingPageProps) => (
   <Layout title={TITLE} description={DESCRIPTION} pathname="/">
-    <Header />
+    <Header user={user} />
     <main>
       <section class="cf-container cf-hero" aria-labelledby="hero-title">
         <h1 id="hero-title">Competitive accuracy tracking for watch enthusiasts.</h1>

--- a/src/public/leaderboard/page.tsx
+++ b/src/public/leaderboard/page.tsx
@@ -8,22 +8,28 @@
 import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
 import type { RankedWatch } from "@/domain/leaderboard-query";
 import { LeaderboardStyles, LeaderboardTable, VerifiedFilterToggle } from "./table";
 
 export interface LeaderboardPageProps {
   watches: RankedWatch[];
   verifiedOnly: boolean;
+  user?: PublicSessionUser | null;
 }
 
 const TITLE = "Leaderboard — rated.watch";
 const DESCRIPTION =
   "Global accuracy leaderboard. Watches ranked by absolute drift rate, grouped by movement caliber.";
 
-export const LeaderboardPage = ({ watches, verifiedOnly }: LeaderboardPageProps) => (
+export const LeaderboardPage = ({
+  watches,
+  verifiedOnly,
+  user = null,
+}: LeaderboardPageProps) => (
   <Layout title={TITLE} description={DESCRIPTION} pathname="/leaderboard">
     <LeaderboardStyles />
-    <Header />
+    <Header user={user} />
     <main>
       <section class="cf-container cf-hero" aria-labelledby="lb-title">
         <h1 id="lb-title">Global leaderboard</h1>

--- a/src/public/movement/page.tsx
+++ b/src/public/movement/page.tsx
@@ -11,6 +11,7 @@
 import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
 import type { Movement } from "@/domain/movements/taxonomy";
 import type { RankedWatch } from "@/domain/leaderboard-query";
 import {
@@ -23,9 +24,15 @@ export interface MovementPageProps {
   movement: Movement;
   watches: RankedWatch[];
   verifiedOnly: boolean;
+  user?: PublicSessionUser | null;
 }
 
-export const MovementPage = ({ movement, watches, verifiedOnly }: MovementPageProps) => {
+export const MovementPage = ({
+  movement,
+  watches,
+  verifiedOnly,
+  user = null,
+}: MovementPageProps) => {
   const title = `Most accurate ${movement.canonical_name} watches — rated.watch`;
   const description = `Drift rate leaderboard for the ${movement.canonical_name} ${movement.type} movement.`;
   // Route the CTA through /out/chrono24/:movementId so the Worker can
@@ -37,7 +44,7 @@ export const MovementPage = ({ movement, watches, verifiedOnly }: MovementPagePr
     <Layout title={title} description={description} pathname={`/m/${movement.id}`}>
       <LeaderboardStyles />
       <MovementPageStyles />
-      <Header />
+      <Header user={user} />
       <main>
         <section class="cf-container cf-hero" aria-labelledby="mv-title">
           <p class="cf-mv-crumbs">
@@ -142,13 +149,15 @@ const NOT_FOUND_TITLE = "Movement not found — rated.watch";
 const NOT_FOUND_DESCRIPTION =
   "The movement you're looking for doesn't exist or isn't published yet.";
 
-export const MovementNotFoundPage = () => (
+export const MovementNotFoundPage = ({
+  user = null,
+}: { user?: PublicSessionUser | null } = {}) => (
   <Layout
     title={NOT_FOUND_TITLE}
     description={NOT_FOUND_DESCRIPTION}
     pathname="/m/unknown"
   >
-    <Header />
+    <Header user={user} />
     <main>
       <section class="cf-container cf-hero">
         <h1>Movement not found</h1>

--- a/src/public/user/page.tsx
+++ b/src/public/user/page.tsx
@@ -11,13 +11,15 @@ import { formatDriftRate, formatWatchLabel } from "../leaderboard/format";
 import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
 import type { ProfileData } from "./load";
 
 export interface UserPageProps {
   profile: ProfileData;
+  user?: PublicSessionUser | null;
 }
 
-export const UserPage = ({ profile }: UserPageProps) => {
+export const UserPage = ({ profile, user = null }: UserPageProps) => {
   const title = `@${profile.canonical_username} on rated.watch`;
   const description = `${profile.watches.length} ${profile.watches.length === 1 ? "watch" : "watches"} tracked — competitive accuracy for watch enthusiasts.`;
   return (
@@ -27,7 +29,7 @@ export const UserPage = ({ profile }: UserPageProps) => {
       pathname={`/u/${profile.canonical_username}`}
     >
       <UserPageStyles />
-      <Header />
+      <Header user={user} />
       <main>
         <section class="cf-container cf-hero" aria-labelledby="user-title">
           <h1 id="user-title">@{profile.canonical_username}</h1>
@@ -63,14 +65,20 @@ export const UserPage = ({ profile }: UserPageProps) => {
  * the header + footer don't disappear — keeps the UX coherent when the
  * user mistypes or follows a stale share link.
  */
-export const UserNotFoundPage = ({ username }: { username: string }) => (
+export const UserNotFoundPage = ({
+  username,
+  user = null,
+}: {
+  username: string;
+  user?: PublicSessionUser | null;
+}) => (
   <Layout
     title="Profile not found — rated.watch"
     description="No watch enthusiast here by that username."
     pathname={`/u/${username}`}
   >
     <UserPageStyles />
-    <Header />
+    <Header user={user} />
     <main>
       <section class="cf-container cf-hero" aria-labelledby="nf-title">
         <h1 id="nf-title">Profile not found</h1>

--- a/src/public/watch/page.tsx
+++ b/src/public/watch/page.tsx
@@ -19,15 +19,17 @@ import type { Reading, SessionStats } from "@/domain/drift-calc";
 import { Footer } from "../components/footer";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
+import type { PublicSessionUser } from "@/public/auth/resolve-session";
 import { formatDriftRate, formatWatchLabel } from "../leaderboard/format";
 import { DeviationChart } from "./chart";
 import type { PublicWatch, PublicWatchPageData } from "./load";
 
 export interface WatchPageProps {
   data: PublicWatchPageData;
+  user?: PublicSessionUser | null;
 }
 
-export const WatchPage = ({ data }: WatchPageProps) => {
+export const WatchPage = ({ data, user = null }: WatchPageProps) => {
   const { watch, readings, session_stats } = data;
   const label = formatWatchLabel({
     name: watch.name,
@@ -50,7 +52,7 @@ export const WatchPage = ({ data }: WatchPageProps) => {
   return (
     <Layout title={title} description={description} pathname={`/w/${watch.watch_id}`}>
       <WatchPageStyles />
-      <Header />
+      <Header user={user} />
       <main>
         <section class="cf-container cf-hero" aria-labelledby="w-title">
           <h1 id="w-title">{watch.name}</h1>
@@ -125,14 +127,20 @@ export const WatchPage = ({ data }: WatchPageProps) => {
   );
 };
 
-export const WatchNotFoundPage = ({ watchId }: { watchId: string }) => (
+export const WatchNotFoundPage = ({
+  watchId,
+  user = null,
+}: {
+  watchId: string;
+  user?: PublicSessionUser | null;
+}) => (
   <Layout
     title="Watch not found — rated.watch"
     description="No public watch with that id."
     pathname={`/w/${watchId}`}
   >
     <WatchPageStyles />
-    <Header />
+    <Header user={user} />
     <main>
       <section class="cf-container cf-hero" aria-labelledby="nf-title">
         <h1 id="nf-title">Watch not found</h1>

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -15,6 +15,10 @@ import { buildSetCookie, parseCookie } from "@/public/lib/cookie";
 import { MovementNotFoundPage, MovementPage } from "@/public/movement/page";
 import { loadPublicProfile } from "@/public/user/load";
 import { UserNotFoundPage, UserPage } from "@/public/user/page";
+import {
+  resolvePublicSession,
+  type PublicSessionUser,
+} from "@/public/auth/resolve-session";
 import { loadPublicWatch } from "@/public/watch/load";
 import { WatchNotFoundPage, WatchPage } from "@/public/watch/page";
 import { getAuth, type AuthEnv } from "@/server/auth";
@@ -122,14 +126,42 @@ function resolveVerifiedFilter(req: Request): {
   return { verifiedOnly: cookieValue === "1", setCookie: null };
 }
 
+/**
+ * Cache-Control picker for session-aware public pages.
+ *
+ * Anonymous visitors get the old `public, s-maxage=300,
+ * stale-while-revalidate=86400` — CF edge caches the rendered HTML
+ * so repeat anonymous hits are served without reaching the Worker.
+ *
+ * Signed-in visitors get `private, max-age=0, must-revalidate` —
+ * the personalised `@username` in the header makes the HTML unique
+ * per session, and a shared public cache would poison responses
+ * for subsequent viewers (first signed-in view would be cached and
+ * served to everyone). A future Vary: Cookie + CF cache rule sharding
+ * pass could restore edge caching for signed-in users; not worth it
+ * until real traffic shows the win.
+ */
+function applyPublicCacheHeader(
+  c: { header: (name: string, value: string) => void },
+  user: PublicSessionUser | null,
+): void {
+  if (user) {
+    c.header("Cache-Control", "private, max-age=0, must-revalidate");
+    return;
+  }
+  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+}
+
 app.get("/", async (c) => {
   // Hero extension (slice #13): surface the top-5 verified watches so
   // first-time visitors see the social proof immediately. Falls back
   // to an empty-state card when nobody has crossed the threshold yet.
   const db = createDb(c.env);
+  const user = await resolvePublicSession(c.env, c.req.raw);
   const topVerified = await queryLeaderboard({ verified_only: true, limit: 5 }, db);
   await logEvent("page_view_home", {}, c.env);
-  return c.html(<LandingPage topVerified={topVerified} />);
+  applyPublicCacheHeader(c, user);
+  return c.html(<LandingPage topVerified={topVerified} user={user} />);
 });
 
 // Public HTML leaderboard. Owned by the Worker (see run_worker_first in
@@ -139,19 +171,25 @@ app.get("/", async (c) => {
 // explicitly so first-time viewers never see a stale ranking for long.
 app.get("/leaderboard", async (c) => {
   const db = createDb(c.env);
+  const user = await resolvePublicSession(c.env, c.req.raw);
   const { verifiedOnly, setCookie } = resolveVerifiedFilter(c.req.raw);
   const watches = await queryLeaderboard({ verified_only: verifiedOnly, limit: 50 }, db);
   await logEvent("page_view_leaderboard", { verifiedOnly }, c.env);
-  // Cookie-toggled responses are unique per preference, so drop the
-  // shared-cache directive when we're setting/clearing the cookie.
+  // Session-aware pages can't share a public cache entry (the header
+  // personalises). `applyPublicCacheHeader` picks private-no-cache
+  // for signed-in callers and the usual public SWR window otherwise.
+  // Filter-cookie toggles (setCookie) still take the no-store path
+  // because the Set-Cookie side-effect must not be shared either.
   if (setCookie) {
     c.header("Set-Cookie", setCookie);
     c.header("Cache-Control", "private, no-store");
     await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
   } else {
-    c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+    applyPublicCacheHeader(c, user);
   }
-  return c.html(<LeaderboardPage watches={watches} verifiedOnly={verifiedOnly} />);
+  return c.html(
+    <LeaderboardPage watches={watches} verifiedOnly={verifiedOnly} user={user} />,
+  );
 });
 
 // Public per-movement leaderboard (slice #14). 404 for unknown or
@@ -160,10 +198,12 @@ app.get("/leaderboard", async (c) => {
 // mutations explicitly purge both.
 app.get("/m/:movementId", async (c) => {
   const db = createDb(c.env);
+  const user = await resolvePublicSession(c.env, c.req.raw);
   const taxonomy = createMovementTaxonomy(db);
   const movement = await taxonomy.getBySlug(c.req.param("movementId"));
   if (!movement || movement.status !== "approved") {
-    return c.html(<MovementNotFoundPage />, 404);
+    applyPublicCacheHeader(c, user);
+    return c.html(<MovementNotFoundPage user={user} />, 404);
   }
   const { verifiedOnly, setCookie } = resolveVerifiedFilter(c.req.raw);
   const watches = await queryLeaderboard(
@@ -175,10 +215,15 @@ app.get("/m/:movementId", async (c) => {
     c.header("Cache-Control", "private, no-store");
     await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
   } else {
-    c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+    applyPublicCacheHeader(c, user);
   }
   return c.html(
-    <MovementPage movement={movement} watches={watches} verifiedOnly={verifiedOnly} />,
+    <MovementPage
+      movement={movement}
+      watches={watches}
+      verifiedOnly={verifiedOnly}
+      user={user}
+    />,
   );
 });
 
@@ -188,16 +233,18 @@ app.get("/m/:movementId", async (c) => {
 // converge on one URL. Unknown usernames render a 404 page.
 app.get("/u/:username", async (c) => {
   const db = createDb(c.env);
+  const user = await resolvePublicSession(c.env, c.req.raw);
   const raw = c.req.param("username");
   const result = await loadPublicProfile(db, raw);
   if (result.status === "redirect") {
     return c.redirect(`/u/${result.canonical_username}`, 301);
   }
   if (result.status === "not_found") {
-    return c.html(<UserNotFoundPage username={raw} />, 404);
+    applyPublicCacheHeader(c, user);
+    return c.html(<UserNotFoundPage username={raw} user={user} />, 404);
   }
-  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
-  return c.html(<UserPage profile={result.profile} />);
+  applyPublicCacheHeader(c, user);
+  return c.html(<UserPage profile={result.profile} user={user} />);
 });
 
 // Public per-watch page (slice #15). 404s for unknown AND private
@@ -205,13 +252,15 @@ app.get("/u/:username", async (c) => {
 // response so the existence of private rows isn't leaked.
 app.get("/w/:watchId", async (c) => {
   const db = createDb(c.env);
+  const user = await resolvePublicSession(c.env, c.req.raw);
   const watchId = c.req.param("watchId");
   const result = await loadPublicWatch(db, watchId);
   if (result.status === "not_found") {
-    return c.html(<WatchNotFoundPage watchId={watchId} />, 404);
+    applyPublicCacheHeader(c, user);
+    return c.html(<WatchNotFoundPage watchId={watchId} user={user} />, 404);
   }
-  c.header("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
-  return c.html(<WatchPage data={result.data} />);
+  applyPublicCacheHeader(c, user);
+  return c.html(<WatchPage data={result.data} user={user} />);
 });
 
 // Better Auth owns every method under /api/v1/auth/*. We pass the raw


### PR DESCRIPTION
Fixes the reported UX break where navigating from `/app/*` to the public site felt like a logout.

## Problem

Visiting `/`, `/leaderboard`, `/m/:id`, `/u/:name`, or `/w/:id` while signed in showed the generic 'Leaderboard / Sign in' header. The Better Auth cookie stayed set, but no UI affordance reflected that — visitors perceived themselves as logged out.

## Fix

- **`resolvePublicSession` helper** — calls Better Auth server-side, returns `{ id, username } | null`. Never throws.
- **`Header` takes an optional `user` prop**. Anonymous → 'Sign in'. Signed-in → '@username → /app/dashboard'.
- **Every public page component** accepts `user` and threads it to its Header (LandingPage, LeaderboardPage, MovementPage/404, UserPage/404, WatchPage/404).
- **Every worker route handler** resolves session once and passes through.
- **Cache safety**: new `applyPublicCacheHeader` keeps `public s-maxage=300 SWR` for anonymous, drops to `private max-age=0` when a session is detected. Without this, the first signed-in response would be edge-cached and poison the header for everyone else.
- **SPA App.tsx**: '← Site' becomes a plain 'Leaderboard' link — same line-weight as Dashboard / Settings, no more 'exit' framing.

395 / 395 tests green.