### PR TITLE
fix(container): use docker.io mirror of uv image (ghcr.io blocked in corp env)

### DIFF
--- a/container/dial-reader/Dockerfile
+++ b/container/dial-reader/Dockerfile
@@ -17,11 +17,18 @@
 # `--platform=linux/amd64` is set on the FROM lines so an Apple-Silicon
 # `docker build` produces an amd64 image rather than silently
 # cross-compiling to arm64.
+#
+# Registry note: we pull `astral/uv` from Docker Hub rather than
+# `ghcr.io/astral-sh/uv` because some operator environments (corp
+# Docker Desktop policy enforcement) deny ghcr.io traffic. Docker Hub
+# hosts an identical mirror published by Astral with the same
+# `python3.12-bookworm-slim` tag — same digest contents, different
+# registry source.
 
 ARG PYTHON_VERSION=3.12-slim-bookworm
 
 # ---- Stage 1: install dependencies into a venv via uv ------------
-FROM --platform=linux/amd64 ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM --platform=linux/amd64 astral/uv:python3.12-bookworm-slim AS builder
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \


### PR DESCRIPTION
## Why

Wrangler deploy of the dial-reader container fails at the build step in operator environments where Docker Desktop has corp-org policy enforcement (specifically the `[cloudflare bastionzero]` org config). All ghcr.io pulls return `denied: denied`, including the `astral-sh/uv` builder-stage base image referenced from the original Dockerfile.

## What

Switch the builder-stage base from `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` to `astral/uv:python3.12-bookworm-slim` (Docker Hub mirror, same content, different registry).

Verified in the affected environment:
- `docker pull --platform=linux/amd64 astral/uv:python3.12-bookworm-slim` ✅ pulls
- `docker pull --platform=linux/amd64 ghcr.io/astral-sh/uv:python3.12-bookworm-slim` ❌ denied

## Operator action after merge

`wrangler deploy` from main will now succeed (assuming Docker daemon is running with whatever auth your environment requires).

Refs the deploy-blocking encounter during slice #84 cutover (PR #96).