### PR TITLE
feat(seo): robots.txt + sitemap.xml

### DIFF
--- a/src/server/routes/seo.ts
+++ b/src/server/routes/seo.ts
@@ -1,0 +1,182 @@
+// SEO plumbing — robots.txt + sitemap.xml.
+//
+// Both routes are owned by the Worker (see run_worker_first in
+// wrangler.jsonc). The SPA fallback would otherwise rewrite unknown
+// paths to /index.html, which is wrong for crawler-facing surfaces:
+// robots.txt would 200 with HTML, and sitemap.xml would never get
+// served at all.
+//
+// Canonical host is always https://rated.watch in emitted URLs,
+// regardless of the hostname the request hit. The Worker is reachable
+// at multiple hostnames (rated.watch, ratedwatch.nmoura.workers.dev,
+// per-PR pr-<N>-… preview aliases), but only the apex is the indexable
+// surface — see wrangler.jsonc and src/server/auth.ts for the same
+// reasoning applied to the auth baseURL.
+//
+// The sitemap is dynamic: it enumerates approved movements, users
+// with at least one public watch, and public watches themselves. The
+// query plan is one query per entity type (no N+1) and the result is
+// edge-cached for an hour, so the per-request cost is bounded.
+
+import { Hono } from "hono";
+import { sql } from "kysely";
+import { createDb } from "@/db";
+
+type Bindings = { DB: D1Database; [key: string]: unknown };
+
+// Canonical host. Phase 1 only — `www.rated.watch` is intentionally
+// NOT a sitemap URL because crawlers would otherwise index two
+// hostnames for the same content.
+const CANONICAL_ORIGIN = "https://rated.watch";
+
+// Static body. Reasons each line is here:
+//   * `Allow: /` is a no-op (the default) but spelled out for human
+//     readers who skim the file.
+//   * /app/ is the authed SPA; nothing under it should be indexed.
+//   * /api/ is the JSON surface; same reason, plus it dampens any
+//     accidental crawler that decides to POST somewhere.
+//   * /out/ is the click-tracker redirect surface; crawling it wastes
+//     crawl budget on 302s and pollutes the analytics events.
+const ROBOTS_TXT = `User-agent: *
+Allow: /
+Disallow: /app/
+Disallow: /api/
+Disallow: /out/
+Sitemap: ${CANONICAL_ORIGIN}/sitemap.xml
+`;
+
+export const seoRoute = new Hono<{ Bindings: Bindings }>();
+
+seoRoute.get("/robots.txt", (c) => {
+  c.header("Content-Type", "text/plain; charset=utf-8");
+  // 24h edge cache — crawlers refetch this rarely; the directives are
+  // stable across deploys.
+  c.header("Cache-Control", "public, s-maxage=86400");
+  return c.body(ROBOTS_TXT);
+});
+
+/**
+ * XML-escape a string for use inside a `<loc>` element. The sitemap
+ * spec mandates entity-encoding for `&`, `<`, `>`, `'`, `"`. We don't
+ * URL-encode the whole thing because slugs and usernames are already
+ * URL-safe by construction (lowercase + hyphen).
+ */
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+  changefreq?: "hourly" | "daily" | "weekly";
+  priority?: number; // 0.0 - 1.0
+}
+
+function renderUrl(entry: SitemapEntry): string {
+  const parts: string[] = [`    <loc>${xmlEscape(entry.loc)}</loc>`];
+  if (entry.lastmod) {
+    parts.push(`    <lastmod>${xmlEscape(entry.lastmod)}</lastmod>`);
+  }
+  if (entry.changefreq) {
+    parts.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+  }
+  if (entry.priority !== undefined) {
+    parts.push(`    <priority>${entry.priority.toFixed(1)}</priority>`);
+  }
+  return `  <url>\n${parts.join("\n")}\n  </url>`;
+}
+
+function renderSitemap(entries: readonly SitemapEntry[]): string {
+  const body = entries.map(renderUrl).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${body}
+</urlset>
+`;
+}
+
+seoRoute.get("/sitemap.xml", async (c) => {
+  const db = createDb(c.env);
+
+  // One query per entity type. Each query stays a single statement —
+  // join-free where possible — so 1k watches + 10k users still finishes
+  // well under the hourly cache window.
+
+  // Approved movements only (matches the /m/:id 404 rule for pending).
+  const movements = await db
+    .selectFrom("movements")
+    .select("id")
+    .where("status", "=", "approved")
+    .orderBy("id")
+    .execute();
+
+  // Users with at least one public watch. Subquery via DISTINCT keeps
+  // this a single-table-scan with an index lookup — no join.
+  const usersWithPublicWatches = await db
+    .selectFrom("user")
+    .select(["username"])
+    .where(
+      "id",
+      "in",
+      db.selectFrom("watches").select("user_id").where("is_public", "=", 1),
+    )
+    .orderBy("username")
+    .execute();
+
+  // Public watches with their `lastmod` candidates: latest reading
+  // created_at (when one exists) or the watch's own created_at.
+  // SQLite's MAX() over the readings join is computed in one query.
+  const publicWatches = await db
+    .selectFrom("watches")
+    .leftJoin("readings", "readings.watch_id", "watches.id")
+    .select([
+      "watches.id as id",
+      "watches.created_at as created_at",
+      sql<string | null>`MAX(readings.created_at)`.as("latest_reading_created_at"),
+    ])
+    .where("watches.is_public", "=", 1)
+    .groupBy("watches.id")
+    .orderBy("watches.id")
+    .execute();
+
+  const entries: SitemapEntry[] = [
+    {
+      loc: `${CANONICAL_ORIGIN}/`,
+      changefreq: "daily",
+      priority: 1.0,
+    },
+    {
+      loc: `${CANONICAL_ORIGIN}/leaderboard`,
+      changefreq: "hourly",
+      priority: 0.9,
+    },
+    ...movements.map<SitemapEntry>((m) => ({
+      loc: `${CANONICAL_ORIGIN}/m/${m.id}`,
+      changefreq: "daily",
+      priority: 0.7,
+    })),
+    ...usersWithPublicWatches.map<SitemapEntry>((u) => ({
+      loc: `${CANONICAL_ORIGIN}/u/${u.username}`,
+      changefreq: "weekly",
+      priority: 0.6,
+    })),
+    ...publicWatches.map<SitemapEntry>((w) => ({
+      loc: `${CANONICAL_ORIGIN}/w/${w.id}`,
+      lastmod: w.latest_reading_created_at ?? w.created_at,
+      changefreq: "weekly",
+      priority: 0.6,
+    })),
+  ];
+
+  c.header("Content-Type", "application/xml; charset=utf-8");
+  // 1h edge cache — short enough that a fresh public watch lands in
+  // the sitemap within an hour, long enough that crawler hits don't
+  // pound the DB.
+  c.header("Cache-Control", "public, s-maxage=3600");
+  return c.body(renderSitemap(entries));
+});

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -28,6 +28,7 @@ import { meRoute } from "@/server/routes/me";
 import { movementsRoute } from "@/server/routes/movements";
 import { outRoute } from "@/server/routes/out";
 import { readingsByIdRoute, readingsByWatchRoute } from "@/server/routes/readings";
+import { seoRoute } from "@/server/routes/seo";
 import { watchesRoute } from "@/server/routes/watches";
 
 // The Worker's full env extends the narrower AuthEnv used by getAuth.
@@ -279,6 +280,12 @@ app.get("/w/:watchId", async (c) => {
   applyPublicCacheHeader(c, user);
   return c.html(<WatchPage data={result.data} user={user} />);
 });
+
+// SEO plumbing — /robots.txt + /sitemap.xml. Owned by the Worker so
+// crawlers see the real responses (not the SPA fallback HTML). The
+// sub-app declares both bare-path routes; mounting at "/" makes them
+// reachable at their advertised URLs.
+app.route("/", seoRoute);
 
 // Better Auth owns every method under /api/v1/auth/*. We pass the raw
 // Request straight through — Better Auth reads method, URL, headers,

--- a/tests/integration/seo.test.ts
+++ b/tests/integration/seo.test.ts
@@ -1,0 +1,328 @@
+// Integration tests for the SEO plumbing routes (followup/robots-sitemap):
+//
+//   * GET /robots.txt   — static directives + Sitemap pointer
+//   * GET /sitemap.xml  — dynamic enumeration of indexable URLs
+//
+// Both are owned by the Worker (see wrangler.jsonc run_worker_first).
+// Sitemap rules:
+//   * Always emits canonical https://rated.watch URLs regardless of
+//     the host that hit the Worker.
+//   * Public watches → included; private watches → excluded.
+//   * Users with at least one public watch → included; users with no
+//     public watches → excluded (avoids leaks + empty pages).
+//   * Approved movements → included; pending → excluded (matches the
+//     /m/:id 404 rule).
+//
+// Seeds run inside per-test-file storage isolation (vitest-pool-workers).
+// Distinct ids namespace this file from public-pages.test.ts so the
+// sitemap assertions stay deterministic even if both tests seed in
+// the same miniflare instance.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const runId = crypto.randomUUID().slice(0, 8);
+const id = (suffix: string) => `seo-${runId}-${suffix}`;
+
+const SEED = {
+  // Owner with at least one public watch — should appear in the sitemap.
+  ownerWithPublic: {
+    id: id("user-pub"),
+    name: "Public Owner",
+    username: id("pub-owner").toLowerCase(),
+    email: `${id("pub")}@test`,
+  },
+  // Owner with only private watches — should NOT appear.
+  ownerPrivateOnly: {
+    id: id("user-priv"),
+    name: "Private Owner",
+    username: id("priv-owner").toLowerCase(),
+    email: `${id("priv")}@test`,
+  },
+  movements: {
+    approved: {
+      id: id("mov-approved"),
+      canonical_name: `ETA ${id("APPR")}`,
+      manufacturer: "ETA",
+      caliber: id("APPR"),
+      type: "automatic" as const,
+      status: "approved" as const,
+    },
+    pending: {
+      id: id("mov-pending"),
+      canonical_name: `Proto ${id("PEND")}`,
+      manufacturer: "Proto",
+      caliber: id("PEND"),
+      type: "automatic" as const,
+      status: "pending" as const,
+    },
+  },
+  watches: {
+    pub: {
+      id: id("w-pub"),
+      name: "Sitemap Public",
+      brand: "Rolex",
+      model: "Submariner",
+      is_public: 1,
+    },
+    priv: {
+      id: id("w-priv"),
+      name: "Sitemap Private",
+      brand: "Nomos",
+      model: "Tangente",
+      is_public: 0,
+    },
+    privOnlyOwner: {
+      id: id("w-priv-only"),
+      name: "Hidden",
+      brand: "Hidden",
+      model: "Hidden",
+      is_public: 0,
+    },
+  },
+};
+
+async function seed() {
+  const db = (env as unknown as { DB: D1Database }).DB;
+  const iso = new Date().toISOString();
+
+  // Users.
+  for (const u of [SEED.ownerWithPublic, SEED.ownerPrivateOnly]) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO user (id, name, email, emailVerified, username, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?, ?)",
+      )
+      .bind(u.id, u.name, u.email, u.username, iso, iso)
+      .run();
+  }
+
+  // Movements (approved + pending).
+  for (const m of [SEED.movements.approved, SEED.movements.pending]) {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(m.id, m.canonical_name, m.manufacturer, m.caliber, m.type, m.status, null)
+      .run();
+  }
+
+  // Public watch owned by ownerWithPublic.
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      SEED.watches.pub.id,
+      SEED.ownerWithPublic.id,
+      SEED.watches.pub.name,
+      SEED.watches.pub.brand,
+      SEED.watches.pub.model,
+      SEED.movements.approved.id,
+      1,
+    )
+    .run();
+  // Private watch owned by ownerWithPublic.
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      SEED.watches.priv.id,
+      SEED.ownerWithPublic.id,
+      SEED.watches.priv.name,
+      SEED.watches.priv.brand,
+      SEED.watches.priv.model,
+      SEED.movements.approved.id,
+      0,
+    )
+    .run();
+  // Private watch owned by ownerPrivateOnly.
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO watches (id, user_id, name, brand, model, movement_id, is_public) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      SEED.watches.privOnlyOwner.id,
+      SEED.ownerPrivateOnly.id,
+      SEED.watches.privOnlyOwner.name,
+      SEED.watches.privOnlyOwner.brand,
+      SEED.watches.privOnlyOwner.model,
+      SEED.movements.approved.id,
+      0,
+    )
+    .run();
+
+  // One reading on the public watch so we can assert the lastmod
+  // path uses readings.created_at when readings exist.
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO readings (id, watch_id, user_id, reference_timestamp, deviation_seconds, is_baseline, verified) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      id("r-pub-1"),
+      SEED.watches.pub.id,
+      SEED.ownerWithPublic.id,
+      Date.now(),
+      0,
+      1,
+      0,
+    )
+    .run();
+}
+
+beforeAll(async () => {
+  await seed();
+});
+
+// ---- /robots.txt ---------------------------------------------------
+
+describe("GET /robots.txt", () => {
+  it("returns 200", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/robots.txt"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("sets Content-Type: text/plain; charset=utf-8", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/robots.txt"),
+    );
+    expect(res.headers.get("content-type") ?? "").toBe("text/plain; charset=utf-8");
+  });
+
+  it("sets Cache-Control: public, s-maxage=86400 (24h edge cache)", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/robots.txt"),
+    );
+    expect(res.headers.get("cache-control") ?? "").toBe("public, s-maxage=86400");
+  });
+
+  it("body contains the expected User-agent and Disallow directives", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/robots.txt"),
+    );
+    const body = await res.text();
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /app/");
+    expect(body).toContain("Disallow: /api/");
+    expect(body).toContain("Disallow: /out/");
+  });
+
+  it("body declares the canonical Sitemap URL", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/robots.txt"),
+    );
+    const body = await res.text();
+    expect(body).toContain("Sitemap: https://rated.watch/sitemap.xml");
+  });
+});
+
+// ---- /sitemap.xml --------------------------------------------------
+
+describe("GET /sitemap.xml", () => {
+  it("returns 200", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("sets Content-Type: application/xml; charset=utf-8", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    expect(res.headers.get("content-type") ?? "").toBe("application/xml; charset=utf-8");
+  });
+
+  it("sets Cache-Control: public, s-maxage=3600 (hourly edge cache)", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    expect(res.headers.get("cache-control") ?? "").toBe("public, s-maxage=3600");
+  });
+
+  it("body is valid XML with the sitemap-0.9 schema preamble", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(body).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    // Closing tag — basic well-formed-ness sanity.
+    expect(body.trimEnd().endsWith("</urlset>")).toBe(true);
+  });
+
+  it("contains the home and global leaderboard locs (always canonical https://rated.watch)", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).toContain("<loc>https://rated.watch/</loc>");
+    expect(body).toContain("<loc>https://rated.watch/leaderboard</loc>");
+  });
+
+  it("contains a /m/<slug> loc for an approved seeded movement", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).toContain(
+      `<loc>https://rated.watch/m/${SEED.movements.approved.id}</loc>`,
+    );
+  });
+
+  it("contains a /u/<username> loc for a user WITH a public watch", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).toContain(
+      `<loc>https://rated.watch/u/${SEED.ownerWithPublic.username}</loc>`,
+    );
+  });
+
+  it("does NOT contain a /u/<username> loc for a user with NO public watches", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).not.toContain(
+      `<loc>https://rated.watch/u/${SEED.ownerPrivateOnly.username}</loc>`,
+    );
+  });
+
+  it("contains a /w/<id> loc for a public watch", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).toContain(`<loc>https://rated.watch/w/${SEED.watches.pub.id}</loc>`);
+  });
+
+  it("does NOT contain a /w/<id> loc for a private watch", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).not.toContain(
+      `<loc>https://rated.watch/w/${SEED.watches.priv.id}</loc>`,
+    );
+    expect(body).not.toContain(
+      `<loc>https://rated.watch/w/${SEED.watches.privOnlyOwner.id}</loc>`,
+    );
+  });
+
+  it("does NOT contain a /m/<slug> loc for a pending movement", async () => {
+    const res = await exports.default.fetch(
+      new Request("https://ratedwatch.test/sitemap.xml"),
+    );
+    const body = await res.text();
+    expect(body).not.toContain(
+      `<loc>https://rated.watch/m/${SEED.movements.pending.id}</loc>`,
+    );
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -41,7 +41,9 @@
       "/w/*",
       "/out/*",
       "/api/*",
-      "/images/*"
+      "/images/*",
+      "/robots.txt",
+      "/sitemap.xml"
     ]
   },
 


### PR DESCRIPTION
## Summary

SEO plumbing before any search-traffic work. Adds two Worker-owned
routes via a new `src/server/routes/seo.ts` sub-app, mounted in the
Hono graph between the public HTML routes and the `/api/v1/auth/*`
catch-all.

## `/robots.txt`

Static directives, served as `text/plain; charset=utf-8` with
`Cache-Control: public, s-maxage=86400` (24h edge cache — directives
are stable across deploys).

```
User-agent: *
Allow: /
Disallow: /app/
Disallow: /api/
Disallow: /out/
Sitemap: https://rated.watch/sitemap.xml
```

- `/app/` — authed SPA, must not be indexed.
- `/api/` — JSON surface; reduces noise + dampens accidental crawler `POST`s.
- `/out/` — click-tracker redirects; crawling them wastes the budget on 302s and pollutes analytics events.

## `/sitemap.xml`

Dynamic enumeration of indexable URLs, served as
`application/xml; charset=utf-8` with `Cache-Control: public, s-maxage=3600`
(1h — fresh public watches surface within the hour without pounding the DB).

Always emits canonical `https://rated.watch` URLs regardless of the
hostname the request hit. The Worker is reachable on multiple
hostnames (apex, `*.workers.dev`, per-PR previews) but only the apex
is the indexable surface.

URLs included:
- `/` — home (priority 1.0, daily)
- `/leaderboard` — global verified leaderboard (priority 0.9, hourly)
- `/m/<slug>` — for every **APPROVED** movement (priority 0.7, daily)
- `/u/<username>` — for every user with **at least one PUBLIC watch** (priority 0.6, weekly)
- `/w/<watchId>` — for every **PUBLIC** watch (priority 0.6, weekly), with `lastmod` = latest reading `created_at` if any, else the watch's `created_at`

URLs **excluded** (and why):
- Private watches — emitting them would leak the existence of private rows.
- Users with no public watches — empty pages + leak.
- Pending / unapproved movements — same rule as the `/m/:id` 404 path; pending submissions stay off the public URL surface.

Query plan: one statement per entity type (no N+1). Movements via a
filtered scan, users via `WHERE id IN (SELECT user_id FROM watches
WHERE is_public=1)`, public watches via a single `LEFT JOIN readings
… GROUP BY watch_id` with `MAX(readings.created_at)` to compute
`lastmod` in one round-trip.

## Wrangler

`run_worker_first` extended with the two exact paths so Workers
Assets doesn't intercept them with a 404 (wildcards aren't useful
here). Lint-staged regenerated `worker-configuration.d.ts` as
expected; the cross-platform `@emnapi/*` lockfile churn was committed
along with it as documented in `AGENTS.md`.

## Tests

16 new integration assertions in `tests/integration/seo.test.ts`:
- `robots.txt`: 200, headers, all five expected directives.
- `sitemap.xml`: 200, headers, well-formed XML preamble, home + leaderboard locs, approved-movement loc present, public-watch + public-user-with-public-watch locs present, AND negative assertions for private watches, private-only-owner users, and pending movements.

Full suite: 46 files / 440 tests green. Typecheck + build clean.

Refs `followup/robots-sitemap`