### PR TITLE
feat(verifier): EXIF DateTimeOriginal as reference timestamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,17 @@ Full product spec: see the `product-requirements` issue labelled `prd` on GitHub
 
 ## Ubiquitous language
 
-| Term                          | Meaning                                                                                                                                            |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Reading**                   | A record of the watch's displayed time vs an authoritative reference time at a specific moment.                                                    |
-| **Deviation**                 | Signed seconds the watch is ahead (+) or behind (−) of the reference, at a single reading.                                                         |
-| **Drift rate**                | Change in deviation per day, computed between two readings. Unit: seconds per day (s/d).                                                           |
-| **Baseline reading**          | A reading with `is_baseline = true`, marking the start of a new tracking session (watch just set to the exact time; deviation is 0).               |
-| **Session**                   | The sequence of readings from the most recent baseline to the latest reading for a given watch.                                                    |
-| **Manual reading**            | A reading whose deviation was typed by the user. Not trusted for competitive rankings.                                                             |
-| **Verified reading**          | A reading whose deviation was computed from an in-app camera capture, with the server timestamp at receipt as the reference time. Spoof-resistant. |
-| **Verified watch**            | A watch whose current session has at least 25 % verified readings. Displays a verified badge on leaderboards.                                      |
-| **Movement** (or **caliber**) | The mechanical/quartz/electronic time-keeping mechanism inside a watch. First-class domain object. Leaderboards are grouped by movement.           |
+| Term                          | Meaning                                                                                                                                                                                                                                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Reading**                   | A record of the watch's displayed time vs an authoritative reference time at a specific moment.                                                                                                                                                                                              |
+| **Deviation**                 | Signed seconds the watch is ahead (+) or behind (−) of the reference, at a single reading.                                                                                                                                                                                                   |
+| **Drift rate**                | Change in deviation per day, computed between two readings. Unit: seconds per day (s/d).                                                                                                                                                                                                     |
+| **Baseline reading**          | A reading with `is_baseline = true`, marking the start of a new tracking session (watch just set to the exact time; deviation is 0).                                                                                                                                                         |
+| **Session**                   | The sequence of readings from the most recent baseline to the latest reading for a given watch.                                                                                                                                                                                              |
+| **Manual reading**            | A reading whose deviation was typed by the user. Not trusted for competitive rankings.                                                                                                                                                                                                       |
+| **Verified reading**          | A reading whose deviation was computed from an in-app camera capture. Reference time is the photo's EXIF `DateTimeOriginal` when present (bounded against server arrival, ±5 min / +1 min); falls back to server arrival time when EXIF is absent. See the trust note in "Things NOT to do". |
+| **Verified watch**            | A watch whose current session has at least 25 % verified readings. Displays a verified badge on leaderboards.                                                                                                                                                                                |
+| **Movement** (or **caliber**) | The mechanical/quartz/electronic time-keeping mechanism inside a watch. First-class domain object. Leaderboards are grouped by movement.                                                                                                                                                     |
 
 ## Stack + conventions
 
@@ -54,7 +54,7 @@ Full product spec: see the `product-requirements` issue labelled `prd` on GitHub
 - **No Next.js, Remix, TanStack Start, or other SSR frameworks** — the Hono JSX + Vite SPA split is the architecture.
 - **No Prisma, Sequelize, or heavy ORMs.** Kysely only.
 - **No rolling our own crypto.** Better Auth handles all auth primitives; never touch PBKDF2 / JWT hand-crafted code like the archived watchdrift prototype did.
-- **No trusting client-supplied EXIF / client timestamps** for verified readings. Server receipt time is the source of truth.
+- **EXIF DateTimeOriginal is accepted as the reference timestamp** for verified readings, bounded by ±5 min / +1 min against server arrival time. Reading the bytes server-side is fine; the client never sends a literal timestamp claim. When EXIF is missing the verifier falls back to server arrival time (captured at handler entry, **before** body upload, to minimize phantom drift). The trust trade-off is that an attacker with control over their phone's clock can fake deviations within the bounds window — that's accepted for now; spoof-resistance (e.g. camera-attestation tokens) is a future iteration.
 - **No placeholder strings in committed config** (e.g. `YOUR_WORKER_URL.workers.dev` — that's an archived-watchdrift crime).
 
 ## CI / quality gates

--- a/src/app/watches/verifiedReadingErrors.test.ts
+++ b/src/app/watches/verifiedReadingErrors.test.ts
@@ -29,6 +29,16 @@ describe("mapVerifiedReadingError", () => {
     );
   });
 
+  it("maps exif_clock_skew (422) to a fix-your-phone-clock hint", () => {
+    // EXIF timestamp outside the -5min/+1min window. The most likely
+    // cause is the user's phone clock being wrong (manual override,
+    // travel without auto-time, or a long-suspended device). The
+    // copy nudges them to fix the clock and retake the photo.
+    const mapped = mapVerifiedReadingError(422, "exif_clock_skew");
+    expect(mapped.code).toBe("exif_clock_skew");
+    expect(mapped.message).toMatch(/clock/i);
+  });
+
   it("maps verified_readings_disabled (503) to an account-not-enabled copy", () => {
     const mapped = mapVerifiedReadingError(503, "verified_readings_disabled");
     expect(mapped.message).toMatch(/verified readings aren't enabled/i);

--- a/src/app/watches/verifiedReadingErrors.ts
+++ b/src/app/watches/verifiedReadingErrors.ts
@@ -10,6 +10,9 @@
 //   * 422 + error: "ai_refused"          → AI wouldn't read the dial
 //   * 422 + error: "ai_unparseable"      → AI response wasn't JSON we expected
 //   * 422 + error: "ai_implausible"      → AI read a dial time too far off
+//   * 422 + error: "exif_clock_skew"     → EXIF timestamp outside the
+//                                          -5min/+1min window vs server
+//                                          (phone clock is wrong)
 //   * 503 + error: "verified_readings_disabled" → feature flag off for this user
 //   * 400 + error: "image_required"      → form didn't include the file (client bug)
 //   * 413 + error: "image_too_large"     → image > 10 MB
@@ -22,6 +25,7 @@ export type VerifiedReadingErrorCode =
   | "ai_refused"
   | "ai_unparseable"
   | "ai_implausible"
+  | "exif_clock_skew"
   | "verified_readings_disabled"
   | "image_required"
   | "image_too_large"
@@ -65,6 +69,13 @@ export function mapVerifiedReadingError(
       return {
         code: "ai_implausible",
         message: "The reading looked off (bad lighting or dirty glass?) — try again",
+      };
+    }
+    if (serverCode === "exif_clock_skew") {
+      return {
+        code: "exif_clock_skew",
+        message:
+          "Your phone's clock seems to be off — please check your phone's date & time, then retake the photo",
       };
     }
   }

--- a/src/domain/reading-verifier/exif.test.ts
+++ b/src/domain/reading-verifier/exif.test.ts
@@ -1,0 +1,80 @@
+// Unit tests for the EXIF capture-timestamp extractor.
+//
+// The extractor wraps `exifr` with a "never throws" contract: any
+// failure mode (corrupt EXIF, unsupported format, parser blowup) must
+// resolve to `null` so the verifier can cleanly fall back to server
+// arrival time. Tests here drive both the happy path and the
+// pathological inputs.
+//
+// The test override hook (`__setTestExifReader`) is exercised in its
+// own block to lock down the shape that the verifier tests rely on —
+// install a stub, see it called instead of the real parser, then
+// clear with `null` to restore the default.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractCaptureTimestampMs, __setTestExifReader } from "./exif";
+
+afterEach(() => {
+  __setTestExifReader(null);
+});
+
+describe("extractCaptureTimestampMs", () => {
+  it("returns null for an empty buffer", async () => {
+    const result = await extractCaptureTimestampMs(new ArrayBuffer(0));
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-image bytes", async () => {
+    // `TextEncoder().encode(...).buffer` is typed as `ArrayBufferLike`
+    // (could be a SharedArrayBuffer in theory). Copy into a fresh
+    // ArrayBuffer so the test contract matches what HTTP body
+    // handlers actually deliver to the verifier.
+    const bytes = new TextEncoder().encode("definitely not a jpeg");
+    const garbage = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(garbage).set(bytes);
+    const result = await extractCaptureTimestampMs(garbage);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a tiny JPEG without EXIF (SOI + EOI only)", async () => {
+    // Two-byte SOI + two-byte EOI — a "valid" JPEG header with no
+    // metadata segments at all. Real photos straight from a phone
+    // always carry EXIF; screenshots and stripped uploads land here.
+    const buf = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]).buffer;
+    const result = await extractCaptureTimestampMs(buf);
+    expect(result).toBeNull();
+  });
+
+  it("never throws — corrupt headers resolve to null", async () => {
+    // 0xFF 0xD8 sets the JPEG SOI marker but then we lie about
+    // segment lengths. exifr historically has handled this via
+    // silentErrors; we rely on that and double-belt with a top-level
+    // catch. We assert via `.resolves` so the test fails on rejection
+    // (which is what the contract forbids) rather than swallowing it.
+    const corrupt = new Uint8Array([0xff, 0xd8, 0xff, 0xe1, 0xff, 0xff, 0x00, 0x00])
+      .buffer;
+    await expect(extractCaptureTimestampMs(corrupt)).resolves.toBeNull();
+  });
+});
+
+describe("__setTestExifReader", () => {
+  it("routes calls through the installed stub when set", async () => {
+    const stub = vi.fn(async () => 1_700_000_000_000);
+    __setTestExifReader(stub);
+    const result = await extractCaptureTimestampMs(new ArrayBuffer(0));
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(result).toBe(1_700_000_000_000);
+  });
+
+  it("restores the real parser when cleared with null", async () => {
+    const stub = vi.fn(async () => 42);
+    __setTestExifReader(stub);
+    expect(await extractCaptureTimestampMs(new ArrayBuffer(0))).toBe(42);
+
+    __setTestExifReader(null);
+    // Same input as the "tiny JPEG, no EXIF" case — the real parser
+    // must take over and yield null.
+    const buf = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]).buffer;
+    expect(await extractCaptureTimestampMs(buf)).toBeNull();
+  });
+});

--- a/src/domain/reading-verifier/exif.ts
+++ b/src/domain/reading-verifier/exif.ts
@@ -1,0 +1,114 @@
+// EXIF capture-timestamp extractor.
+//
+// We use the `exifr` lite ESM build (no GPS/XMP/IPTC/ICC/HEIC parsers)
+// because all we need is `DateTimeOriginal` (or, as a fallback,
+// `CreateDate`). The lite bundle is ~45 KB minified vs ~75 KB for the
+// full build — measurable savings on the Worker upload size budget.
+// Both fields live in the `exif` IFD which the lite build covers.
+//
+// Trust contract (see AGENTS.md): EXIF DateTimeOriginal is the
+// reference timestamp for verified readings, bounded against server
+// arrival time in the verifier. Reading the bytes server-side is
+// fine; the client never sends a literal timestamp claim. When EXIF
+// is missing the verifier falls back to server arrival time
+// (captured at handler entry, before body upload, to minimize
+// upload-latency phantom drift).
+//
+// Failure mode: this function MUST NOT throw. Corrupt EXIF, an image
+// format that exifr can't parse, an internal exifr blowup — all of
+// these are functionally identical to "no EXIF" from the verifier's
+// perspective: fall back to server arrival time. We log nothing on
+// failure because successful screenshots / privacy-stripped photos
+// are a normal user flow, not an error condition.
+
+import { parse as exifrParse } from "exifr/dist/lite.esm.mjs";
+
+/**
+ * Extract the camera-capture timestamp from a JPEG/PNG/HEIC byte
+ * buffer. Returns the EXIF DateTimeOriginal (or CreateDate fallback)
+ * as a millisecond unix timestamp, or null when the image carries no
+ * EXIF date metadata (screenshots, privacy-stripped photos).
+ *
+ * Never throws — corrupt EXIF, unsupported formats, or any parse
+ * error returns null and the caller falls back to server arrival
+ * time. We deliberately avoid leaking parser errors to the user;
+ * "couldn't read EXIF" is functionally identical to "no EXIF".
+ */
+export async function extractCaptureTimestampMs(
+  buffer: ArrayBuffer,
+): Promise<number | null> {
+  if (testReader) {
+    return testReader(buffer);
+  }
+  return defaultReader(buffer);
+}
+
+async function defaultReader(buffer: ArrayBuffer): Promise<number | null> {
+  // exifr accepts an empty buffer by returning undefined, but a
+  // non-empty buffer that isn't a recognized image throws. We catch
+  // both shapes so callers always see a clean null on failure.
+  if (buffer.byteLength === 0) {
+    return null;
+  }
+  let parsed: { DateTimeOriginal?: unknown; CreateDate?: unknown } | undefined;
+  try {
+    parsed = (await exifrParse(buffer, {
+      // Only ask for the two fields we use. Cuts work — exifr can
+      // skip whole IFDs / segments when we explicitly pick.
+      pick: ["DateTimeOriginal", "CreateDate"],
+    })) as typeof parsed;
+  } catch {
+    return null;
+  }
+  if (!parsed) {
+    return null;
+  }
+  // Prefer DateTimeOriginal — the moment the shutter fired. CreateDate
+  // is a fallback because some pipelines (HEIC, certain Android
+  // cameras) only populate one or the other.
+  const candidate = parsed.DateTimeOriginal ?? parsed.CreateDate;
+  return toMs(candidate);
+}
+
+// `exifr` returns a JS Date for revivable date fields when
+// `reviveValues: true` (the default). Defensive: we also tolerate a
+// numeric ms timestamp or an ISO string in case a future exifr
+// upgrade changes the surface.
+function toMs(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const ms = Date.parse(value);
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return null;
+}
+
+// --- Test override hook -------------------------------------------------
+//
+// Mirrors the `__setTestAiRunner` pattern in src/domain/ai-dial-reader/
+// runner.ts. The verifier's integration tests need a way to inject a
+// known timestamp without juggling real EXIF-bearing fixtures. The
+// override is module-level (fine — vitest-pool-workers gives us a
+// fresh worker per test file) and a `null` clears it. Keep this in
+// the same module as the function it overrides so a grep for
+// `__setTestExifReader` lands in one place.
+
+type ExifReader = (buffer: ArrayBuffer) => Promise<number | null>;
+
+let testReader: ExifReader | null = null;
+
+/**
+ * TEST-ONLY. Install a fake EXIF reader. Subsequent calls to
+ * `extractCaptureTimestampMs` route through `fn` until cleared.
+ * Pass `null` in a teardown hook to restore the real parser.
+ */
+export function __setTestExifReader(fn: ExifReader | null): void {
+  testReader = fn;
+}

--- a/src/domain/reading-verifier/exifr-lite.d.ts
+++ b/src/domain/reading-verifier/exifr-lite.d.ts
@@ -1,0 +1,28 @@
+// exifr ships its top-level types via `index.d.ts` but does not
+// declare types for the per-bundle entrypoints (`dist/lite.esm.mjs`,
+// `dist/full.esm.mjs`, `dist/mini.esm.mjs`). The lite build exposes
+// the same `parse(input, options)` shape as the top-level package —
+// minus the GPS / thumbnail / orientation helpers we don't use. We
+// declare a narrow shim here so the import in `./exif.ts` typechecks
+// against the surface we actually call.
+//
+// If a future exifr version reorganises its bundles, drop this file
+// and switch back to the top-level `import { parse } from "exifr"`
+// (with the bundle-size cost it incurs).
+
+declare module "exifr/dist/lite.esm.mjs" {
+  interface ParseOptions {
+    pick?: Array<string | number>;
+    skip?: Array<string | number>;
+    translateKeys?: boolean;
+    translateValues?: boolean;
+    reviveValues?: boolean;
+  }
+
+  type ParseInput = ArrayBuffer | SharedArrayBuffer | Uint8Array | DataView;
+
+  export function parse(
+    input: ParseInput,
+    options?: ParseOptions | string[] | true,
+  ): Promise<Record<string, unknown> | undefined>;
+}

--- a/src/domain/reading-verifier/verifier.test.ts
+++ b/src/domain/reading-verifier/verifier.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { computeVerifiedDeviation } from "./verifier";
+import { env } from "cloudflare:test";
+import { afterEach, beforeAll, describe, it, expect } from "vitest";
+import { __setTestAiRunner, type AiRunner } from "@/domain/ai-dial-reader/runner";
+import { __setTestExifReader } from "./exif";
+import { computeVerifiedDeviation, verifyReading } from "./verifier";
 
-// Unit tests for the MM:SS drift-computation helper. The broader
-// verifier pipeline (R2 upload, DB insert, AI call) is covered by
-// tests/integration/readings.verified.test.ts — this file is only
-// the minute-boundary math.
+// ---- Unit tests for the MM:SS drift-computation helper ------------
+//
+// The broader verifier pipeline is also exercised below (now that
+// EXIF parsing has joined the pipeline and is hard to cover purely
+// in integration tests) — but the math helper deserves its own block
+// because it's a pure function and the boundary cases are dense.
 //
 // Contract: the dial reader returns `{ minutes, seconds }` (0-59
 // each). The verifier wraps (dialMin*60 + dialSec) - (refMin*60 +
@@ -122,5 +127,301 @@ describe("computeVerifiedDeviation", () => {
         expect(result).toBeLessThanOrEqual(1800);
       }
     }
+  });
+});
+
+// ---- Pipeline tests for the EXIF-bound reference-timestamp logic --
+//
+// The verified-reading pipeline used to capture `Date.now()` *after*
+// awaiting `c.req.formData()` — on cellular with a 2 MB photo that's
+// 2-8 s of phantom drift baked into every reading. We now route the
+// reference timestamp through EXIF DateTimeOriginal (the moment the
+// shutter fired) bounded against server arrival time. EXIF outside
+// the bounds is rejected; missing EXIF falls back to server arrival.
+//
+// These tests stub both the AI runner (so we don't need a real model)
+// and the EXIF reader (so we don't need real EXIF-bearing fixtures)
+// and drive `verifyReading` directly. They use the real D1 / R2 from
+// vitest-pool-workers, but those are incidental — the contract under
+// test is "what reference timestamp ends up in the row, and which
+// telemetry events fire?".
+
+const VerifierEnv = env as unknown as {
+  DB: D1Database;
+  AI: Ai;
+  IMAGES: R2Bucket;
+  ANALYTICS: AnalyticsEngineDataset;
+};
+
+type DataPoint = AnalyticsEngineDataPoint;
+let captured: DataPoint[] = [];
+const originalWriteDataPoint = VerifierEnv.ANALYTICS.writeDataPoint.bind(
+  VerifierEnv.ANALYTICS,
+);
+
+function eventsOfKind(kind: string): DataPoint[] {
+  return captured.filter((dp) => Array.isArray(dp.indexes) && dp.indexes[0] === kind);
+}
+
+function payloadOf(dp: DataPoint): Record<string, unknown> {
+  return JSON.parse(dp.blobs![1] as string) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  // Seed a movement + watch row so the verifier's DB INSERT has a
+  // valid foreign key. Test rows live in a dedicated movement so we
+  // don't collide with the integration suite.
+  await VerifierEnv.DB.prepare(
+    "INSERT OR IGNORE INTO movements (id, canonical_name, manufacturer, caliber, type, status, submitted_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  )
+    .bind(
+      "verifier-unit-mvt",
+      "Verifier Unit Mvt",
+      "ETA",
+      "U-1",
+      "automatic",
+      "approved",
+      null,
+    )
+    .run();
+});
+
+afterEach(() => {
+  __setTestAiRunner(null);
+  __setTestExifReader(null);
+  captured = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (VerifierEnv.ANALYTICS as any).writeDataPoint = originalWriteDataPoint;
+});
+
+function startCapture(): void {
+  captured = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (VerifierEnv.ANALYTICS as any).writeDataPoint = (dp?: DataPoint) => {
+    if (dp) {
+      captured.push({ blobs: dp.blobs, indexes: dp.indexes, doubles: dp.doubles });
+    }
+    originalWriteDataPoint(dp);
+  };
+}
+
+async function ensureUser(prefix = "verifier"): Promise<string> {
+  const id = `${prefix}-${crypto.randomUUID()}`;
+  // The user table is required because watches.user_id has a FK.
+  // Better Auth normally creates the row; for these unit-style tests
+  // we insert directly. Using INSERT OR IGNORE keeps the test idempotent.
+  await VerifierEnv.DB.prepare(
+    "INSERT OR IGNORE INTO user (id, name, username, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  )
+    .bind(
+      id,
+      "Verifier Unit",
+      `verifier-${crypto.randomUUID().slice(0, 8)}`,
+      `${id}@ratedwatch.test`,
+      0,
+      new Date().toISOString(),
+      new Date().toISOString(),
+    )
+    .run();
+  return id;
+}
+
+async function ensureWatch(userId: string): Promise<string> {
+  const id = `wch-${crypto.randomUUID()}`;
+  await VerifierEnv.DB.prepare(
+    "INSERT INTO watches (id, user_id, name, movement_id, is_public) VALUES (?, ?, ?, ?, ?)",
+  )
+    .bind(id, userId, "Verifier Unit Watch", "verifier-unit-mvt", 1)
+    .run();
+  return id;
+}
+
+function installFakeAi(response: string): void {
+  const runner: AiRunner = async () => ({ response });
+  __setTestAiRunner(runner);
+}
+
+function tinyJpegBuffer(): ArrayBuffer {
+  return new Uint8Array([0xff, 0xd8, 0xff, 0xd9]).buffer;
+}
+
+const SERVER_ARRIVAL = Date.UTC(2024, 0, 15, 14, 32, 5);
+
+describe("verifyReading — EXIF reference timestamp", () => {
+  it("uses EXIF DateTimeOriginal as the reference when within bounds", async () => {
+    // Case A: EXIF is 30 s old (well within the 5-minute window).
+    // Reference must be the EXIF value, not the server-arrival time
+    // we passed in.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    const exifMs = SERVER_ARRIVAL - 30_000;
+    __setTestExifReader(async () => exifMs);
+    // AI returns "32:07" (matches the EXIF clock's MM:SS = 31:35).
+    // But the deviation only depends on the dial vs the reference,
+    // so feed the AI a value 2s ahead of the EXIF MM:SS.
+    const exifMmSs = new Date(exifMs);
+    installFakeAi(`${exifMmSs.getUTCMinutes()}:${exifMmSs.getUTCSeconds() + 2}`);
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reading.reference_timestamp).toBe(exifMs);
+    expect(result.reading.deviation_seconds).toBe(2);
+
+    const okEvents = eventsOfKind("verified_reading_exif_ok");
+    expect(okEvents).toHaveLength(1);
+    expect(payloadOf(okEvents[0]!)).toMatchObject({
+      userId,
+      watchId,
+      delta_ms: -30_000,
+    });
+  });
+
+  it("accepts EXIF exactly at the lower bound (-5 min)", async () => {
+    // Case B: boundary is inclusive on accept side.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    const exifMs = SERVER_ARRIVAL - 5 * 60 * 1000;
+    __setTestExifReader(async () => exifMs);
+    installFakeAi("0:0");
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reading.reference_timestamp).toBe(exifMs);
+    expect(eventsOfKind("verified_reading_exif_ok")).toHaveLength(1);
+  });
+
+  it("rejects EXIF older than the lower bound (>5 min in the past)", async () => {
+    // Case C: 5 min + 1 ms older — out.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    const exifMs = SERVER_ARRIVAL - 5 * 60 * 1000 - 1;
+    __setTestExifReader(async () => exifMs);
+    installFakeAi("0:0");
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("exif_clock_skew");
+    // raw_response should describe the direction of the skew —
+    // "too old" is the user-actionable hint that the phone clock is
+    // behind the server.
+    expect(result.raw_response).toMatch(/too old/i);
+
+    const skewEvents = eventsOfKind("verified_reading_exif_clock_skew");
+    expect(skewEvents).toHaveLength(1);
+    expect(payloadOf(skewEvents[0]!)).toMatchObject({
+      userId,
+      watchId,
+      delta_ms: -(5 * 60 * 1000 + 1),
+    });
+  });
+
+  it("rejects EXIF in the future beyond bounds (>1 min ahead)", async () => {
+    // Case D: 1 min + 1 ms ahead — out.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    const exifMs = SERVER_ARRIVAL + 1 * 60 * 1000 + 1;
+    __setTestExifReader(async () => exifMs);
+    installFakeAi("0:0");
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("exif_clock_skew");
+    expect(result.raw_response).toMatch(/future/i);
+  });
+
+  it("accepts EXIF in the future within bounds (+30 s)", async () => {
+    // Case E: 30 s ahead is fine — small clock drift is normal.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    const exifMs = SERVER_ARRIVAL + 30_000;
+    __setTestExifReader(async () => exifMs);
+    installFakeAi("0:0");
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reading.reference_timestamp).toBe(exifMs);
+    const okEvents = eventsOfKind("verified_reading_exif_ok");
+    expect(okEvents).toHaveLength(1);
+    expect(payloadOf(okEvents[0]!)).toMatchObject({ delta_ms: 30_000 });
+  });
+
+  it("falls back to server arrival when EXIF is missing", async () => {
+    // Case F: no EXIF (screenshots, privacy-stripped photos). The
+    // verifier creates the reading using server arrival — never
+    // rejects.
+    const userId = await ensureUser();
+    const watchId = await ensureWatch(userId);
+    __setTestExifReader(async () => null);
+    installFakeAi("0:0");
+    startCapture();
+
+    const result = await verifyReading({
+      watchId,
+      userId,
+      imageBuffer: tinyJpegBuffer(),
+      isBaseline: false,
+      serverArrivalMs: SERVER_ARRIVAL,
+      env: VerifierEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reading.reference_timestamp).toBe(SERVER_ARRIVAL);
+
+    const missingEvents = eventsOfKind("verified_reading_exif_missing");
+    expect(missingEvents).toHaveLength(1);
+    expect(payloadOf(missingEvents[0]!)).toMatchObject({ userId, watchId });
+    // No exif_ok event in this case.
+    expect(eventsOfKind("verified_reading_exif_ok")).toHaveLength(0);
   });
 });

--- a/src/domain/reading-verifier/verifier.ts
+++ b/src/domain/reading-verifier/verifier.ts
@@ -1,10 +1,24 @@
 // Reading verifier — orchestrates the verified-reading pipeline.
 //
-// Pipeline (matches slice #16 / issue #17 spec):
+// Pipeline (matches slice #16 / issue #17 spec, with the EXIF
+// reference-timestamp change layered on top):
 //
-//   1. Capture server-side reference timestamp (`Date.now()`). This
-//      is the canonical source of truth — client / EXIF timestamps
-//      are NEVER trusted for competitive scoring.
+//   1. Reference timestamp resolution.
+//      We try to read EXIF DateTimeOriginal (the moment the shutter
+//      fired) from the image bytes. When present and within the
+//      bounds window vs server arrival time, that's the reference.
+//      When missing, we fall back to server arrival time (captured
+//      at handler entry, BEFORE the formData await — see the route).
+//      When present but outside bounds, the request is rejected.
+//
+//      Why we changed: the previous implementation captured
+//      `Date.now()` AFTER awaiting the multipart body. On cellular
+//      with a 2 MB photo that's 2-8 s of phantom drift baked into
+//      every reading. EXIF DateTimeOriginal is the moment the
+//      shutter fired and is upload-latency-immune. The trust
+//      trade-off (an attacker with control over their phone clock
+//      can fake deviations within the bounds window) is documented
+//      in AGENTS.md.
 //   2. Run the image through the AI dial reader. The reader returns
 //      the minute + second hand positions (0-59 each) — only the
 //      hour is inferred from the reference clock.
@@ -34,20 +48,36 @@
 import { createDb } from "@/db";
 import { readDialTime, type DialReaderError } from "@/domain/ai-dial-reader/reader";
 import type { Reading } from "@/domain/drift-calc";
+import { logEvent, type EventLoggerEnv } from "@/observability/events";
+import { extractCaptureTimestampMs } from "./exif";
 
 export interface VerifyReadingInput {
   watchId: string;
   userId: string;
   imageBuffer: ArrayBuffer;
   isBaseline: boolean;
+  /**
+   * The wall-clock millisecond timestamp captured at route handler
+   * entry, BEFORE awaiting the multipart body. Used as the fallback
+   * reference when EXIF is missing, and as the bounds anchor when
+   * EXIF is present. Capturing this in the route — not here —
+   * sidesteps the upload-latency phantom drift bug (#TBD): a
+   * `Date.now()` inside this function would have included the
+   * formData parse time on cellular.
+   */
+  serverArrivalMs: number;
   env: {
     AI: Ai;
     DB: D1Database;
     IMAGES: R2Bucket;
-  };
+  } & EventLoggerEnv;
 }
 
-export type VerifyReadingErrorCode = "ai_refused" | "ai_unparseable" | "ai_implausible";
+export type VerifyReadingErrorCode =
+  | "ai_refused"
+  | "ai_unparseable"
+  | "ai_implausible"
+  | "exif_clock_skew";
 
 export type VerifyReadingResult =
   | {
@@ -86,6 +116,27 @@ export interface VerifiedReadingRow {
 // never triggers.
 const SECONDS_PER_HOUR = 3600;
 const HALF_HOUR_SECONDS = 1800;
+
+// EXIF clock-skew bounds.
+//
+// We accept EXIF DateTimeOriginal as the reference timestamp when it
+// is within `[server - 5 min, server + 1 min]`. The asymmetric window
+// reflects how phones drift in practice:
+//
+//   * The 5-minute past tolerance covers the realistic upload-delay
+//     band (cellular, retries, queued uploads on poor connectivity)
+//     plus a small phone-clock-behind-server allowance.
+//   * The 1-minute future tolerance covers small clock skew from
+//     phones whose NTP-synced clock is marginally ahead of the
+//     server. We don't allow much because EXIF "in the future"
+//     beyond a minute is almost always a sign of a misset clock or
+//     a deliberate spoof attempt.
+//
+// The bounds are inclusive on accept side: `delta == -5min` and
+// `delta == +1min` both pass. A delta of `-5min - 1ms` or
+// `+1min + 1ms` is rejected.
+const EXIF_MAX_AGE_MS = 5 * 60 * 1000;
+const EXIF_MAX_FUTURE_MS = 1 * 60 * 1000;
 
 /**
  * Exported for tests. Computes the signed drift in seconds between
@@ -138,12 +189,45 @@ export function computeVerifiedDeviation(
 export async function verifyReading(
   input: VerifyReadingInput,
 ): Promise<VerifyReadingResult> {
-  const { watchId, userId, imageBuffer, isBaseline, env } = input;
+  const { watchId, userId, imageBuffer, isBaseline, serverArrivalMs, env } = input;
 
-  // 1. Server-side reference timestamp. Captured BEFORE any I/O so
-  //    all the rest of the pipeline (AI call, DB insert) adds drift
-  //    that the user cannot influence.
-  const referenceTimestamp = Date.now();
+  // 1. Resolve the reference timestamp. EXIF preferred (upload-latency
+  //    immune), bounded against server clock; server arrival is the
+  //    fallback when EXIF is missing.
+  const exifMs = await extractCaptureTimestampMs(imageBuffer);
+  let referenceTimestamp: number;
+  if (exifMs === null) {
+    referenceTimestamp = serverArrivalMs;
+    await logEvent("verified_reading_exif_missing", { userId, watchId }, env);
+  } else {
+    const delta = exifMs - serverArrivalMs;
+    if (delta < -EXIF_MAX_AGE_MS) {
+      await logEvent(
+        "verified_reading_exif_clock_skew",
+        { userId, watchId, delta_ms: delta },
+        env,
+      );
+      return {
+        ok: false,
+        error: "exif_clock_skew",
+        raw_response: `EXIF too old: ${delta}ms`,
+      };
+    }
+    if (delta > EXIF_MAX_FUTURE_MS) {
+      await logEvent(
+        "verified_reading_exif_clock_skew",
+        { userId, watchId, delta_ms: delta },
+        env,
+      );
+      return {
+        ok: false,
+        error: "exif_clock_skew",
+        raw_response: `EXIF in future: +${delta}ms`,
+      };
+    }
+    referenceTimestamp = exifMs;
+    await logEvent("verified_reading_exif_ok", { userId, watchId, delta_ms: delta }, env);
+  }
 
   // 2. AI dial read.
   const image = new Uint8Array(imageBuffer);

--- a/src/observability/events.ts
+++ b/src/observability/events.ts
@@ -24,6 +24,16 @@ export type EventKind =
   | "verified_reading_attempted"
   | "verified_reading_succeeded"
   | "verified_reading_failed"
+  // EXIF-reference telemetry. The verified-reading pipeline now uses
+  // EXIF DateTimeOriginal as the reference timestamp (see
+  // src/domain/reading-verifier/verifier.ts). These three events let
+  // us monitor the rollout: how often EXIF is present (`_exif_ok`),
+  // missing (`_exif_missing`), or out-of-bounds (`_exif_clock_skew`,
+  // which causes a 422). Watching `_exif_clock_skew` is the early
+  // signal for users with bad phone clocks vs spoof attempts.
+  | "verified_reading_exif_ok"
+  | "verified_reading_exif_missing"
+  | "verified_reading_exif_clock_skew"
   | "movement_suggested"
   | "chrono24_click"
   | "leaderboard_filter_changed"

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -386,6 +386,16 @@ readingsByWatchRoute.post("/tap", async (c) => {
  * raw AI response for debugging.
  */
 readingsByWatchRoute.post("/verified", async (c) => {
+  // Capture the wall-clock at handler entry, BEFORE any await. This
+  // is the fallback reference timestamp the verifier uses when EXIF
+  // is missing and the bounds anchor when EXIF is present. Capturing
+  // here — rather than inside `verifyReading` after `formData()` has
+  // resolved — sidesteps the upload-latency phantom drift that
+  // motivated this slice: a 2 MB photo on cellular bakes 2-8 s of
+  // body-parse delay into a `Date.now()` placed any later in the
+  // handler.
+  const serverArrivalMs = Date.now();
+
   const user = c.get("user");
   const watchId = getWatchIdParam(c);
   if (!watchId) return c.json({ error: "not_found" }, 404);
@@ -444,6 +454,7 @@ readingsByWatchRoute.post("/verified", async (c) => {
     userId: user.id,
     imageBuffer,
     isBaseline,
+    serverArrivalMs,
     env: c.env,
   });
 

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -14,6 +14,7 @@ import { env } from "cloudflare:test";
 import { exports } from "cloudflare:workers";
 import { afterEach, beforeAll, describe, it, expect, vi } from "vitest";
 import { __setTestAiRunner, type AiRunner } from "@/domain/ai-dial-reader/runner";
+import { __setTestExifReader } from "@/domain/reading-verifier/exif";
 
 // ---- Fixture ------------------------------------------------------
 
@@ -39,6 +40,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   __setTestAiRunner(null);
+  __setTestExifReader(null);
   vi.useRealTimers();
 });
 
@@ -346,5 +348,32 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     // short-circuits before the handler runs.
     const res = await postVerifiedReading("whatever", undefined);
     expect(res.status).toBe(401);
+  });
+
+  it("rejects EXIF outside the bounds window with 422 exif_clock_skew", async () => {
+    // End-to-end check that the EXIF clock-skew gate fires through
+    // the HTTP layer. We freeze the server clock so the bound
+    // calculation is deterministic, then install an EXIF reader that
+    // returns a timestamp 10 minutes in the past — well outside the
+    // 5-minute past tolerance.
+    const user = await registerAndGetCookie();
+    await setVerifiedFlagForUser(user.userId);
+    const { id: watchId } = await createWatch(
+      { name: "EXIFOOB", movement_id: movementId },
+      user.cookie,
+    );
+
+    const refTime = Date.UTC(2024, 0, 15, 14, 32, 5);
+    vi.useFakeTimers();
+    vi.setSystemTime(refTime);
+    __setTestExifReader(async () => refTime - 10 * 60 * 1000);
+    // AI fake is irrelevant — the EXIF gate fires before the AI call.
+    installFakeAi("0:0");
+
+    const res = await postVerifiedReading(watchId, user.cookie);
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; raw_response?: string };
+    expect(body.error).toBe("exif_clock_skew");
+    expect(body.raw_response).toMatch(/too old/i);
   });
 });


### PR DESCRIPTION
## Bug being fixed

Cellular uploads of 1-3 MB photos take 2-8 seconds. The verifier was capturing `Date.now()` **after** awaiting `c.req.formData()`, which baked the entire upload duration into every verified reading as phantom drift. For a product measuring ±2 s/d, that was noise larger than the signal.

## Trust model change

**Old AGENTS.md rule**: "No trusting client-supplied EXIF / client timestamps. Server receipt time is the source of truth."

**New rule** (updated in this PR): EXIF `DateTimeOriginal` is accepted as the reference timestamp, bounded against server arrival time (±5 min / +1 min). Falls back to server arrival time when EXIF is absent. The trade-off: an attacker with phone-clock control can fake deviations within the bounds window. Accepted for now; spoof-resistance (camera attestation, etc.) is a future iteration.

## What changed

- `src/domain/reading-verifier/exif.ts` — new module. `extractCaptureTimestampMs(buffer)` reads EXIF DateTimeOriginal (or CreateDate fallback). Returns `null` on missing/corrupt EXIF — never throws. Includes `__setTestExifReader(fn)` so tests can stub without real EXIF fixtures.
- `src/domain/reading-verifier/exifr-lite.d.ts` — local type declarations for the lite `exifr` entrypoint (saves bundle vs the full one).
- `src/domain/reading-verifier/verifier.ts` — `verifyReading` now takes `serverArrivalMs` from the caller. Decision tree: EXIF in bounds → use EXIF; EXIF out of bounds → reject with `exif_clock_skew`; EXIF missing → fall back to `serverArrivalMs`. Bounds constants `EXIF_MAX_AGE_MS = 5 * 60 * 1000` and `EXIF_MAX_FUTURE_MS = 60 * 1000`.
- `src/server/routes/readings.ts` — `/verified` POST handler captures `Date.now()` at the **top of the handler**, before `await c.req.formData()`. Passes it to `verifyReading` as `serverArrivalMs`. Critically, this also fixes the upload-latency issue for the EXIF-missing fallback path.
- `src/observability/events.ts` — three new event names: `verified_reading_exif_ok` (with `delta_ms`), `verified_reading_exif_missing`, `verified_reading_exif_clock_skew` (with `delta_ms`). Emitted from the verifier.
- `src/app/watches/verifiedReadingErrors.ts` — maps the new `exif_clock_skew` server error to a user-facing "Your phone's clock seems to be off" hint with a "fix and retake" call-to-action.
- `AGENTS.md` — Ubiquitous-language entry for "Verified reading" and the "Things NOT to do" rule both updated to reflect the new contract.

## Tests

- 6 new in `src/domain/reading-verifier/verifier.test.ts` covering: in-bounds, lower-bound boundary, too-old reject, future-skew reject, future in-bounds accept, EXIF-missing fallback.
- 80-line new `src/domain/reading-verifier/exif.test.ts` covering the extractor module + test override hook.
- 1 new in `tests/integration/readings.verified.test.ts` exercising the end-to-end 422 + `exif_clock_skew` HTTP path.
- 1 new in `src/app/watches/verifiedReadingErrors.test.ts` for the SPA mapper case.

**Total**: 48 test files / 458 tests passing (was 46 / 440 on main).

## Bundle-size impact

`exifr` adds ~1.4 MB to `node_modules` but the lite entrypoint is tree-shakable. The Worker build ships `dist/assets/index-*.js` at 352 KB (gzipped 106 KB) — within the 1 MB Workers limit and unchanged in size relative to the previous slice's 360 KB (the lite entrypoint dead-code-eliminates the formats we don't read). Net neutral.

## Operator note

No new bindings, no new secrets. Deploy as normal — the next verified reading from a phone whose clock is correct will use EXIF DateTimeOriginal, and Analytics Engine will start emitting `verified_reading_exif_ok` events with `delta_ms` so we can see the real-world clock-skew distribution.

Refs feat/exif-reference-timestamp