### PR TITLE
fix(design): shadow-lift utility respects dark-mode CSS var

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -176,6 +176,50 @@
   color-scheme: light;
 }
 
+/* Tailwind v4 `.shadow-<name>` utility overrides for dark-mode
+ * support. Tailwind compiles `@theme { --shadow-<name>: … }` into
+ * utility classes whose box-shadow values are SNAPSHOTTED at build
+ * time as the LIGHT-mode literal — the @media (prefers-color-scheme:
+ * dark) :root block above redefines --shadow-* to warm-white rings,
+ * but Tailwind's emitted utility ignores that override because it
+ * was baked in at build time. Call sites like
+ * `<button className="hover:shadow-lift">` therefore show invisible
+ * black shadows on near-black surfaces in dark mode.
+ *
+ * `@utility` is Tailwind v4's first-class hook for (re)defining a
+ * utility — Tailwind handles variant generation (hover, md, etc.)
+ * automatically and the override emerges later in the cascade than
+ * the @theme-generated rule, winning by source order. The body
+ * resolves `var(--shadow-<name>)` at runtime so prefers-color-scheme
+ * picks up the dark-mode redefinition.
+ *
+ * Tailwind v4 keeps the @theme `--shadow-*` tokens available as
+ * :root,:host CSS custom properties (alongside snapshotting them
+ * into utility-class literals), so `var(--shadow-<name>)` resolves
+ * to the light-mode value at the cascade root and to the warm-white
+ * variant under the dark @media query.
+ *
+ * Scope: only the utilities actually referenced as Tailwind classes
+ * in src/app/**\/*.tsx are overridden — `shadow-card`,
+ * `shadow-inset-edge`, and `hover:shadow-lift`. shadow-warm,
+ * shadow-soft, and shadow-outline are only consumed via
+ * `box-shadow: var(--shadow-<name>)` from .cf-* classes
+ * (src/public/**) and other plain-CSS rules, which already read
+ * the runtime CSS var and pick up the dark-mode override correctly.
+ *
+ * The base `shadow-lift` is included for parity even though only
+ * `hover:shadow-lift` is currently used — keeps the override
+ * surface consistent and future-proofs a non-hover use. */
+@utility shadow-card {
+  box-shadow: var(--shadow-card);
+}
+@utility shadow-inset-edge {
+  box-shadow: var(--shadow-inset-edge);
+}
+@utility shadow-lift {
+  box-shadow: var(--shadow-lift);
+}
+
 html,
 body {
   background: var(--color-canvas);

--- a/tests/integration/shadow-utilities.test.ts
+++ b/tests/integration/shadow-utilities.test.ts
@@ -1,0 +1,101 @@
+import { env } from "cloudflare:workers";
+import { describe, it, expect, beforeAll } from "vitest";
+
+// Tailwind v4 design-token regression guard — dark-mode shadow fix.
+//
+// Tailwind v4's @theme block in src/app/styles.css registers
+// --shadow-<name> tokens, which Tailwind then emits as `.shadow-<name>`
+// utility classes. The emitted utility BAKES THE LIGHT-MODE LITERAL
+// in as the box-shadow fallback at build time:
+//
+//   .shadow-card { --tw-shadow: var(--tw-shadow-color, #0000000f) 0 0 0 1px, ...; }
+//
+// The @media (prefers-color-scheme: dark) block in styles.css redefines
+// --shadow-<name> to warm-white rings, but Tailwind's emitted utility
+// IGNORES that override because it was snapshotted at build time. So
+// `shadow-card`, `hover:shadow-lift`, etc. show black-tinted shadows
+// in dark mode — invisible on near-black surfaces.
+//
+// The fix: add `@utility shadow-<name> { box-shadow: var(--shadow-<name>); }`
+// blocks after `:root { color-scheme: light; }` so each used utility
+// (and its variants) reads the runtime CSS var. The override emerges
+// later in the cascade than the @theme-generated rule and Tailwind
+// keeps `--shadow-*` available as :root custom properties, so the
+// dark-mode @media block applies. This test asserts those overrides
+// made it into the production CSS bundle.
+//
+// Scope: only the utilities ACTUALLY used as Tailwind classes in
+// src/app/**/*.tsx need overriding. shadow-warm/soft/outline are only
+// referenced via `.cf-*` classes that already do box-shadow:
+// var(--shadow-X) directly, so they are dark-mode-correct already.
+//
+// Note on Tailwind's lazy emission: Tailwind only emits the `.shadow-X`
+// rule for utilities that actually appear in source files. The current
+// codebase uses `shadow-card` and `shadow-inset-edge` directly but only
+// `hover:shadow-lift` (no bare `shadow-lift`), so we assert overrides
+// for the three SHAPES present in the build: `.shadow-card`,
+// `.shadow-inset-edge`, and `.hover\:shadow-lift:hover`. The bare
+// `.shadow-lift` rule is ALSO registered via @utility for parity
+// (future-proofing a non-hover use) but Tailwind won't emit it until
+// some source file references the bare class — this test deliberately
+// does NOT require a bare `.shadow-lift` rule in the bundle, because
+// asserting absence of an unused utility is a flake risk.
+
+let cssBody: string;
+
+beforeAll(async () => {
+  const shellResponse = await env.ASSETS.fetch(
+    new Request("https://ratedwatch.test/app/dashboard"),
+  );
+  const shell = await shellResponse.text();
+  const match = shell.match(/<link[^>]+rel="stylesheet"[^>]+href="(\/assets\/[^"]+)"/);
+  if (!match) throw new Error("no stylesheet link in SPA shell");
+  const cssHref = match[1]!;
+
+  const cssResponse = await env.ASSETS.fetch(
+    new Request(`https://ratedwatch.test${cssHref}`),
+  );
+  expect(cssResponse.status).toBe(200);
+  cssBody = await cssResponse.text();
+});
+
+describe("Shadow utility dark-mode override", () => {
+  // Each assertion looks for a rule matching `<selector> { box-shadow:
+  // var(--shadow-<name>); }` (allowing for minified whitespace and
+  // additional declarations in the same block). The presence of this
+  // override bypasses Tailwind's snapshotted literal and lets the
+  // @media (prefers-color-scheme: dark) block in styles.css take effect.
+
+  it(".shadow-card reads from var(--shadow-card) at runtime", () => {
+    expect(cssBody).toMatch(
+      /\.shadow-card\s*\{[^}]*box-shadow\s*:\s*var\s*\(\s*--shadow-card\s*\)[^}]*\}/,
+    );
+  });
+
+  it(".shadow-inset-edge reads from var(--shadow-inset-edge) at runtime", () => {
+    expect(cssBody).toMatch(
+      /\.shadow-inset-edge\s*\{[^}]*box-shadow\s*:\s*var\s*\(\s*--shadow-inset-edge\s*\)[^}]*\}/,
+    );
+  });
+
+  it("hover:shadow-lift variant reads from var(--shadow-lift) at runtime", () => {
+    // GoogleSignInButton uses `hover:shadow-lift`. Tailwind escapes the
+    // colon in the selector, so the emitted class is
+    // `.hover\:shadow-lift:hover`. The escape is a literal backslash in
+    // the CSS source, which we match with `\\:` in the regex.
+    expect(cssBody).toMatch(
+      /\.hover\\:shadow-lift:hover\s*\{[^}]*box-shadow\s*:\s*var\s*\(\s*--shadow-lift\s*\)[^}]*\}/,
+    );
+  });
+
+  // Sanity: the dark-mode @media block must still be present — that's
+  // what redefines --shadow-<name>, which our overrides now read.
+  it("dark-mode media query redefines --shadow-lift to warm-white rings", () => {
+    expect(cssBody).toMatch(/prefers-color-scheme\s*:\s*dark/i);
+    // The dark --shadow-lift uses rgba(255,255,255,...) which Tailwind
+    // does NOT minify into a hex (alpha channel). Its first colour
+    // stop is rgba(255, 255, 255, 0.08) — minifier may compact to
+    // #ffffff14 or rgba(255,255,255,.08).
+    expect(cssBody).toMatch(/(#ffffff14|rgba\(255,\s*255,\s*255,\s*\.?0?\.08\))/);
+  });
+});


### PR DESCRIPTION
## Summary

Tailwind v4's `@theme` block in `src/app/styles.css` registers `--shadow-<name>` tokens. Tailwind compiles those into `.shadow-<name>` utility classes whose `box-shadow` values are **snapshotted at build time** with the light-mode literal. The `@media (prefers-color-scheme: dark) :root` block redefines `--shadow-*` to warm-white rings, but Tailwind's emitted utility class ignores that override because the box-shadow was baked in.

So `<button className="hover:shadow-lift">` showed invisible black shadows on near-black surfaces in dark mode (and the same applied to `shadow-card`, `shadow-inset-edge`).

## Fix

Add Tailwind v4 `@utility shadow-<name>` blocks after the `:root` light-mode declaration in `src/app/styles.css`:

```css
@utility shadow-card { box-shadow: var(--shadow-card); }
@utility shadow-inset-edge { box-shadow: var(--shadow-inset-edge); }
@utility shadow-lift { box-shadow: var(--shadow-lift); }
```

Tailwind v4's `@utility` directive registers an override that emerges later in the cascade than the `@theme`-generated rule (winning by source order) and Tailwind handles variant generation (`hover:`, `md:`, etc.) automatically. The body resolves `var(--shadow-<name>)` at runtime so `prefers-color-scheme: dark` picks up the warm-white-ring redefinition.

Tailwind v4 keeps the `@theme` `--shadow-*` tokens available as `:root,:host` CSS custom properties (alongside snapshotting them into utility-class literals), so the var resolves to the light value at the cascade root and to the dark variant under the `@media` query — no extra plumbing needed.

## Which utilities were overridden

| Utility | Used in `src/app/**/*.tsx`? | Override added? |
| --- | --- | --- |
| `shadow-card` | yes (8+ call sites: `WatchPhotoPanel`, `SessionStatsPanel`, `DashboardPage`, etc.) | **yes** |
| `shadow-inset-edge` | yes (form fields across the SPA) | **yes** |
| `hover:shadow-lift` | yes (`GoogleSignInButton`) | **yes** (Tailwind generates the hover variant from the base `shadow-lift` @utility) |
| `shadow-lift` (bare) | no (only `hover:` variant used) | base @utility registered for parity / future-proofing |
| `shadow-warm` | only via `.cf-*` classes that already read `var(--shadow-warm)` directly | **skipped** |
| `shadow-soft` | only via `.cf-*` classes | **skipped** |
| `shadow-outline` | only via `.cf-*` classes | **skipped** |

The skipped utilities are referenced exclusively by SSR `.cf-*` rules that already do `box-shadow: var(--shadow-X);` directly — they pick up the dark-mode override correctly with no Tailwind layer involved.

`src/public/components/layout.tsx` deliberately untouched: the inlined `DesignTokensStyle` doesn't load Tailwind at all, and SSR pages use `.cf-btn--ghost { box-shadow: var(--shadow-card); }` etc. that already read the runtime var.

## Tests

New regression guard: `tests/integration/shadow-utilities.test.ts` (4 tests) asserts the production CSS bundle contains:

- `.shadow-card { box-shadow: var(--shadow-card) }`
- `.shadow-inset-edge { box-shadow: var(--shadow-inset-edge) }`
- `.hover\:shadow-lift:hover { … box-shadow: var(--shadow-lift) }`
- The `@media (prefers-color-scheme: dark)` block still ships and redefines `--shadow-lift` to the warm-white-ring variant (`#ffffff14`).

Without the override these would fail because Tailwind's emitted rule sets `--tw-shadow` to a literal RGBA value with no `var(--shadow-X)` reference.

Full suite: 428 tests passing (was 424 before, +4 from this change). Build clean. No new dependencies.

This completes the dark-mode shadow polish from the phase-1 followup list.

Refs followup/shadow-lift-darkmode