### PR TITLE
Slice 6: hand angles + composite confidence + smoke corpus passing (#79)

### DIFF
--- a/container/dial-reader/src/dial_reader/confidence_scorer.py
+++ b/container/dial-reader/src/dial_reader/confidence_scorer.py
@@ -66,7 +66,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-
 # Public, immutable weights. Operators reading the code can
 # verify exactly what each component contributes to the final
 # score by reading these constants. Sum to 1.0 by construction

--- a/container/dial-reader/src/dial_reader/confidence_scorer.py
+++ b/container/dial-reader/src/dial_reader/confidence_scorer.py
@@ -1,0 +1,180 @@
+"""Composite confidence score from CV sub-signals.
+
+The verifier (`src/domain/reading-verifier/verifier.ts`) gates a
+verified-reading attempt on `confidence >= 0.7`. The scorer here
+collapses 5 sub-signals from the pipeline into that single value:
+
+  - `circle_quality`            HoughCircles fit quality, 0-1 from
+                                the locator stage.
+  - `hand_count`                ideally 3; anything else is an
+                                upstream rejection signal but
+                                we encode it here so the scorer
+                                is also internally consistent.
+  - `classification_consistency`  0-1, comes from `hand_geometry`
+                                heuristic — agreement of length
+                                + width ratios with canonical
+                                3-hand geometry.
+  - `line_residuals`            (h, m, s) RMS perpendicular
+                                distances from each hand's PCA
+                                line fit. Smaller = the hand
+                                was line-shaped (good); a noisy
+                                detection produces a fat blob
+                                with large residual.
+  - `time_consistency`          0-1, agreement of hour-hand
+                                position with minute-hand
+                                position. At minute=56 the hour
+                                hand should be at h+0.93. A
+                                mismatch > 0.15 hour-step triggers
+                                a multiplicative penalty (× 0.3
+                                on the final score) — this is the
+                                strongest CV-readability sanity
+                                check, since it catches dials
+                                where the hand classifier
+                                mislabelled hour vs minute.
+
+Weights
+=======
+Picked so the dominant signal is time_consistency (the readability
+sanity check) but the other 4 cumulatively provide enough lift
+that a clean detection always lands above the 0.7 threshold:
+
+    circle_quality:           0.15
+    hand_count == 3:          0.15
+    classification_consistency: 0.20
+    line_residuals (averaged):  0.20
+    time_consistency:         0.30
+                              ----
+                              1.00
+
+The weights are tunable via the public dataclass constants below;
+do NOT change them in tests via monkeypatch — the test grid
+parameter values assume the published weights.
+
+Penalty
+=======
+When `time_consistency < 0.4` (i.e. the hour/minute mismatch is
+> 0.15 hour-step), multiply the final score by 0.3. This is more
+aggressive than a continuous gradient because the failure mode
+is binary: either the hour-hand is plausibly placed for the
+minute reading (the pipeline read the dial correctly) or it
+isn't (something is off, and we should refuse to publish the
+reading rather than report it with a moderate confidence).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+# Public, immutable weights. Operators reading the code can
+# verify exactly what each component contributes to the final
+# score by reading these constants. Sum to 1.0 by construction
+# so a perfect-signal input produces a 1.0 score.
+_W_CIRCLE_QUALITY: Final[float] = 0.15
+_W_HAND_COUNT: Final[float] = 0.15
+_W_CLASSIFICATION: Final[float] = 0.20
+_W_LINE_RESIDUAL: Final[float] = 0.20
+_W_TIME_CONSISTENCY: Final[float] = 0.30
+
+# Time-consistency penalty. When the time_consistency signal
+# falls below this threshold, multiply the final score by
+# `_TIME_CONSISTENCY_PENALTY`. 0.4 maps to a 0.15 hour-step
+# error using the linear `1 - error/0.25` mapping in
+# `dial_reader.compute_time_consistency`.
+_TIME_CONSISTENCY_PENALTY_THRESHOLD: Final[float] = 0.4
+_TIME_CONSISTENCY_PENALTY: Final[float] = 0.3
+
+# Pixel scale for the line-residual normalisation. A perfect
+# straight line gives residual 0; we map residual `r` to signal
+# `1 - clamp(r / _RESIDUAL_FULL_SCALE_PX, 0, 1)`. 10 pixels of
+# RMS deviation effectively zeroes out the signal — that's a
+# very fat blob, well past anything the synthetic generator
+# produces (residuals on synthetic dials are < 1 px).
+_RESIDUAL_FULL_SCALE_PX: Final[float] = 10.0
+
+
+@dataclass(frozen=True)
+class ConfidenceSignals:
+    """The 5 sub-signals fed into `score`.
+
+    Attributes:
+        circle_quality: 0-1. From the locator. Today derived from
+            `interior_std_ratio` in `dial_locator`; clamped at the
+            scorer boundary.
+        hand_count: integer count of hands the detector returned.
+            3 is the ideal; anything else gets a heavy penalty.
+        classification_consistency: 0-1. Agreement of the hour /
+            minute / second contour geometry with canonical
+            ratios (thinnest = second, widest = hour, etc.).
+        line_residuals: (hour, minute, second) RMS perpendicular
+            pixel distances from the per-hand PCA line fit. The
+            scorer takes the mean of the three.
+        time_consistency: 0-1. Cross-check between the hour-hand
+            position and the minute-hand position; see the
+            module docstring.
+    """
+
+    circle_quality: float
+    hand_count: int
+    classification_consistency: float
+    line_residuals: tuple[float, float, float]
+    time_consistency: float
+
+
+def _clamp01(x: float) -> float:
+    """Clamp `x` into [0, 1]. Defensive against caller signals that
+    happen to fall outside the contract; the scorer should NEVER
+    produce a final value outside [0, 1] regardless of inputs."""
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+def _residual_signal(residuals: tuple[float, float, float]) -> float:
+    """Map per-hand RMS residuals → a single 0-1 signal.
+
+    For each residual, signal = 1 - clamp(r / FULL_SCALE, 0, 1).
+    Take the unweighted average across the 3 hands. Negative
+    residuals are clamped to 0 (residual is by definition
+    non-negative; defensive).
+    """
+    parts = []
+    for r in residuals:
+        if r < 0.0:
+            r = 0.0
+        # `r / scale` clamped at 1, inverted to give "1 = no error".
+        contribution = 1.0 - min(1.0, r / _RESIDUAL_FULL_SCALE_PX)
+        parts.append(contribution)
+    if not parts:
+        return 0.0
+    return sum(parts) / len(parts)
+
+
+def score(signals: ConfidenceSignals) -> float:
+    """Composite 0-1 confidence score from the 5 sub-signals.
+
+    See module docstring for the weighting + penalty rationale.
+    Output is always in [0, 1]; defensive clamping is applied on
+    every sub-signal.
+    """
+    circle = _clamp01(signals.circle_quality)
+    classification = _clamp01(signals.classification_consistency)
+    time_ok = _clamp01(signals.time_consistency)
+    residual = _residual_signal(signals.line_residuals)
+    hand = 1.0 if signals.hand_count == 3 else 0.0
+
+    raw = (
+        _W_CIRCLE_QUALITY * circle
+        + _W_HAND_COUNT * hand
+        + _W_CLASSIFICATION * classification
+        + _W_LINE_RESIDUAL * residual
+        + _W_TIME_CONSISTENCY * time_ok
+    )
+
+    if signals.time_consistency < _TIME_CONSISTENCY_PENALTY_THRESHOLD:
+        raw *= _TIME_CONSISTENCY_PENALTY
+
+    return _clamp01(raw)

--- a/container/dial-reader/src/dial_reader/dial_reader.py
+++ b/container/dial-reader/src/dial_reader/dial_reader.py
@@ -1,0 +1,353 @@
+"""Top-level dial-reader orchestrator.
+
+Stitches together the CV pipeline:
+
+  1. `image_decoder.decode`  — bytes → RGB ndarray
+  2. `dial_locator.locate`   — locate the dial circle
+  3. `hand_geometry.detect_hand_contours` + `classify_hands`
+                              — detect + classify the 3 hands
+  4. `hand_geometry.compute_hand_angles` — sub-pixel-refined
+                              clockwise-from-north angles
+  5. `time_translator.to_mmss`  — angles → (minute, second)
+  6. Hour computation        — (minute, hour-hand-angle) → hour
+                              0-11 with cross-hand correction
+  7. `confidence_scorer.score`  — composite 0-1 confidence
+
+The orchestrator is the single source of truth for the success
+shape returned to the HTTP layer. Each call returns a
+`DialReadResult` discriminated union over the three outcomes the
+HTTP handler needs to handle:
+
+  - kind=="success"          → 200, ok:true, populated result
+  - kind=="rejection"        → 200, ok:false, structured rejection
+                              (no_dial_found, unsupported_dial,
+                              low_confidence)
+  - kind=="malformed_image"  → 400, error:"malformed_image"
+  - kind=="unsupported_format" → 200, ok:false, structured
+                              rejection (unsupported_format)
+
+This is the layer that hosts the cross-hand corrections. The two
+non-trivial ones:
+
+Minute correction
+=================
+A smooth-sweep minute hand at minute=N rotates an extra
+(seconds/60)*6° beyond N*6°. Naively translating the minute-hand
+angle via `to_mmss` rounds up at the boundary: e.g. minute=35
+seconds=50 puts the minute hand at 215° (= 35*6 + 50/60*6 = 215),
+which `to_mmss(215, _)` reports as 36 not 35. We correct by
+subtracting `seconds/60` from the minute-hand-derived minute
+estimate before rounding. The seconds value comes from the
+already-translated second-hand reading.
+
+Hour computation
+================
+The hour-hand position carries (hours + minutes/60) of rotation
+information. Given the minute reading, we can solve back for the
+integer hour:
+    hour = round((hour_deg / 30 - minute / 60)) % 12
+with a tie-break that, if the implied real-valued hour is e.g.
+11.95 and the minute is 5 (a 360° wrap), we pick 0 not 11.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from dial_reader.confidence_scorer import ConfidenceSignals, score
+from dial_reader.dial_locator import DialCircle, locate
+from dial_reader.hand_geometry import (
+    HandAngles,
+    classify_hands,
+    compute_hand_angles,
+    detect_hand_contours,
+    fit_hand_lines,
+)
+from dial_reader.image_decoder import (
+    MalformedImageError,
+    UnsupportedFormatError,
+    decode,
+)
+from dial_reader.time_translator import to_mmss
+
+
+# ---------------------------------------------------------------
+# Result types.
+# ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DisplayedTime:
+    """The (h, m, s) the dial is showing. h is in [0, 11]."""
+
+    h: int
+    m: int
+    s: int
+
+
+@dataclass(frozen=True)
+class DialReadResult:
+    """Discriminated union over the orchestrator's outcomes.
+
+    Inspect `kind` first; each kind populates a different subset
+    of the optional fields. The HTTP layer consumes this directly
+    to produce the JSON response.
+    """
+
+    kind: Literal[
+        "success",
+        "rejection",
+        "malformed_image",
+        "unsupported_format",
+    ]
+    displayed_time: Optional[DisplayedTime] = None
+    confidence: float = 0.0
+    rejection_reason: Optional[str] = None
+    rejection_details: Optional[str] = None
+    dial_detection: Optional[DialCircle] = None
+    hand_angles: Optional[HandAngles] = None
+    # Internal sub-signals for observability — surfaced on the
+    # log line so the operator can investigate borderline-confident
+    # rejections without re-running the pipeline.
+    confidence_signals: Optional[ConfidenceSignals] = None
+
+
+# ---------------------------------------------------------------
+# Public threshold + helpers.
+# ---------------------------------------------------------------
+
+# Confidence below which the orchestrator rejects with
+# `low_confidence` rather than emitting a success. This MUST stay
+# in sync with `DIAL_READER_CONFIDENCE_THRESHOLD` in
+# `src/domain/reading-verifier/verifier.ts` — but the verifier
+# does its own check after parsing the success body, so the
+# value below is the container's internal-rejection threshold,
+# kept slightly *under* the verifier's value so a borderline
+# success isn't double-rejected with two different reasons.
+LOW_CONFIDENCE_THRESHOLD: float = 0.7
+
+
+def _circle_quality_signal(_dial: DialCircle) -> float:
+    """Heuristic circle-quality signal in [0, 1].
+
+    The HoughCircles accumulator score isn't surfaced through the
+    locator's public API — `dial_locator.locate` returns just the
+    `DialCircle`. For now we treat a present `DialCircle` as
+    high-quality (1.0); when the locator surfaces accumulator
+    scores in a later slice we'll plumb it through here.
+
+    Returning a constant doesn't undermine the scorer because the
+    other 4 signals carry enough information to discriminate
+    pass/fail; it's effectively a "we got past the locator"
+    floor.
+    """
+    return 1.0
+
+
+def _classification_consistency_signal(
+    hands_thicknesses: tuple[float, float, float],
+    hands_lengths: tuple[float, float, float],
+) -> float:
+    """How well the (hour, minute, second) thickness + length
+    ordering matches the canonical 3-hander pattern.
+
+    Canonical:
+        hour:   thickest, shortest
+        minute: medium-thick, longest (or close to it)
+        second: thinnest
+
+    Encoded as a 0-1 score that's 1.0 when the orderings hold
+    perfectly and decays as they break.
+    """
+    h_thick, m_thick, s_thick = hands_thicknesses
+    h_len, m_len, s_len = hands_lengths
+
+    score_v = 1.0
+    # second hand should be thinnest
+    if s_thick > m_thick:
+        score_v *= 0.5
+    if s_thick > h_thick:
+        score_v *= 0.5
+    # hour hand should be at least as thick as minute
+    if h_thick < m_thick:
+        score_v *= 0.5
+    # hour hand should be the shortest of the three
+    if h_len > m_len:
+        score_v *= 0.7
+    if h_len > s_len:
+        score_v *= 0.7
+    return score_v
+
+
+def _compute_hour_and_consistency(
+    hour_deg: float,
+    minute: int,
+    second: int,
+) -> tuple[int, float]:
+    """Given the hour-hand angle and the (already corrected) minute
+    + second, derive the integer hour 0-11 and a 0-1 consistency
+    signal.
+
+    Real-valued hour position implied by the hour hand:
+        hour_real = hour_deg / 30  ∈ [0, 12)
+
+    Real-valued hour position implied by the minute reading:
+        hour_implied = (minute + second/60) / 60 ∈ [0, 1)
+
+    The hour hand should sit at `H + hour_implied` for integer H.
+    We solve:
+        H_continuous = hour_real - hour_implied   (mod 12)
+        H_int = round(H_continuous) % 12
+        error = |H_continuous - H_int|            (mod 12, take min wrap)
+
+    consistency = max(0, 1 - error / 0.25):
+        - error 0  → 1.0
+        - error 0.25 hour-step → 0
+        - linearly between
+
+    The 0.25 ceiling is loose enough to absorb real-watch wear
+    (hour hands drift up to ~5 minutes off true position over
+    months) while still firing on the obviously-misclassified
+    cases (hour and minute swapped, etc.).
+    """
+    hour_real = hour_deg / 30.0  # in [0, 12)
+    hour_implied = (minute + second / 60.0) / 60.0  # in [0, 1)
+    h_continuous = (hour_real - hour_implied) % 12.0
+    h_int = int(round(h_continuous)) % 12
+
+    # Wrap-aware error: smaller of |delta| and 12 - |delta|.
+    raw_error = abs(h_continuous - h_int)
+    error = min(raw_error, 12.0 - raw_error)
+    consistency = max(0.0, 1.0 - error / 0.25)
+    return h_int, consistency
+
+
+def _compute_minute_with_correction(minute_deg: float, second: int) -> int:
+    """Smooth-sweep correction: subtract the partial-minute the
+    second hand contributes to the minute-hand position before
+    rounding.
+
+    Naive `to_mmss(minute_deg, _)[0]` rounds the minute up when
+    the seconds are large enough to push the minute hand past
+    the integer-tick boundary. By backing out `second/60` of a
+    minute-step from the angle before rounding, we recover the
+    true integer minute.
+    """
+    # Each minute corresponds to 6° of rotation; subtract the
+    # partial-minute contribution attributable to the second
+    # hand. The (now corrected) angle / 6 is the integer minute.
+    corrected_deg = (minute_deg - (second / 60.0) * 6.0) % 360.0
+    minute = int(round(corrected_deg / 6.0)) % 60
+    return minute
+
+
+# ---------------------------------------------------------------
+# The orchestrator.
+# ---------------------------------------------------------------
+
+
+def read_dial(image_bytes: bytes) -> DialReadResult:
+    """Run the full CV pipeline against `image_bytes`.
+
+    Returns a `DialReadResult` whose `kind` field identifies the
+    outcome. The HTTP layer consumes the result directly and
+    translates it into the appropriate JSON response.
+    """
+    # ---- Stage 1: decode ---------------------------------------
+    try:
+        img = decode(image_bytes)
+    except UnsupportedFormatError as e:
+        return DialReadResult(
+            kind="unsupported_format",
+            rejection_reason="unsupported_format",
+            rejection_details=str(e),
+        )
+    except MalformedImageError as e:
+        return DialReadResult(
+            kind="malformed_image",
+            rejection_reason="malformed_image",
+            rejection_details=str(e),
+        )
+
+    # ---- Stage 2: locate dial ----------------------------------
+    circle = locate(img)
+    if circle is None:
+        return DialReadResult(
+            kind="rejection",
+            rejection_reason="no_dial_found",
+            rejection_details=(
+                "No watch dial detected. Frame the dial centered and well-lit, then try again."
+            ),
+        )
+
+    # ---- Stage 3: detect + classify hands ----------------------
+    contours = detect_hand_contours(img, circle)
+    hands = classify_hands(contours)
+    if hands is None:
+        return DialReadResult(
+            kind="rejection",
+            rejection_reason="unsupported_dial",
+            rejection_details=(
+                f"Detected {len(contours)} hand candidates; expected 3. "
+                "This watch type isn't supported by verified-reading yet."
+            ),
+            dial_detection=circle,
+        )
+
+    # ---- Stage 4: compute angles -------------------------------
+    angles = compute_hand_angles(hands, circle)
+    line_fits = fit_hand_lines(hands, circle)
+    line_residuals = (
+        line_fits[0].residual_px,
+        line_fits[1].residual_px,
+        line_fits[2].residual_px,
+    )
+
+    # ---- Stage 5: angles → (minute, second) -------------------
+    # Compute second first; minute computation needs it for the
+    # smooth-sweep correction.
+    _, second = to_mmss(0.0, angles.second_deg)
+    minute = _compute_minute_with_correction(angles.minute_deg, second)
+
+    # ---- Stage 6: hour ----------------------------------------
+    hour, time_consistency = _compute_hour_and_consistency(angles.hour_deg, minute, second)
+
+    # ---- Stage 7: confidence ----------------------------------
+    classification = _classification_consistency_signal(
+        hands_thicknesses=(hands.hour.width_px, hands.minute.width_px, hands.second.width_px),
+        hands_lengths=(hands.hour.length_px, hands.minute.length_px, hands.second.length_px),
+    )
+    signals = ConfidenceSignals(
+        circle_quality=_circle_quality_signal(circle),
+        hand_count=3,
+        classification_consistency=classification,
+        line_residuals=line_residuals,
+        time_consistency=time_consistency,
+    )
+    confidence = score(signals)
+
+    # ---- Stage 8: low-confidence gate -------------------------
+    if confidence < LOW_CONFIDENCE_THRESHOLD:
+        return DialReadResult(
+            kind="rejection",
+            rejection_reason="low_confidence",
+            rejection_details=(
+                f"Dial reading confidence {confidence:.2f} below threshold "
+                f"{LOW_CONFIDENCE_THRESHOLD:.2f}. The dial may be obscured, "
+                "blurry, or the hands misaligned with the time markers."
+            ),
+            dial_detection=circle,
+            hand_angles=angles,
+            confidence=confidence,
+            confidence_signals=signals,
+        )
+
+    return DialReadResult(
+        kind="success",
+        displayed_time=DisplayedTime(h=hour, m=minute, s=second),
+        confidence=confidence,
+        dial_detection=circle,
+        hand_angles=angles,
+        confidence_signals=signals,
+    )

--- a/container/dial-reader/src/dial_reader/dial_reader.py
+++ b/container/dial-reader/src/dial_reader/dial_reader.py
@@ -53,7 +53,7 @@ with a tie-break that, if the implied real-valued hour is e.g.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal
 
 from dial_reader.confidence_scorer import ConfidenceSignals, score
 from dial_reader.dial_locator import DialCircle, locate
@@ -70,7 +70,6 @@ from dial_reader.image_decoder import (
     decode,
 )
 from dial_reader.time_translator import to_mmss
-
 
 # ---------------------------------------------------------------
 # Result types.
@@ -101,16 +100,16 @@ class DialReadResult:
         "malformed_image",
         "unsupported_format",
     ]
-    displayed_time: Optional[DisplayedTime] = None
+    displayed_time: DisplayedTime | None = None
     confidence: float = 0.0
-    rejection_reason: Optional[str] = None
-    rejection_details: Optional[str] = None
-    dial_detection: Optional[DialCircle] = None
-    hand_angles: Optional[HandAngles] = None
+    rejection_reason: str | None = None
+    rejection_details: str | None = None
+    dial_detection: DialCircle | None = None
+    hand_angles: HandAngles | None = None
     # Internal sub-signals for observability — surfaced on the
     # log line so the operator can investigate borderline-confident
     # rejections without re-running the pipeline.
-    confidence_signals: Optional[ConfidenceSignals] = None
+    confidence_signals: ConfidenceSignals | None = None
 
 
 # ---------------------------------------------------------------

--- a/container/dial-reader/src/dial_reader/hand_geometry.py
+++ b/container/dial-reader/src/dial_reader/hand_geometry.py
@@ -115,6 +115,44 @@ class Hands:
     second: HandContour
 
 
+@dataclass(frozen=True)
+class HandAngles:
+    """Refined hand angles in degrees, clockwise from north (12 o'clock).
+
+    All three values are in [0, 360). Produced by
+    `compute_hand_angles`, which fits a line through each hand's
+    contour via PCA, picks the hull endpoint farthest from the
+    dial center as the refined tip, and recomputes the angle from
+    center to refined tip.
+
+    The refinement is sub-pixel: `extreme_point_xy` is the integer
+    pixel furthest from center, but the PCA-fit endpoint is a
+    float coordinate, which removes the integer-quantisation jitter.
+    """
+
+    hour_deg: float
+    minute_deg: float
+    second_deg: float
+
+
+@dataclass(frozen=True)
+class HandLineFit:
+    """Diagnostic output of the per-hand PCA line fit.
+
+    Attributes:
+        tip_xy: Refined tip coordinate (float pixel space).
+        residual_px: RMS perpendicular distance of contour points
+            from the fitted line, restricted to the tip-region
+            points used in the fit. Smaller = the contour is more
+            line-like, which is the structural signal that the
+            hand was cleanly detected. Plumbed into the confidence
+            scorer.
+    """
+
+    tip_xy: tuple[float, float]
+    residual_px: float
+
+
 # ---------------------------------------------------------------
 # Tunables. Picked for the rated.watch synthetic generator and
 # typical wrist-photo geometry; bake-offs against the smoke corpus
@@ -487,6 +525,170 @@ def _passes_area(contour: NDArray[np.int32], dial_area_px: float) -> bool:
     """Area within [0.5%, 30%] of the dial area."""
     area = float(cv2.contourArea(contour))
     return area >= _MIN_AREA_FRAC * dial_area_px and area <= _MAX_AREA_FRAC * dial_area_px
+
+
+# ---------------------------------------------------------------
+# Sub-pixel hand-tip refinement (slice #79).
+# ---------------------------------------------------------------
+
+# Fraction of the contour's points (by distance from the dial
+# center) used in the tip-region PCA fit. The outer 30% is the
+# part of the hand that's most directional — the inner pixels
+# near the hub are essentially radial-symmetric and add noise to
+# a directional fit. Tuned empirically on the synthetic generator;
+# the smoke-corpus accuracy stays well within the slice tolerance
+# at 0.30.
+_TIP_REGION_FRAC: Final[float] = 0.30
+
+
+def _atan2_clockwise_from_north(dx: float, dy: float) -> float:
+    """Convert a (dx, dy) image-space delta to a clockwise-from-north
+    angle in degrees, normalised into [0, 360).
+
+    Image axes: x grows right, y grows DOWN. So a vector pointing
+    at "12 o'clock" is (0, -y), which we want to map to 0°.
+
+    `math.atan2(dx, -dy)` gives that mapping directly:
+        - (0, -1) → atan2(0, 1) = 0      → 0°       (north)
+        - (1,  0) → atan2(1, 0) = π/2    → 90°      (east)
+        - (0,  1) → atan2(0, -1) = π     → 180°     (south)
+        - (-1, 0) → atan2(-1, 0) = -π/2  → 270° (after % 360)
+    """
+    rad = math.atan2(dx, -dy)
+    return math.degrees(rad) % 360.0
+
+
+def _fit_tip_line(hand: HandContour, dial: DialCircle) -> HandLineFit:
+    """Sub-pixel hand-tip refinement via PCA on the outer-30% contour.
+
+    Algorithm:
+      1. Take the contour points whose distance from the dial center
+         is in the outer `_TIP_REGION_FRAC` fraction of the per-hand
+         range.
+      2. Fit a line through those points using PCA: the dominant
+         eigenvector of their covariance matrix is the line
+         direction, and the mean is the line origin.
+      3. Project every tip-region point onto that line; the
+         projection coordinate furthest from the dial center is
+         the refined tip.
+      4. The line residual (RMS perpendicular distance from the
+         fitted line) is returned alongside; the confidence
+         scorer uses it as a "is this hand actually line-shaped"
+         signal.
+
+    Falls back to the integer `extreme_point_xy` if the contour
+    has fewer than 3 points (PCA needs at least 2 to define a
+    direction; we want one extra point so the projection has a
+    non-trivial range to optimise over).
+    """
+    cx, cy = dial.center_xy
+    pts = hand.contour.reshape(-1, 2).astype(np.float64)
+    if pts.shape[0] < 3:
+        return HandLineFit(tip_xy=hand.extreme_point_xy, residual_px=0.0)
+
+    # Distances from dial center → tip-region selection.
+    deltas = pts - np.array([float(cx), float(cy)], dtype=np.float64)
+    dists = np.hypot(deltas[:, 0], deltas[:, 1])
+    d_min, d_max = float(dists.min()), float(dists.max())
+    if d_max - d_min < 1e-6:
+        return HandLineFit(tip_xy=hand.extreme_point_xy, residual_px=0.0)
+
+    threshold = d_max - (d_max - d_min) * _TIP_REGION_FRAC
+    tip_mask = dists >= threshold
+    tip_pts = pts[tip_mask]
+    # PCA needs at least 2 points; fall back if the tip region
+    # collapsed (degenerate contour).
+    if tip_pts.shape[0] < 2:
+        return HandLineFit(tip_xy=hand.extreme_point_xy, residual_px=0.0)
+
+    # PCA via covariance eigen-decomposition. We could use
+    # cv2.fitLine, but a numpy PCA gives us the residual in the
+    # same pass without re-projecting through OpenCV.
+    mean = tip_pts.mean(axis=0)
+    centered = tip_pts - mean
+    cov = centered.T @ centered / max(1, tip_pts.shape[0] - 1)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    # eigh returns eigvals in ascending order; the largest is the
+    # dominant direction. Eigenvectors are columns.
+    direction = eigvecs[:, -1]  # (dx, dy) unit vector along the line
+
+    # Project each tip-region point onto the line direction.
+    proj = centered @ direction
+    # The "tip" is the projection coordinate whose corresponding
+    # point is FURTHEST from the dial center (along the dominant
+    # direction). Pick the projection extremum that maps to the
+    # higher-distance point.
+    far_idx = int(dists[tip_mask].argmax())
+    sign = 1.0 if proj[far_idx] >= 0.0 else -1.0
+    proj_extremum = float(proj.max()) if sign > 0 else float(proj.min())
+    tip = mean + direction * proj_extremum
+
+    # RMS perpendicular distance: the smaller eigenvalue is the
+    # variance perpendicular to the line, in pixel² units.
+    residual_var = float(eigvals[0])
+    residual = math.sqrt(max(0.0, residual_var))
+
+    return HandLineFit(
+        tip_xy=(float(tip[0]), float(tip[1])),
+        residual_px=residual,
+    )
+
+
+def compute_hand_angles(hands: Hands, dial: DialCircle) -> HandAngles:
+    """Compute per-hand angles (clockwise from north) with sub-pixel
+    tip refinement.
+
+    For each hand:
+      1. Fit a line through the outer 30% of the contour points
+         (the tip region) via PCA.
+      2. Project the tip-region points onto the dominant direction
+         and pick the projection extremum farther from the dial
+         center as the refined tip.
+      3. Recompute `atan2(dx, -dy)` from the dial center to the
+         refined tip → angle in [0, 360).
+
+    Args:
+        hands: Classified `Hands(hour, minute, second)` from
+            `classify_hands`.
+        dial: The located dial circle from `dial_locator.locate`.
+
+    Returns:
+        A `HandAngles` with three floats in [0, 360).
+
+    The refinement removes integer-pixel quantisation noise from
+    the existing `extreme_point_xy` field; on the smoke corpus
+    the per-hand angle error drops from ~1° to ~0.5° (well below
+    the slice's 1.5° per-hand tolerance).
+    """
+
+    cx, cy = dial.center_xy
+
+    def _angle(hand: HandContour) -> float:
+        fit = _fit_tip_line(hand, dial)
+        dx = fit.tip_xy[0] - float(cx)
+        dy = fit.tip_xy[1] - float(cy)
+        return _atan2_clockwise_from_north(dx, dy)
+
+    return HandAngles(
+        hour_deg=_angle(hands.hour),
+        minute_deg=_angle(hands.minute),
+        second_deg=_angle(hands.second),
+    )
+
+
+def fit_hand_lines(hands: Hands, dial: DialCircle) -> tuple[HandLineFit, HandLineFit, HandLineFit]:
+    """Return the per-hand line-fit diagnostics.
+
+    Convenience accessor for the confidence scorer, which needs the
+    PCA residuals to estimate how line-like each hand was. Computed
+    in one place so `compute_hand_angles` and the scorer can't
+    drift on the residual definition.
+    """
+    return (
+        _fit_tip_line(hands.hour, dial),
+        _fit_tip_line(hands.minute, dial),
+        _fit_tip_line(hands.second, dial),
+    )
 
 
 # ---------------------------------------------------------------

--- a/container/dial-reader/src/dial_reader/http_app.py
+++ b/container/dial-reader/src/dial_reader/http_app.py
@@ -57,21 +57,15 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from dial_reader import sentry_init
-from dial_reader.dial_locator import locate
-from dial_reader.hand_geometry import classify_hands, detect_hand_contours
-from dial_reader.image_decoder import (
-    MalformedImageError,
-    UnsupportedFormatError,
-    decode,
-)
+from dial_reader.dial_reader import read_dial
 
 # Bumped when the response shape or behaviour changes in a way
 # operators need to see. Slice #74 was `v0.0.1-scaffolding`,
-# slice #76 was `v0.1.0-decode`, slice #77 was `v0.2.0-dial-locator`;
-# this slice plugs hand-geometry classification on top so that
-# 3-hand-vs-other (chronograph / GMT / 2-hand) is detected and
-# surfaced as `unsupported_dial`.
-_VERSION: Final[str] = "v0.3.0-hand-classification"
+# slice #76 was `v0.1.0-decode`, slice #77 was `v0.2.0-dial-locator`,
+# slice #78 was `v0.3.0-hand-classification`; this slice (`#79`)
+# plugs in real angle math, time translation, and composite
+# confidence scoring → first end-to-end CV-correct dial reader.
+_VERSION: Final[str] = "v1.0.0"
 
 # Initialise Sentry once at module load. The init is idempotent and
 # becomes a no-op when SENTRY_DSN is unset, so this is safe in tests
@@ -138,20 +132,6 @@ def _log_request(payload: dict[str, Any]) -> None:
     _request_logger.info(payload)
 
 
-# Hardcoded zeros for fields the CV pipeline hasn't implemented
-# yet. Slice #78 fills `displayed_time`, `hand_angles_deg`, and
-# `confidence` with real values. Keeping these as named constants
-# at module scope makes them trivially auditable in a code review.
-_HARDCODED_DISPLAYED_TIME: Final[dict[str, int]] = {"h": 12, "m": 0, "s": 0}
-_HARDCODED_HAND_ANGLES_DEG: Final[dict[str, float]] = {
-    "hour": 0.0,
-    "minute": 0.0,
-    "second": 0.0,
-}
-_HARDCODED_CONFIDENCE: Final[float] = 0.0
-_HARDCODED_PROCESSING_MS: Final[int] = 0
-
-
 app = FastAPI(
     title="rated.watch dial-reader",
     version=_VERSION,
@@ -175,19 +155,18 @@ def healthz() -> dict[str, str]:
 
 
 @app.post("/v1/read-dial")
-async def read_dial(request: Request) -> JSONResponse:
+async def read_dial_endpoint(request: Request) -> JSONResponse:
     """Read the time displayed by a watch in the request body.
 
     The body is the raw image bytes (any of JPEG, PNG, WebP, HEIC).
     Format detection is done on the bytes themselves — we never
     trust the `Content-Type` header.
 
-    Slice #77 (dial locator): after a successful decode, runs
-    `dial_locator.locate()` to find the dial circle. If no plausible
-    dial is found we return a structured `no_dial_found` rejection;
-    if found, the success shape is returned with the real
-    `dial_detection` geometry. Hand-geometry, real time, and real
-    confidence land in subsequent slices.
+    Slice #79 (this slice) plugs in the full CV pipeline via
+    `dial_reader.read_dial`: decode → locate → segment → classify
+    → angles → translate → score. The handler is now a thin
+    translation layer between `DialReadResult` and the JSON wire
+    format; all CV decisions live in `dial_reader.read_dial`.
 
     Slice #83 (observability): every code path emits a single
     structured JSON log line via `_log_request` so Workers Logs
@@ -207,14 +186,11 @@ async def read_dial(request: Request) -> JSONResponse:
     image_bytes = await request.body()
     image_size = len(image_bytes)
 
-    try:
-        img = decode(image_bytes)
-    except UnsupportedFormatError as e:
-        # Recognised-but-rejected format. The Worker-side adapter
-        # turns this into a `DialReadResult` of kind `rejection`,
-        # which the verifier surfaces as a polite "this format
-        # isn't supported yet" message.
-        elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
+    result = read_dial(image_bytes)
+    elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
+
+    # ---- Branch on the discriminated union --------------------
+    if result.kind == "unsupported_format":
         _log_request(
             {
                 "event": "read_dial",
@@ -233,15 +209,12 @@ async def read_dial(request: Request) -> JSONResponse:
                 "ok": False,
                 "rejection": {
                     "reason": "unsupported_format",
-                    "details": str(e),
+                    "details": result.rejection_details or "",
                 },
             },
         )
-    except MalformedImageError as e:
-        # Bytes are corrupt or empty. A retry with the same bytes
-        # cannot succeed, so we surface this as a 400 rather than
-        # a structured rejection.
-        elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
+
+    if result.kind == "malformed_image":
         _log_request(
             {
                 "event": "read_dial",
@@ -258,86 +231,43 @@ async def read_dial(request: Request) -> JSONResponse:
             content={
                 "version": _VERSION,
                 "error": "malformed_image",
-                "details": str(e),
+                "details": result.rejection_details or "",
             },
         )
 
-    # Image decoded into an RGB ndarray. Run the dial locator.
-    circle = locate(img)
-    if circle is None:
-        # No plausible dial circle. Surface as a structured
-        # rejection so the SPA can show "we couldn't find a watch
-        # dial in this photo — make sure the dial is centered and
-        # well-lit" with only a "Retake" button (no manual
-        # fallback — the user needs to retry).
-        elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
-        _log_request(
-            {
-                "event": "read_dial",
-                "reading_id": reading_id,
-                "dial_reader_version": _VERSION,
-                "processing_ms": elapsed_ms,
-                "image_bytes": image_size,
-                "outcome": "rejection",
-                "rejection_reason": "no_dial_found",
-            }
-        )
+    if result.kind == "rejection":
+        log_payload: dict[str, Any] = {
+            "event": "read_dial",
+            "reading_id": reading_id,
+            "dial_reader_version": _VERSION,
+            "processing_ms": elapsed_ms,
+            "image_bytes": image_size,
+            "outcome": "rejection",
+            "rejection_reason": result.rejection_reason,
+        }
+        if result.dial_detection is not None:
+            log_payload["dial_radius_px"] = result.dial_detection.radius_px
+        if result.confidence:
+            log_payload["confidence"] = result.confidence
+        _log_request(log_payload)
         return JSONResponse(
             status_code=200,
             content={
                 "version": _VERSION,
                 "ok": False,
                 "rejection": {
-                    "reason": "no_dial_found",
-                    "details": (
-                        "No watch dial detected. Frame the dial centered "
-                        "and well-lit, then try again."
-                    ),
+                    "reason": result.rejection_reason or "rejection",
+                    "details": result.rejection_details or "",
                 },
             },
         )
 
-    # Dial located → run hand detection + classification. Slice
-    # #78 surfaces "≠ 3 hands found" as `unsupported_dial` so the
-    # SPA can show the manual-fallback dialog. The success branch
-    # keeps the hardcoded h/m/s + confidence — slice #79 plugs in
-    # real angle math and confidence scoring lands in #80.
-    contours = detect_hand_contours(img, circle)
-    hands = classify_hands(contours)
-    if hands is None:
-        elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
-        _log_request(
-            {
-                "event": "read_dial",
-                "reading_id": reading_id,
-                "dial_reader_version": _VERSION,
-                "processing_ms": elapsed_ms,
-                "image_bytes": image_size,
-                "outcome": "rejection",
-                "rejection_reason": "unsupported_dial",
-                "hand_candidates": len(contours),
-                "dial_radius_px": circle.radius_px,
-            }
-        )
-        return JSONResponse(
-            status_code=200,
-            content={
-                "version": _VERSION,
-                "ok": False,
-                "rejection": {
-                    "reason": "unsupported_dial",
-                    "details": (
-                        f"Detected {len(contours)} hand candidates; expected 3. "
-                        "This watch type isn't supported by verified-reading yet."
-                    ),
-                },
-            },
-        )
+    # ---- Success ------------------------------------------------
+    assert result.kind == "success", f"unexpected kind {result.kind}"
+    assert result.displayed_time is not None
+    assert result.dial_detection is not None
+    assert result.hand_angles is not None
 
-    # Hands detected and classified. Return the success shape with
-    # the real detection geometry; `displayed_time`, `confidence`,
-    # and `hand_angles_deg` stay hardcoded until #79 / #80.
-    elapsed_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
     _log_request(
         {
             "event": "read_dial",
@@ -346,27 +276,33 @@ async def read_dial(request: Request) -> JSONResponse:
             "processing_ms": elapsed_ms,
             "image_bytes": image_size,
             "outcome": "success",
-            "confidence": _HARDCODED_CONFIDENCE,
-            # Slice #77 added real geometry — surface the located
-            # radius on the log line so the operator can spot-check
-            # detection-size distribution from Workers Logs without
-            # re-querying the response body.
-            "dial_radius_px": circle.radius_px,
-            "hand_candidates": len(contours),
+            "confidence": result.confidence,
+            "dial_radius_px": result.dial_detection.radius_px,
         }
     )
     success_body: dict[str, Any] = {
         "version": _VERSION,
         "ok": True,
         "result": {
-            "displayed_time": _HARDCODED_DISPLAYED_TIME,
-            "confidence": _HARDCODED_CONFIDENCE,
-            "dial_detection": {
-                "center_xy": [circle.center_xy[0], circle.center_xy[1]],
-                "radius_px": circle.radius_px,
+            "displayed_time": {
+                "h": result.displayed_time.h,
+                "m": result.displayed_time.m,
+                "s": result.displayed_time.s,
             },
-            "hand_angles_deg": _HARDCODED_HAND_ANGLES_DEG,
-            "processing_ms": _HARDCODED_PROCESSING_MS,
+            "confidence": result.confidence,
+            "dial_detection": {
+                "center_xy": [
+                    result.dial_detection.center_xy[0],
+                    result.dial_detection.center_xy[1],
+                ],
+                "radius_px": result.dial_detection.radius_px,
+            },
+            "hand_angles_deg": {
+                "hour": result.hand_angles.hour_deg,
+                "minute": result.hand_angles.minute_deg,
+                "second": result.hand_angles.second_deg,
+            },
+            "processing_ms": elapsed_ms,
         },
     }
     return JSONResponse(status_code=200, content=success_body)

--- a/container/dial-reader/src/dial_reader/time_translator.py
+++ b/container/dial-reader/src/dial_reader/time_translator.py
@@ -1,0 +1,57 @@
+"""Pure angle → (mm, ss) translation.
+
+Given the minute-hand and second-hand angles measured clockwise
+from north (12 o'clock), produce the displayed minute and second
+on the dial face. Each unit (1 minute, 1 second) corresponds to
+exactly 6° of rotation, so the math is dead simple — the only
+thing this module pins down is the rounding rule and the wrap
+behaviour at the 360° boundary.
+
+Rounding rule
+=============
+Round-to-nearest, then `% 60`. A second hand visually at 359.5°
+is one tick short of the top; humans naturally read that as "0",
+not "59". Round-to-nearest captures that intuition. The tradeoff
+is that 358.8° (= 59.8 ticks) also rounds up to 60 and wraps to
+0; this only ever introduces sub-second error at the boundary,
+which is well within the slice's ±2s tolerance.
+
+Floor would have been the cheap alternative but produces a
+±1s error every time the hand sits between integer ticks, which
+is most of the time on a smooth-sweep movement. Round-to-nearest
+keeps the error symmetric.
+
+This module has zero external dependencies on purpose: the unit
+tests in `tests/test_time_translator.py` exhaustively cover the
+60 second-tick positions plus the cardinal boundaries, and we
+want this function to be the cheapest possible thing to verify.
+"""
+
+from __future__ import annotations
+
+
+def to_mmss(minute_deg: float, second_deg: float) -> tuple[int, int]:
+    """Translate hand angles in [0, 360) to (minute, second) in [0, 59].
+
+    Args:
+        minute_deg: Minute-hand angle clockwise from north (12 o'clock).
+            Values outside [0, 360) are normalised via `% 360.0`.
+        second_deg: Second-hand angle clockwise from north (12 o'clock).
+            Values outside [0, 360) are normalised via `% 360.0`.
+
+    Returns:
+        A `(minute, second)` tuple where each component is an integer
+        in [0, 59]. Angles near 360° round up to 60 and then wrap to 0
+        via the trailing `% 60`.
+
+    The function is total — every float input produces a valid output.
+    NaN handling is not specified because the upstream pipeline
+    (`hand_geometry.compute_hand_angles`) cannot produce NaN: the
+    hand-tip is by construction at finite pixel coordinates relative
+    to the dial center, so `atan2(dx, -dy)` is always finite.
+    """
+    minute_norm = minute_deg % 360.0
+    second_norm = second_deg % 360.0
+    minute = int(round(minute_norm / 6.0)) % 60
+    second = int(round(second_norm / 6.0)) % 60
+    return (minute, second)

--- a/container/dial-reader/tests/test_confidence_scorer.py
+++ b/container/dial-reader/tests/test_confidence_scorer.py
@@ -1,0 +1,151 @@
+"""Tests for `confidence_scorer.score`.
+
+The scorer composes 5 sub-signals into a single 0-1 number that
+the verifier compares against `DIAL_READER_CONFIDENCE_THRESHOLD`
+(0.7 today, see `src/domain/reading-verifier/verifier.ts`).
+
+Boundary cases:
+  - Degenerate signals (all zeros) → 0
+  - Perfect signals (all ones, no residual, no time-consistency error) → 1
+  - Misaligned hour/minute (time_consistency error > 0.15 hour-step) →
+    multiplier penalty applied (final < 0.5)
+
+The weighting picked here:
+    circle_quality:           0.15
+    hand_count == 3:          0.15 (else 0)
+    classification_consistency: 0.20
+    line_residuals (averaged → 1 - clamp(rms / R, 0, 1)): 0.20
+    time_consistency:         0.30
+    time-consistency penalty (× 0.3 when error > 0.15 hour-step)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dial_reader.confidence_scorer import ConfidenceSignals, score
+
+
+def test_score_returns_zero_for_degenerate_signals() -> None:
+    """All zeros → 0. The most degenerate possible input."""
+    sig = ConfidenceSignals(
+        circle_quality=0.0,
+        hand_count=0,
+        classification_consistency=0.0,
+        line_residuals=(999.0, 999.0, 999.0),
+        time_consistency=0.0,
+    )
+    assert score(sig) == 0.0
+
+
+def test_score_returns_one_for_perfect_signals() -> None:
+    """All sub-signals at maximum → 1.0 exactly. The line residuals
+    are normalised against an internal pixel scale; 0 residual is
+    the "perfect" value."""
+    sig = ConfidenceSignals(
+        circle_quality=1.0,
+        hand_count=3,
+        classification_consistency=1.0,
+        line_residuals=(0.0, 0.0, 0.0),
+        time_consistency=1.0,
+    )
+    assert score(sig) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_score_zero_when_hand_count_not_three() -> None:
+    """The scorer should heavily penalise hand_count != 3 — that's
+    the cardinal failure mode the upstream pipeline already
+    rejects, but the scorer must agree with the rejection if it
+    ever sees the signal."""
+    sig = ConfidenceSignals(
+        circle_quality=1.0,
+        hand_count=2,
+        classification_consistency=1.0,
+        line_residuals=(0.0, 0.0, 0.0),
+        time_consistency=1.0,
+    )
+    s = score(sig)
+    # hand_count 0 weight → score loses 0.15 points but everything
+    # else stays. Should be 0.85.
+    assert s == pytest.approx(0.85, abs=1e-6)
+
+
+def test_score_misaligned_time_triggers_penalty() -> None:
+    """time_consistency near 0 (hours and minutes don't agree) →
+    penalty multiplier (× 0.3) → final < 0.5."""
+    # All other signals strong, but time_consistency = 0 → penalty
+    # fires. With the default multiplier 0.3 and weights summing to
+    # 1.0, the un-penalised score from the 4 non-time signals is
+    # 0.70, so the final after × 0.3 is 0.21.
+    sig = ConfidenceSignals(
+        circle_quality=1.0,
+        hand_count=3,
+        classification_consistency=1.0,
+        line_residuals=(0.0, 0.0, 0.0),
+        time_consistency=0.0,
+    )
+    s = score(sig)
+    assert s < 0.5, f"misaligned-time score {s} should be < 0.5"
+
+
+def test_score_partial_signals() -> None:
+    """All signals at 0.5 → score around 0.5. Sanity check the
+    weighting averages out reasonably."""
+    sig = ConfidenceSignals(
+        circle_quality=0.5,
+        hand_count=3,
+        classification_consistency=0.5,
+        line_residuals=(2.0, 2.0, 2.0),
+        time_consistency=0.5,
+    )
+    s = score(sig)
+    # circle 0.5*0.15 + hand 1*0.15 + class 0.5*0.20 + residual 0.5*0.20
+    # + time 0.5*0.30 = 0.075 + 0.15 + 0.10 + 0.10 + 0.15 = 0.575
+    # No penalty fires (time_consistency 0.5 > the 0.15 threshold).
+    assert 0.4 <= s <= 0.8
+
+
+def test_score_clamps_signals_above_one() -> None:
+    """Sub-signals out of [0, 1] are clamped — no negative or
+    above-one component should be able to push the final score
+    out of [0, 1]."""
+    sig = ConfidenceSignals(
+        circle_quality=2.0,
+        hand_count=3,
+        classification_consistency=2.0,
+        line_residuals=(0.0, 0.0, 0.0),
+        time_consistency=2.0,
+    )
+    s = score(sig)
+    assert 0.0 <= s <= 1.0
+
+
+def test_score_clamps_signals_below_zero() -> None:
+    """Negative sub-signals → clamped to 0, score never goes
+    below 0."""
+    sig = ConfidenceSignals(
+        circle_quality=-0.5,
+        hand_count=3,
+        classification_consistency=-0.5,
+        line_residuals=(-1.0, -1.0, -1.0),
+        time_consistency=-1.0,
+    )
+    s = score(sig)
+    assert 0.0 <= s <= 1.0
+
+
+def test_score_residual_normalisation() -> None:
+    """Residual signal is normalised against an internal pixel
+    scale; 0 residual → max signal, very large residual → 0
+    signal. Verify the gradient is monotonic."""
+    base = dict(
+        circle_quality=1.0,
+        hand_count=3,
+        classification_consistency=1.0,
+        time_consistency=1.0,
+    )
+    s_zero = score(ConfidenceSignals(line_residuals=(0.0, 0.0, 0.0), **base))
+    s_small = score(ConfidenceSignals(line_residuals=(1.0, 1.0, 1.0), **base))
+    s_large = score(ConfidenceSignals(line_residuals=(50.0, 50.0, 50.0), **base))
+    assert s_zero >= s_small >= s_large
+    assert s_zero - s_large > 0.05

--- a/container/dial-reader/tests/test_dial_reader.py
+++ b/container/dial-reader/tests/test_dial_reader.py
@@ -1,0 +1,330 @@
+"""End-to-end tests for `dial_reader.read_dial`.
+
+This is the slice's headline test surface. Three layers:
+
+  1. Smoke corpus — 5 noised-synthetic fixtures from
+     `tests/fixtures/smoke/`. Truth comes from `manifest.json`.
+     Acceptance: every fixture reads with confidence ≥ 0.7 AND
+     |actual_seconds - truth_seconds| ≤ 2 (mod 3600, wrapped into
+     [-1800, +1800]).
+
+  2. 720 synthetic dial parametrized — 12 hours × 60 second
+     positions. The minute is picked deterministically per (hh, ss)
+     to keep the three hand angles at least ~14° apart so the
+     classifier can separate them. Tighter tolerance: ±1s.
+
+  3. Negative corpus — 5 fixtures generated inline (chronograph,
+     blurry, misaligned, non-watch, digital-clock mockup). All must
+     produce `result.kind == "rejection"` with a reason in
+     {no_dial_found, unsupported_dial, low_confidence}.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import math
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+from PIL import Image
+
+from dial_reader.dial_reader import DialReadResult, read_dial
+from dial_reader.synthetic import generate_dial
+
+SMOKE_FIXTURES_DIR = Path(__file__).parent / "fixtures" / "smoke"
+SMOKE_MANIFEST = SMOKE_FIXTURES_DIR / "manifest.json"
+NEGATIVE_FIXTURES_DIR = Path(__file__).parent / "fixtures" / "negative"
+
+
+def _img_to_bytes(rgb: np.ndarray, format: str = "JPEG") -> bytes:
+    """Encode an RGB ndarray as image bytes for `read_dial`."""
+    pil = Image.fromarray(rgb)
+    buf = io.BytesIO()
+    pil.save(buf, format=format, quality=92 if format == "JPEG" else None)
+    return buf.getvalue()
+
+
+def _seconds_diff(actual_m: int, actual_s: int, truth_m: int, truth_s: int) -> int:
+    """Signed second-position diff in [-1800, +1800] (mod 3600)."""
+    actual = actual_m * 60 + actual_s
+    truth = truth_m * 60 + truth_s
+    diff = (actual - truth) % 3600
+    if diff > 1800:
+        diff -= 3600
+    return diff
+
+
+# ---------------------------------------------------------------
+# Smoke corpus.
+# ---------------------------------------------------------------
+
+
+def _load_smoke_manifest() -> list[tuple[str, dict]]:
+    manifest = json.loads(SMOKE_MANIFEST.read_text())
+    return [(filename, meta) for filename, meta in manifest.items()]
+
+
+@pytest.mark.parametrize(
+    "filename,meta",
+    _load_smoke_manifest(),
+    ids=[item[0] for item in _load_smoke_manifest()],
+)
+def test_smoke_corpus_reads_within_2s_at_high_confidence(filename: str, meta: dict) -> None:
+    """Every smoke fixture reads MM:SS within ±2s of manifest truth
+    AND surfaces confidence ≥ 0.7. This is the slice's primary
+    acceptance criterion."""
+    image_bytes = (SMOKE_FIXTURES_DIR / filename).read_bytes()
+    result = read_dial(image_bytes)
+    assert result.kind == "success", (
+        f"{filename}: expected success, got {result.kind} "
+        f"({result.rejection_reason}: {result.rejection_details})"
+    )
+    assert result.displayed_time is not None
+    assert result.confidence >= 0.7, f"{filename}: confidence {result.confidence:.3f} below 0.7"
+    diff = _seconds_diff(
+        result.displayed_time.m,
+        result.displayed_time.s,
+        int(meta["mm"]),
+        int(meta["ss"]),
+    )
+    assert abs(diff) <= 2, (
+        f"{filename}: read {result.displayed_time.m:02d}:{result.displayed_time.s:02d}, "
+        f"truth {int(meta['mm']):02d}:{int(meta['ss']):02d}, deviation {diff:+d}s "
+        f"exceeds ±2s tolerance"
+    )
+
+
+# ---------------------------------------------------------------
+# 720 synthetic dials.
+# ---------------------------------------------------------------
+
+
+def _expected_angles(hh: int, mm: int, ss: int) -> tuple[float, float, float]:
+    hour = ((hh % 12) * 30.0) + (mm / 60.0) * 30.0
+    minute = (mm * 6.0) + (ss / 60.0) * 6.0
+    second = ss * 6.0
+    return (hour % 360.0, minute % 360.0, second % 360.0)
+
+
+def _circular_sep_deg(a: float, b: float) -> float:
+    d = abs(a - b) % 360.0
+    return min(d, 360.0 - d)
+
+
+def _pick_mm_with_max_separation(hh: int, ss: int) -> int:
+    best_mm = 0
+    best_sep = -1.0
+    for mm in range(60):
+        h, m, s = _expected_angles(hh, mm, ss)
+        sep = min(
+            _circular_sep_deg(h, m),
+            _circular_sep_deg(h, s),
+            _circular_sep_deg(m, s),
+        )
+        if sep > best_sep:
+            best_sep = sep
+            best_mm = mm
+    return best_mm
+
+
+def _generate_720_cases() -> list[tuple[int, int, int]]:
+    cases: list[tuple[int, int, int]] = []
+    for hh in range(12):
+        for ss in range(60):
+            mm = _pick_mm_with_max_separation(hh, ss)
+            cases.append((hh, mm, ss))
+    return cases
+
+
+CASES_720 = _generate_720_cases()
+
+
+@pytest.mark.parametrize(
+    "hh,mm,ss",
+    CASES_720,
+    ids=[f"{hh:02d}-{mm:02d}-{ss:02d}" for hh, mm, ss in CASES_720],
+)
+def test_synthetic_dial_reads_within_1s(hh: int, mm: int, ss: int) -> None:
+    """720 parametrized clean synthetic dials read MM:SS within ±1s
+    of truth. Tighter than the smoke corpus because synthetic input
+    has zero noise."""
+    rgb = generate_dial(hh, mm, ss)
+    image_bytes = _img_to_bytes(rgb)
+    result = read_dial(image_bytes)
+    assert result.kind == "success", (
+        f"{hh:02d}:{mm:02d}:{ss:02d}: expected success, got {result.kind}"
+    )
+    assert result.displayed_time is not None
+    diff = _seconds_diff(result.displayed_time.m, result.displayed_time.s, mm, ss)
+    assert abs(diff) <= 1, (
+        f"{hh:02d}:{mm:02d}:{ss:02d}: read "
+        f"{result.displayed_time.m:02d}:{result.displayed_time.s:02d}, "
+        f"deviation {diff:+d}s exceeds ±1s tolerance"
+    )
+    # Hour readout should also match — modulo 12 because the
+    # synthetic generator uses (hh % 12).
+    assert result.displayed_time.h == hh % 12, (
+        f"{hh:02d}:{mm:02d}:{ss:02d}: read hour {result.displayed_time.h}, expected {hh % 12}"
+    )
+
+
+# ---------------------------------------------------------------
+# Negative corpus — every case must produce a rejection.
+# ---------------------------------------------------------------
+
+
+_ACCEPTABLE_NEG_REASONS = frozenset({"no_dial_found", "unsupported_dial", "low_confidence"})
+
+
+def _negative_chronograph_bytes() -> bytes:
+    """Synthetic 3-hander + 2 sub-dial pointers in different
+    positions → 5 hand candidates → unsupported_dial."""
+    base = generate_dial(8, 56, 6).copy()
+    cx, cy = 400, 400
+    for angle_deg, length_frac, thickness in [
+        (120.0, 0.30, 8),
+        (210.0, 0.30, 8),
+    ]:
+        rad = math.radians(angle_deg)
+        end_x = int(round(cx + math.sin(rad) * 350 * length_frac))
+        end_y = int(round(cy - math.cos(rad) * 350 * length_frac))
+        cv2.line(base, (cx, cy), (end_x, end_y), (240, 240, 240), thickness, cv2.LINE_AA)
+    return _img_to_bytes(base)
+
+
+def _negative_blurry_bytes() -> bytes:
+    """Heavy-blur synthetic dial. The blur smears the chapter ring
+    + hands enough that the locator may pass but the hand classifier
+    or the confidence threshold will fire."""
+    rgb = generate_dial(8, 56, 6)
+    blurred = cv2.GaussianBlur(rgb, (51, 51), sigmaX=15)
+    return _img_to_bytes(blurred)
+
+
+def _negative_misaligned_bytes() -> bytes:
+    """Hour and minute hands deliberately disagree. We render the
+    minute hand at minute=56 (336°) but the hour hand at 4.5 (135°
+    rather than the synthetic-generator's natural 8.93*30 = 268°
+    that would be consistent with 56 minutes). This trips the
+    time-consistency check → confidence < 0.5 → low_confidence
+    rejection by the orchestrator's threshold."""
+    # Build it from scratch instead of monkey-patching synthetic;
+    # synthetic enforces consistency by construction.
+    img = np.full((800, 800, 3), (200, 200, 200), dtype=np.uint8)
+    cx, cy = 400, 400
+    r = 350
+    cv2.circle(img, (cx, cy), r, (40, 70, 60), -1, cv2.LINE_AA)
+    # 12 hour ticks
+    for i in range(12):
+        rad = math.radians(i * 30.0)
+        ix = int(round(cx + math.sin(rad) * r * 0.88))
+        iy = int(round(cy - math.cos(rad) * r * 0.88))
+        ox = int(round(cx + math.sin(rad) * r * 0.97))
+        oy = int(round(cy - math.cos(rad) * r * 0.97))
+        cv2.line(img, (ix, iy), (ox, oy), (240, 240, 240), 8, cv2.LINE_AA)
+
+    def _draw(angle_deg: float, length: int, thickness: int) -> None:
+        rad = math.radians(angle_deg)
+        end_x = int(round(cx + math.sin(rad) * length))
+        end_y = int(round(cy - math.cos(rad) * length))
+        cv2.line(img, (cx, cy), (end_x, end_y), (240, 240, 240), thickness, cv2.LINE_AA)
+
+    # Minute at 336° (= minute=56), second at 36° (= second=6),
+    # but hour deliberately at 135° (4.5 hours, very inconsistent
+    # with minute=56 which expects ~9*30+28°=298°). ~163° error.
+    _draw(135.0, int(r * 0.50), max(1, int(2 * r * 0.020)))  # hour
+    _draw(336.0, int(r * 0.85), max(1, int(2 * r * 0.010)))  # minute
+    _draw(36.0, int(r * 0.90), max(1, int(2 * r * 0.004)))  # second
+    return _img_to_bytes(img)
+
+
+def _negative_nonwatch_bytes() -> bytes:
+    """Random noise — definitely not a watch."""
+    rng = np.random.default_rng(42)
+    rgb = rng.integers(0, 255, size=(800, 800, 3), dtype=np.uint8)
+    return _img_to_bytes(rgb)
+
+
+def _negative_digital_clock_bytes() -> bytes:
+    """Rectangular block of digits (mock digital display). No round
+    dial → no_dial_found from the locator."""
+    rgb = np.full((600, 800, 3), (20, 20, 20), dtype=np.uint8)
+    # Big white text in a rectangle
+    cv2.rectangle(rgb, (200, 200), (600, 400), (240, 240, 240), -1)
+    cv2.putText(
+        rgb,
+        "12:34",
+        (220, 360),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        4.0,
+        (20, 20, 20),
+        10,
+        cv2.LINE_AA,
+    )
+    return _img_to_bytes(rgb)
+
+
+_NEGATIVE_CASES = [
+    ("chronograph", _negative_chronograph_bytes),
+    ("blurry", _negative_blurry_bytes),
+    ("misaligned", _negative_misaligned_bytes),
+    ("nonwatch", _negative_nonwatch_bytes),
+    ("digital_clock", _negative_digital_clock_bytes),
+]
+
+
+@pytest.mark.parametrize(
+    "label,bytes_factory",
+    _NEGATIVE_CASES,
+    ids=[label for label, _ in _NEGATIVE_CASES],
+)
+def test_negative_corpus_rejected(label: str, bytes_factory) -> None:
+    """Every negative-corpus fixture produces a rejection — never a
+    falsely-confident success."""
+    image_bytes = bytes_factory()
+    result: DialReadResult = read_dial(image_bytes)
+    assert result.kind == "rejection", (
+        f"{label}: expected rejection, got kind={result.kind}; "
+        f"reason={result.rejection_reason}; details={result.rejection_details}"
+    )
+    assert result.rejection_reason in _ACCEPTABLE_NEG_REASONS, (
+        f"{label}: rejection reason {result.rejection_reason!r} not in "
+        f"{sorted(_ACCEPTABLE_NEG_REASONS)}"
+    )
+
+
+def test_negative_misaligned_specifically_triggers_low_confidence() -> None:
+    """The misaligned-hands negative case is engineered to test the
+    time_consistency penalty. Specifically assert that branch
+    fires (rather than a different upstream rejection) so a
+    regression in the scorer doesn't silently move detection up
+    the pipeline."""
+    result = read_dial(_negative_misaligned_bytes())
+    assert result.kind == "rejection"
+    assert result.rejection_reason == "low_confidence", (
+        f"misaligned-hands fixture rejected with {result.rejection_reason!r} "
+        f"rather than low_confidence; the time-consistency check may have "
+        f"regressed."
+    )
+
+
+# ---------------------------------------------------------------
+# Discriminated-union shape contract.
+# ---------------------------------------------------------------
+
+
+def test_read_dial_with_empty_bytes_returns_malformed_image() -> None:
+    """0 bytes → kind=malformed_image so the HTTP layer surfaces 400."""
+    result = read_dial(b"")
+    assert result.kind == "malformed_image"
+
+
+def test_read_dial_with_solid_color_returns_no_dial_found() -> None:
+    """Flat color decodes fine but locator finds no circle."""
+    rgb = np.full((400, 400, 3), 200, dtype=np.uint8)
+    result = read_dial(_img_to_bytes(rgb))
+    assert result.kind == "rejection"
+    assert result.rejection_reason == "no_dial_found"

--- a/container/dial-reader/tests/test_hand_angles.py
+++ b/container/dial-reader/tests/test_hand_angles.py
@@ -1,0 +1,127 @@
+"""Tests for `hand_geometry.compute_hand_angles`.
+
+Sub-pixel hand-tip refinement matters: the existing
+`extreme_point_xy` is the contour pixel furthest from the dial
+center, which is integer-quantised. For a thin second hand on a
+700-px-radius dial that's already <0.1° of error, but for a thick
+hour hand the centroid of the *tip region* (outer 30% of the
+contour) gives a more stable angle than a single corner pixel
+that happens to win the argmax.
+
+The acceptance bar: per-hand angle error ≤ 1.5° on every clean
+synthetic dial in the 720-case grid. That's tighter than the
+locator-stage 30° tolerance because the time translator
+(`time_translator.to_mmss`) is sensitive at 6°/tick.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from dial_reader.dial_locator import locate
+from dial_reader.hand_geometry import (
+    HandAngles,
+    classify_hands,
+    compute_hand_angles,
+    detect_hand_contours,
+)
+from dial_reader.synthetic import generate_dial
+
+
+def _expected_angles(hh: int, mm: int, ss: int) -> tuple[float, float, float]:
+    hour = ((hh % 12) * 30.0) + (mm / 60.0) * 30.0
+    minute = (mm * 6.0) + (ss / 60.0) * 6.0
+    second = ss * 6.0
+    return (hour % 360.0, minute % 360.0, second % 360.0)
+
+
+def _circular_diff_deg(a: float, b: float) -> float:
+    """Signed shortest-distance angular difference (b - a) in degrees,
+    folded into [-180, +180]."""
+    d = (b - a + 540.0) % 360.0 - 180.0
+    return d
+
+
+def _abs_circular_diff_deg(a: float, b: float) -> float:
+    return abs(_circular_diff_deg(a, b))
+
+
+def test_compute_hand_angles_returns_dataclass() -> None:
+    """The output is a `HandAngles` with three float fields in [0, 360)."""
+    img = generate_dial(8, 56, 6)
+    circle = locate(img)
+    assert circle is not None
+    hands = classify_hands(detect_hand_contours(img, circle))
+    assert hands is not None
+
+    angles = compute_hand_angles(hands, circle)
+    assert isinstance(angles, HandAngles)
+    for v in (angles.hour_deg, angles.minute_deg, angles.second_deg):
+        assert isinstance(v, float)
+        assert 0.0 <= v < 360.0
+
+
+def test_compute_hand_angles_at_8_56_06_within_1_5_deg() -> None:
+    """Reference case from the existing fixtures: 08:56:06 → angles
+    268° / 336.6° / 36° clockwise from north. Each refined hand angle
+    must land within 1.5° of the truth."""
+    img = generate_dial(8, 56, 6)
+    circle = locate(img)
+    assert circle is not None
+    hands = classify_hands(detect_hand_contours(img, circle))
+    assert hands is not None
+    angles = compute_hand_angles(hands, circle)
+
+    eh, em, es = _expected_angles(8, 56, 6)
+    assert _abs_circular_diff_deg(angles.hour_deg, eh) < 1.5
+    assert _abs_circular_diff_deg(angles.minute_deg, em) < 1.5
+    assert _abs_circular_diff_deg(angles.second_deg, es) < 1.5
+
+
+@pytest.mark.parametrize(
+    "hh,mm,ss",
+    [
+        (1, 35, 50),  # smoke-01 truth
+        (8, 56, 6),  # smoke-02 truth
+        (4, 25, 13),  # smoke-03 truth
+        (11, 5, 30),  # smoke-04 truth
+        (6, 42, 18),  # smoke-05 truth
+        (2, 17, 44),  # arbitrary well-separated time
+    ],
+)
+def test_compute_hand_angles_within_1_5_deg_on_canonical_times(hh: int, mm: int, ss: int) -> None:
+    """Several manually-picked canonical times — verify the refined
+    angles are within 1.5° of truth on every clean synthetic input.
+
+    All cases chosen so the three hand angles stay well-separated
+    (>12°), the minimum the existing classifier needs."""
+    img = generate_dial(hh, mm, ss)
+    circle = locate(img)
+    assert circle is not None
+    hands = classify_hands(detect_hand_contours(img, circle))
+    assert hands is not None, f"classify failed at {hh:02d}:{mm:02d}:{ss:02d}"
+    angles = compute_hand_angles(hands, circle)
+
+    eh, em, es = _expected_angles(hh, mm, ss)
+    err_h = _abs_circular_diff_deg(angles.hour_deg, eh)
+    err_m = _abs_circular_diff_deg(angles.minute_deg, em)
+    err_s = _abs_circular_diff_deg(angles.second_deg, es)
+    assert err_h < 1.5, f"hour err {err_h:.2f}° at {hh:02d}:{mm:02d}:{ss:02d}"
+    assert err_m < 1.5, f"min  err {err_m:.2f}° at {hh:02d}:{mm:02d}:{ss:02d}"
+    assert err_s < 1.5, f"sec  err {err_s:.2f}° at {hh:02d}:{mm:02d}:{ss:02d}"
+
+
+def test_compute_hand_angles_normalisation_into_0_360() -> None:
+    """All output angles must be in [0, 360) — never negative,
+    never ≥ 360. Use a well-separated time that exercises the
+    near-360°/near-0° wrap region (sec=59 → 354°)."""
+    img = generate_dial(2, 17, 59)
+    circle = locate(img)
+    assert circle is not None
+    hands = classify_hands(detect_hand_contours(img, circle))
+    assert hands is not None
+    angles = compute_hand_angles(hands, circle)
+    for v in (angles.hour_deg, angles.minute_deg, angles.second_deg):
+        assert 0.0 <= v < 360.0

--- a/container/dial-reader/tests/test_hand_angles.py
+++ b/container/dial-reader/tests/test_hand_angles.py
@@ -16,8 +16,6 @@ locator-stage 30° tolerance because the time translator
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from dial_reader.dial_locator import locate

--- a/container/dial-reader/tests/test_http_app.py
+++ b/container/dial-reader/tests/test_http_app.py
@@ -48,7 +48,7 @@ from dial_reader.synthetic import generate_dial
 # ASGI lifespan once per test.
 client = TestClient(app)
 
-VERSION = "v0.3.0-hand-classification"
+VERSION = "v1.0.0"
 
 
 def _synthetic_dial_jpeg(hh: int = 8, mm: int = 56, ss: int = 6) -> bytes:

--- a/container/dial-reader/tests/test_time_translator.py
+++ b/container/dial-reader/tests/test_time_translator.py
@@ -1,0 +1,98 @@
+"""Tests for `time_translator` — pure angle → (mm, ss) math.
+
+The function is deliberately stateless and dependency-free so the
+boundary cases below are exhaustive: at angles 0°/90°/180°/270°
+(the cardinal positions) the output must be exactly the
+corresponding 0/15/30/45 reading; near 360° we exercise the wrap
+behaviour explicitly so a future change to floor-vs-round can't
+silently flip the corpus accuracy.
+
+Rationale for round-to-nearest with wrap-to-0
+=============================================
+A second hand visually at 359.5° is, to a human eye, "right at the
+top of the dial" — i.e. effectively pointing at 12. Floor rounding
+would surface that as 59 (one tick before the top); round-to-nearest
+correctly surfaces it as 0 (the top itself). The tradeoff is that a
+hand at 358.8° (which is 59.8 seconds, perceptually closer to 60
+than to 59 by 0.2s) also surfaces as 0 — which is consistent with
+the rounding rule and only ever introduces sub-second error at the
+boundary. We document this explicitly via `test_to_mmss_just_below_360`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dial_reader.time_translator import to_mmss
+
+
+def test_to_mmss_at_0_returns_0_0() -> None:
+    """0° (12 o'clock, the top) → 0 minutes / 0 seconds."""
+    assert to_mmss(0.0, 0.0) == (0, 0)
+
+
+def test_to_mmss_at_90_returns_15_15() -> None:
+    """90° (3 o'clock) → 15 minutes / 15 seconds. Each unit on the
+    dial is 6°, so 90° = 15 ticks."""
+    assert to_mmss(90.0, 90.0) == (15, 15)
+
+
+def test_to_mmss_at_180_returns_30_30() -> None:
+    """180° (6 o'clock) → 30 minutes / 30 seconds."""
+    assert to_mmss(180.0, 180.0) == (30, 30)
+
+
+def test_to_mmss_at_270_returns_45_45() -> None:
+    """270° (9 o'clock) → 45 minutes / 45 seconds."""
+    assert to_mmss(270.0, 270.0) == (45, 45)
+
+
+def test_to_mmss_at_just_below_360_wraps_to_0() -> None:
+    """358.8° is 59.8 ticks; round-to-nearest gives 60, which wraps
+    via `% 60` to 0. This is the documented boundary behaviour
+    (see module docstring) — round-to-nearest, not floor."""
+    assert to_mmss(358.8, 358.8) == (0, 0)
+
+
+def test_to_mmss_at_356_4_returns_59_59() -> None:
+    """356.4° is exactly 59.4 ticks; round-to-nearest gives 59. This
+    is the smallest integer-tick value that does NOT wrap to 0."""
+    assert to_mmss(356.4, 356.4) == (59, 59)
+
+
+def test_to_mmss_independent_axes() -> None:
+    """The minute and second outputs are computed independently —
+    the second hand at 12 o'clock and the minute hand at 6 o'clock
+    must produce (30, 0)."""
+    assert to_mmss(180.0, 0.0) == (30, 0)
+    assert to_mmss(0.0, 180.0) == (0, 30)
+
+
+def test_to_mmss_at_30_returns_5_5() -> None:
+    """One hour position (30°) is 5 ticks → 5 minutes / 5 seconds."""
+    assert to_mmss(30.0, 30.0) == (5, 5)
+
+
+def test_to_mmss_at_6_returns_1_1() -> None:
+    """One tick (6°) → 1 minute / 1 second. The smallest unit."""
+    assert to_mmss(6.0, 6.0) == (1, 1)
+
+
+def test_to_mmss_handles_negative_angle_via_mod() -> None:
+    """Defensive: angles outside [0, 360) get normalised. -6° is the
+    same as 354° → 59 ticks."""
+    assert to_mmss(-6.0, -6.0) == (59, 59)
+
+
+def test_to_mmss_handles_angle_above_360_via_mod() -> None:
+    """Defensive: 366° is the same as 6° → 1 tick."""
+    assert to_mmss(366.0, 366.0) == (1, 1)
+
+
+@pytest.mark.parametrize("ss", list(range(60)))
+def test_to_mmss_round_trip_for_every_integer_second(ss: int) -> None:
+    """For every integer second in [0, 60), feeding `ss * 6.0` back
+    through `to_mmss` returns ss for both axes. Exhaustive guard
+    against accumulator drift in the rounding path."""
+    angle = ss * 6.0
+    assert to_mmss(angle, angle) == (ss, ss)


### PR DESCRIPTION
Closes #79.

## Summary

Slice 6 of PRD #73. The CV pipeline now produces real readings.

- `time_translator.to_mmss(minute_deg, second_deg)` — pure angle → (mm, ss) math; round-to-nearest with `% 60` wrap.
- `hand_geometry.compute_hand_angles(hands, dial)` — sub-pixel tip refinement via PCA on the outer 30 % of each hand contour.
- `confidence_scorer.score(signals)` — 5-signal composite; time-consistency penalty (× 0.3) when hour vs minute disagrees by > 0.15 hour-step.
- `dial_reader.read_dial(image_bytes)` — top-level orchestrator returning a `DialReadResult` discriminated union (success / rejection / malformed_image / unsupported_format). Hosts the smooth-sweep minute correction and hour computation.
- `http_app.py` — handler is now a thin JSON adapter; version bumped to **v1.0.0**.

## Smoke corpus accuracy

| Photo | Truth (HH:MM:SS) | CV Reading | Δ (s) | Confidence |
|---|---|---|---|---|
| smoke-01.jpg | 01:35:50 | 01:35:50 | +0 | 0.91 |
| smoke-02.jpg | 08:56:06 | 08:56:06 | +0 | 0.92 |
| smoke-03.jpg | 04:25:13 | 04:25:13 | +0 | 0.91 |
| smoke-04.jpg | 11:05:30 | 11:05:30 | +0 | 0.90 |
| smoke-05.jpg | 06:42:18 | 06:42:18 | +0 | 0.91 |

All 5 fixtures read **exactly** correct (Δ = 0 s) at confidence ≥ 0.90 — well within the slice's ±2 s / ≥ 0.7 acceptance bars.

## 720 synthetic dials

All 720 parametrized clean synthetic dials (12 hours × 60 second positions, with the minute picked deterministically per (hh, ss) for max hand separation) read **exactly** correct (Δ = 0 s) for both MM:SS and the hour readout. Acceptance was ±1 s.

## Negative corpus

5 inline negative cases — all reject with no false-positive readings:

| Case | Reason returned |
|---|---|
| chronograph (3 hands + 2 sub-dial pointers) | `unsupported_dial` |
| heavy gaussian blur of synthetic dial | `unsupported_dial` |
| deliberately misaligned hour vs minute | `low_confidence` |
| random RGB noise | `no_dial_found` |
| digital-clock mockup (rectangular block of digits) | `no_dial_found` |

The misaligned-hands case explicitly asserts `low_confidence` (catches scorer regressions where the time-consistency check stops firing).

## Acceptance criteria

- [x] All 5 smoke-corpus real photos read within ±2 s of manifest truth (actual: Δ = 0 s)
- [x] All 5 smoke-corpus reads return confidence ≥ 0.7 (actual: ≥ 0.90)
- [x] All 5 negative-corpus photos rejected with no_dial_found / unsupported_dial / low_confidence
- [x] All 720 parametrized synthetic-dial tests read within ±1 s
- [x] `time_translator.to_mmss` boundary tests pass
- [x] `confidence_scorer` returns 0 on degenerate inputs and 1 on perfect inputs
- [x] Time-consistency check fires correctly: misaligned hands → confidence < 0.5 → low_confidence
- [x] PR description includes summary table of smoke-corpus readings

## Test counts

- Container: **1615 tests** pass (was 882 pre-slice; +733 new)
- Worker: **566 tests** pass
- Lint (`ruff`) + types (`mypy`) clean

## Commits

1. `feat(container): time_translator pure angle→mmss math`
2. `feat(container): hand angle computation with sub-pixel tip refinement`
3. `feat(container): composite confidence_scorer with time-consistency check`
4. `feat(container): dial_reader orchestrator wiring all CV stages`
5. `test(container): smoke + 720 synthetic + negative corpus integration`

## Notes

- Did not touch `wrangler.jsonc`, `infra/terraform/`, `migrations/`, or `src/server/routes/readings.ts` — verifier already gates on confidence ≥ 0.7 from earlier slices.
- The negative-corpus fixtures are generated inline rather than checked into `tests/fixtures/negative/` — keeps the diff text-only and reproducible across machines.
- The HoughCircles accumulator score is not surfaced through the locator's public API yet; `_circle_quality_signal` returns 1.0 (clean detection floor). Plumbing it through is a future tuning lever.