### PR TITLE
feat(cache): emit Vary: Cookie on public SSR pages

### DIFF
--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -137,14 +137,24 @@ function resolveVerifiedFilter(req: Request): {
  * the personalised `@username` in the header makes the HTML unique
  * per session, and a shared public cache would poison responses
  * for subsequent viewers (first signed-in view would be cached and
- * served to everyone). A future Vary: Cookie + CF cache rule sharding
- * pass could restore edge caching for signed-in users; not worth it
- * until real traffic shows the win.
+ * served to everyone).
+ *
+ * Both branches emit `Vary: Cookie` unconditionally. Browser (per-
+ * device) caches honour it today: after a user signs out, their
+ * local cache won't replay the personalised HTML because the Cookie
+ * header that keyed the stored response is no longer on the request.
+ *
+ * The matching CF edge cache-rule that would let the shared edge
+ * keep caching signed-in HTML (keyed on the session cookie) is
+ * intentionally deferred — it needs real-traffic validation and
+ * Terraform infra work. Emitting the header now means that future
+ * rule can be layered on without re-touching this helper.
  */
 function applyPublicCacheHeader(
   c: { header: (name: string, value: string) => void },
   user: PublicSessionUser | null,
 ): void {
+  c.header("Vary", "Cookie");
   if (user) {
     c.header("Cache-Control", "private, max-age=0, must-revalidate");
     return;
@@ -182,6 +192,10 @@ app.get("/leaderboard", async (c) => {
   // because the Set-Cookie side-effect must not be shared either.
   if (setCookie) {
     c.header("Set-Cookie", setCookie);
+    // no-store is correct here (the Set-Cookie side-effect must not
+    // be shared), but the Vary: Cookie contract still applies so
+    // browser caches differentiate a subsequent signed-out replay.
+    c.header("Vary", "Cookie");
     c.header("Cache-Control", "private, no-store");
     await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
   } else {
@@ -212,6 +226,9 @@ app.get("/m/:movementId", async (c) => {
   );
   if (setCookie) {
     c.header("Set-Cookie", setCookie);
+    // See /leaderboard above — same reasoning for keeping the
+    // Vary: Cookie contract on the no-store branch.
+    c.header("Vary", "Cookie");
     c.header("Cache-Control", "private, no-store");
     await logEvent("leaderboard_filter_changed", { verifiedOnly }, c.env);
   } else {

--- a/tests/integration/home.test.ts
+++ b/tests/integration/home.test.ts
@@ -72,4 +72,48 @@ describe("GET / — design system + home shell", () => {
     const body = await response.text();
     expect(body).toMatch(/prefers-color-scheme\s*:\s*dark/i);
   });
+
+  // Followup (cache-vary-cookie): public SSR pages must emit
+  // `Vary: Cookie` so browser caches correctly differentiate anon
+  // vs authed variants after sign-out.
+  it("emits Vary: Cookie and the anon s-maxage Cache-Control (no cookie)", async () => {
+    const response = await exports.default.fetch(new Request("https://ratedwatch.test/"));
+    expect(response.headers.get("vary") ?? "").toMatch(/Cookie/i);
+    expect(response.headers.get("cache-control") ?? "").toMatch(/s-maxage=300/);
+  });
+
+  it("emits Vary: Cookie and the private signed-in Cache-Control when authenticated", async () => {
+    // Register + sign in to acquire a Better Auth session cookie, then
+    // hit the home page as that signed-in user. The public-pages
+    // session resolver reads the same cookie via getSession.
+    const email = `home-vary-${crypto.randomUUID()}@ratedwatch.test`;
+    const password = "correct-horse-42";
+    await exports.default.fetch(
+      new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "home-vary", email, password }),
+      }),
+    );
+    const login = await exports.default.fetch(
+      new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      }),
+    );
+    expect(login.status).toBe(200);
+    const rawCookie = login.headers.get("set-cookie") ?? "";
+    const cookie = rawCookie.split(";")[0] ?? "";
+    expect(cookie).toBeTruthy();
+
+    const response = await exports.default.fetch(
+      new Request("https://ratedwatch.test/", { headers: { cookie } }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("vary") ?? "").toMatch(/Cookie/i);
+    expect(response.headers.get("cache-control") ?? "").toMatch(
+      /private,\s*max-age=0,\s*must-revalidate/,
+    );
+  });
 });

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -455,6 +455,30 @@ describe("GET /leaderboard — public HTML", () => {
     expect(cacheControl).toMatch(/stale-while-revalidate=86400/);
   });
 
+  // Followup (cache-vary-cookie): public SSR pages must emit
+  // `Vary: Cookie` so browser caches correctly differentiate the
+  // anon variant from the signed-in variant after sign-out. A
+  // future CF edge cache-rule can key off this header too.
+  it("emits Vary: Cookie on the anon no-toggle path", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard"),
+    );
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
+  it("emits Vary: Cookie on the Set-Cookie filter-toggle path", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/leaderboard?verified=1"),
+    );
+    expect(res.status).toBe(200);
+    // Cache-Control stays `private, no-store` on the toggle path —
+    // the Set-Cookie side-effect must never be shared — but the
+    // Vary: Cookie header is still emitted so browser caches
+    // differentiate the signed-out replay.
+    expect(res.headers.get("cache-control") ?? "").toMatch(/private,\s*no-store/);
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
   it("footer mentions the eligibility rule (7 days, 3 readings)", async () => {
     const res = await exports.default.fetch(
       new Request("https://ratedwatch.test/leaderboard"),

--- a/tests/integration/per-movement-leaderboard.test.ts
+++ b/tests/integration/per-movement-leaderboard.test.ts
@@ -316,6 +316,23 @@ describe("GET /m/:movementId — public HTML", () => {
     expect(cacheControl).toMatch(/stale-while-revalidate=86400/);
   });
 
+  // Followup (cache-vary-cookie): Vary: Cookie on the anon path.
+  it("emits Vary: Cookie on the anon no-toggle path", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}`),
+    );
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
+  it("emits Vary: Cookie on the Set-Cookie filter-toggle path", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/m/${SEED.movements.alpha.id}?verified=1`),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control") ?? "").toMatch(/private,\s*no-store/);
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
   it("returns 404 HTML for a pending movement", async () => {
     const res = await exports.default.fetch(
       new Request(`https://ratedwatch.test/m/${SEED.movements.pending.id}`),

--- a/tests/integration/public-pages.test.ts
+++ b/tests/integration/public-pages.test.ts
@@ -205,6 +205,24 @@ describe("GET /u/:username — public user profile", () => {
     expect(res.status).toBe(404);
   });
 
+  // Followup (cache-vary-cookie): Vary: Cookie on both the 200
+  // and 404 anon branches. Browser caches need it so signed-out
+  // users don't serve the personalised authed variant back.
+  it("emits Vary: Cookie on the 200 anon profile path", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/u/${SEED.user.username}`),
+    );
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
+  it("emits Vary: Cookie on the 404 anon profile path", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/u/nobody-exists-here"),
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
   it("emits zero client-side JavaScript", async () => {
     const res = await exports.default.fetch(
       new Request(`https://ratedwatch.test/u/${SEED.user.username}`),
@@ -288,6 +306,23 @@ describe("GET /w/:watchId — public watch page", () => {
       new Request("https://ratedwatch.test/w/does-not-exist-anywhere"),
     );
     expect(res.status).toBe(404);
+  });
+
+  // Followup (cache-vary-cookie): Vary: Cookie on both the 200
+  // and 404 anon branches.
+  it("emits Vary: Cookie on the 200 anon watch path", async () => {
+    const res = await exports.default.fetch(
+      new Request(`https://ratedwatch.test/w/${SEED.publicWatch.id}`),
+    );
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
+  });
+
+  it("emits Vary: Cookie on the 404 anon watch path", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/w/does-not-exist-anywhere"),
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("vary") ?? "").toMatch(/Cookie/i);
   });
 
   it("emits zero client-side JavaScript", async () => {


### PR DESCRIPTION
## Why

Public SSR pages (\`/\`, \`/leaderboard\`, \`/m/:id\`, \`/u/:name\`, \`/w/:id\`) currently tell the CF edge to cache anon responses for 5 min (\`public, s-maxage=300, SWR=86400\`) and send signed-in responses through origin on every load (\`private, max-age=0, must-revalidate\`). That picker is correct as far as it goes, but neither branch emits \`Vary: Cookie\`, so **browser** (per-device) caches don't know the response varies on the session cookie. After a user signs out, their local browser cache could replay the signed-in HTML (header with \`@username\`, etc.) back at them.

Emitting \`Vary: Cookie\` on every public-SSR response fixes that browser-cache failure mode today and sets up the contract for a future CF edge cache-rule that would let the shared edge also cache signed-in HTML keyed on the session cookie.

## Why not more

The matching **CF cache rule** that would actually shard the edge cache key on \`Cookie\` is intentionally deferred. It needs real-traffic validation (cache hit-rate, risk of serving stale personalised HTML between invalidations) and Terraform infra work. Layering it on later will not require re-touching this helper — the \`Vary: Cookie\` contract is already in place.

## What changed

- \`src/worker/index.tsx\` — \`applyPublicCacheHeader\` now unconditionally sets \`Vary: Cookie\`. Cache-Control values unchanged. JSDoc rewritten to document the new contract and flag the deferred-CF-rule work.
- \`src/worker/index.tsx\` — the two \`/leaderboard\` and \`/m/:id\` branches where \`setCookie\` is non-null (filter toggle, \`private, no-store\`) now also emit \`Vary: Cookie\` inline for consistency. Cache-Control still \`private, no-store\` there — that's correct because the Set-Cookie side-effect must never be shared.
- No changes to \`resolveVerifiedFilter\`, no Terraform changes, no styles touched.

## Tests

+10 integration tests covering:

- \`/\` anon → \`vary\` contains \`Cookie\`, cache-control unchanged (\`s-maxage=300\`)
- \`/\` **signed-in** (sign up + login via Better Auth, replay with session cookie) → \`vary\` contains \`Cookie\`, cache-control is \`private, max-age=0, must-revalidate\`
- \`/leaderboard\` anon no-toggle → \`vary\` contains \`Cookie\`
- \`/leaderboard?verified=1\` Set-Cookie path → \`vary\` contains \`Cookie\`, cache-control still \`private, no-store\`
- \`/m/:id\` anon no-toggle + \`/m/:id?verified=1\` Set-Cookie path → same two assertions
- \`/u/:name\` 200 + 404 anon paths → \`vary\` contains \`Cookie\`
- \`/w/:id\` 200 + 404 anon paths → \`vary\` contains \`Cookie\`

**Count**: 395 → 405 tests. Full suite green. \`npm run build\` green.