### PR TITLE
chore(observability): sentry beforeSend filter for AbortError + WorkerTimeout

### DIFF
--- a/src/observability/sentry.beforeSend.test.ts
+++ b/src/observability/sentry.beforeSend.test.ts
@@ -1,0 +1,60 @@
+// Unit tests for the beforeSend filter that drops known-noisy
+// runtime errors (AbortError, WorkerTimeout) before they burn
+// Sentry event budget. Everything else — TypeError, ReferenceError,
+// custom app errors — must pass through unchanged.
+//
+// We test beforeSend as a pure function (exported from ./sentry) so
+// these tests don't need the full Sentry SDK wiring.
+
+import { describe, expect, it } from "vitest";
+import { beforeSend } from "./sentry";
+import type { ErrorEvent, EventHint } from "@sentry/cloudflare";
+
+function makeEvent(exceptionType: string, message = "x"): ErrorEvent {
+  return {
+    type: undefined,
+    exception: {
+      values: [{ type: exceptionType, value: message }],
+    },
+  } as ErrorEvent;
+}
+
+describe("beforeSend — drops known-noisy runtime errors", () => {
+  it("filters out AbortError (client disconnect mid-response)", () => {
+    const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+    const evt = makeEvent("AbortError", "aborted");
+    const hint: EventHint = { originalException: err };
+    expect(beforeSend(evt, hint)).toBeNull();
+  });
+
+  it("filters out WorkerTimeout (CPU-time limit)", () => {
+    const err = Object.assign(new Error("cpu exceeded"), {
+      name: "WorkerTimeout",
+    });
+    const evt = makeEvent("WorkerTimeout", "cpu exceeded");
+    const hint: EventHint = { originalException: err };
+    expect(beforeSend(evt, hint)).toBeNull();
+  });
+
+  it("passes through a generic Error unchanged", () => {
+    const err = new Error("boom");
+    const evt = makeEvent("Error", "boom");
+    const hint: EventHint = { originalException: err };
+    expect(beforeSend(evt, hint)).toBe(evt);
+  });
+
+  it("passes through TypeError (real bug signal)", () => {
+    const err = new TypeError("cannot read x of undefined");
+    const evt = makeEvent("TypeError", "cannot read x of undefined");
+    const hint: EventHint = { originalException: err };
+    expect(beforeSend(evt, hint)).toBe(evt);
+  });
+
+  it("falls back to event.exception.values[0].type when hint.originalException is absent", () => {
+    // Sentry doesn't always populate originalException (e.g. events
+    // constructed from captureMessage paths). Ensure we still drop
+    // the noisy type from the event payload itself.
+    const evt = makeEvent("AbortError", "aborted");
+    expect(beforeSend(evt, {})).toBeNull();
+  });
+});

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -20,6 +20,15 @@
 // `captureException` signature is preserved so callsites from slice
 // #19 don't change.
 import * as Sentry from "@sentry/cloudflare";
+import type { ErrorEvent, EventHint } from "@sentry/cloudflare";
+
+// Error names / exception types we never want to send to Sentry.
+// These are infra-level noise, not actionable code bugs:
+//   - AbortError: Workers runtime throws when a client disconnects
+//     mid-response (writes after the response body has been consumed).
+//   - WorkerTimeout: emitted near the CPU-time limit; indicates a
+//     platform ceiling, not a logic error.
+const DROPPED_ERROR_NAMES = new Set(["AbortError", "WorkerTimeout"]);
 
 export interface CaptureContext {
   // Primitives only — the same shape as the slice-19 stub. Sentry
@@ -88,11 +97,31 @@ export function captureException(
 }
 
 /**
+ * Sentry `beforeSend` hook: return `null` to drop an event, or the
+ * event (optionally mutated) to let it through. We drop known-noisy
+ * runtime errors (see DROPPED_ERROR_NAMES) so they don't burn event
+ * budget. Everything else — TypeError, ReferenceError, app errors —
+ * passes through untouched.
+ */
+export function beforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null {
+  const originalName =
+    hint.originalException instanceof Error ? hint.originalException.name : undefined;
+  const payloadType = event.exception?.values?.[0]?.type;
+  if (originalName && DROPPED_ERROR_NAMES.has(originalName)) return null;
+  if (payloadType && DROPPED_ERROR_NAMES.has(payloadType)) return null;
+  return event;
+}
+
+/**
  * Wrap the Worker's default export so Sentry automatically captures
  * every unhandled exception.
  *
  * When `SENTRY_DSN` is not set (local dev, anonymous preview), this
  * returns the handler unchanged so the Worker still boots.
+ *
+ * The `beforeSend` option filters out known-noisy runtime errors
+ * (AbortError, WorkerTimeout) so the Sentry event budget isn't
+ * consumed by infra-level noise that isn't actionable.
  */
 export function withSentry<THandler>(handler: THandler): THandler {
   // Broad generic rather than `ExportedHandler<Env>` because Hono's
@@ -128,6 +157,8 @@ export function withSentry<THandler>(handler: THandler): THandler {
       // set it here — future followup if release-tracking becomes a
       // real need.
       environment: "production",
+      // Filter noisy runtime errors before they hit the ingest.
+      beforeSend,
     };
   }, handler);
   return wrapped;


### PR DESCRIPTION
## Summary

Adds a `beforeSend` hook to the Sentry `withSentry` options that drops two classes of known-noisy runtime errors before they reach ingest, so the free-tier event budget isn't consumed by non-actionable platform signal.

**Dropped:**
- `AbortError` — client disconnects mid-response (Workers runtime throws this on writes after the response body has been consumed)
- `WorkerTimeout` (`error.name === "WorkerTimeout"`) — Workers CPU-time limit; infra ceiling, not a code bug

**Kept (signal):** `TypeError`, `ReferenceError`, custom app errors, and everything else — unchanged pass-through.

## Implementation

- Exported `beforeSend` as a named function in `src/observability/sentry.ts` so it can be unit-tested as a pure function (no Sentry SDK init required in tests).
- Matches against both `hint.originalException.name` (preferred) and `event.exception.values[0].type` (fallback for events that don't carry an `originalException`).
- Wired `beforeSend` into the options object returned to `Sentry.withSentry`.
- JSDoc above `withSentry` now documents the filter contract (2-3 lines).

## Tests

New co-located unit test: `src/observability/sentry.beforeSend.test.ts` — 5 cases covering AbortError, WorkerTimeout, generic Error, TypeError, and the hint-less fallback path.

- Before: 395 tests in 42 files
- After: 400 tests in 43 files, all passing
- `npm run typecheck` + `npm run build` both clean

## Context

One of five flagged followups from the phase-1 tracker. Non-urgent hardening — sample rate (`0.1`), PII flag (`false`), and hardcoded environment (`"production"`) are all intentionally untouched per the task scope.