### PR TITLE
feat(dial-reader-vlm): median-of-3 + anchor-disagreement guard — Refs #99

### DIFF
--- a/src/app/watches/verifiedReadingErrors.test.ts
+++ b/src/app/watches/verifiedReadingErrors.test.ts
@@ -117,6 +117,30 @@ describe("mapVerifiedReadingError", () => {
     expect(mapped.manualFallback).toBe(false);
   });
 
+  // Slice #5 of PRD #99 (issue #104) — median-of-3 + anchor-guard
+  // rejections.
+
+  it("maps dial_reader_anchor_disagreement (422) to a retake hint mentioning the phone clock", () => {
+    const mapped = mapVerifiedReadingError(422, "dial_reader_anchor_disagreement");
+    expect(mapped.code).toBe("dial_reader_anchor_disagreement");
+    expect(mapped.message).toMatch(/clock|reconcile/i);
+    expect(mapped.message).toMatch(/retake/i);
+    expect(mapped.canRetake).toBe(true);
+    expect(mapped.canRetry).toBe(false);
+    expect(mapped.manualFallback).toBe(false);
+  });
+
+  it("maps dial_reader_anchor_echo_flagged (422) to a neutral retake hint (does not leak cheat detection)", () => {
+    const mapped = mapVerifiedReadingError(422, "dial_reader_anchor_echo_flagged");
+    expect(mapped.code).toBe("dial_reader_anchor_echo_flagged");
+    expect(mapped.message).toMatch(/inconclusive|retake/i);
+    // Don't expose internal cheat-detection vocabulary.
+    expect(mapped.message).not.toMatch(/cheat|echo|suspicious/i);
+    expect(mapped.canRetake).toBe(true);
+    expect(mapped.canRetry).toBe(false);
+    expect(mapped.manualFallback).toBe(false);
+  });
+
   it("maps 429 to a daily-cap message with no retry/retake", () => {
     const mapped = mapVerifiedReadingError(429);
     expect(mapped.code).toBe("rate_limited");

--- a/src/app/watches/verifiedReadingErrors.ts
+++ b/src/app/watches/verifiedReadingErrors.ts
@@ -52,6 +52,8 @@ export type VerifiedReadingErrorCode =
   | "dial_reader_no_dial_found"
   | "dial_reader_malformed_image"
   | "dial_reader_transport_error"
+  | "dial_reader_anchor_disagreement"
+  | "dial_reader_anchor_echo_flagged"
   | "rate_limited"
   | "unknown";
 
@@ -153,6 +155,31 @@ export function mapVerifiedReadingError(
       manualFallback: false,
       canRetake: false,
       canRetry: true,
+    };
+  }
+
+  // Slice #5 of PRD #99 (issue #104) — median-of-3 + anchor-guard
+  // rejections. These both render as 422s with a retake nudge. The
+  // anchor-echo path deliberately uses neutral copy ("inconclusive
+  // read") rather than telling the user "we caught the model
+  // cheating" — that's an internal-only signal.
+  if (status === 422 && serverCode === "dial_reader_anchor_disagreement") {
+    return {
+      code: "dial_reader_anchor_disagreement",
+      message:
+        "We couldn't reconcile the dial with your phone's clock. Please retake the photo.",
+      manualFallback: false,
+      canRetake: true,
+      canRetry: false,
+    };
+  }
+  if (status === 422 && serverCode === "dial_reader_anchor_echo_flagged") {
+    return {
+      code: "dial_reader_anchor_echo_flagged",
+      message: "Inconclusive read — please retake the photo.",
+      manualFallback: false,
+      canRetake: true,
+      canRetry: false,
     };
   }
 

--- a/src/domain/dial-reader-vlm/__tests__/cheat-regression.node.test.ts
+++ b/src/domain/dial-reader-vlm/__tests__/cheat-regression.node.test.ts
@@ -307,20 +307,40 @@ describe.skipIf(!SHOULD_RUN)("VLM dial-reader: cheat-detection regression", () =
               );
             }
 
-            if (result.kind === "unparseable") {
-              // Unparseable is not anchor-echo — count it as a non-echo
-              // attempt and short-circuit the cell as a pass. Persistent
-              // unparseables across multiple cells would suggest model
-              // degradation; that's the weekly run's job to surface.
+            if (result.kind === "rejection") {
+              // The dial-reader-vlm module's own anchor-guard caught one
+              // of these:
+              //   anchor_echo_suspicious — all 3 reads exactly = anchor.
+              //     This IS the cheat we're testing for. Fail loudly.
+              //   anchor_disagreement — median diverged from anchor by
+              //     >60s. With our ±90s anchor offset, this is the
+              //     EXPECTED outcome (model is reading pixels and they
+              //     don't match the wrong anchor). Pass the cell.
+              //   unparseable_majority / all_runs_failed — not a cheat
+              //     signature; treat as non-echo and pass the cell.
+              //     Persistent rejections across multiple cells would
+              //     surface in the weekly run as model degradation.
+              if (result.reason === "anchor_echo_suspicious") {
+                throw new Error(
+                  `ANCHOR-ECHO REGRESSION DETECTED (rejection variant): the ` +
+                    `dial-reader-vlm anchor-guard fired on fixture ${fixture} ` +
+                    `with anchor offset ${offsetLabel}s. All 3 individual ` +
+                    `reads were byte-identical to the (false) anchor. This is ` +
+                    `the same cheat that disqualified Claude Opus 4.5 in PRD ` +
+                    `#99's bake-off. Either the model has degraded OR the ` +
+                    `prompt has been weakened. DO NOT MERGE. Investigate ` +
+                    `before flipping the verified_reading_cv flag back on.`,
+                );
+              }
               attempts.push({
                 kind: result.kind,
-                rawSnippet: result.raw_response.slice(0, 100),
+                rawSnippet: `rejection:${result.reason}`,
               });
               // eslint-disable-next-line no-console
               console.warn(
                 `[cheat-regression] ${fixture} offset ${offsetLabel}s ` +
-                  `attempt ${attempt}: model returned unparseable response. ` +
-                  `Treating as non-echo. Raw: ${result.raw_response.slice(0, 200)}`,
+                  `attempt ${attempt}: model returned rejection ` +
+                  `(reason=${result.reason}). Treating as non-echo.`,
               );
               return;
             }

--- a/src/domain/dial-reader-vlm/anchor-guard.test.ts
+++ b/src/domain/dial-reader-vlm/anchor-guard.test.ts
@@ -1,0 +1,242 @@
+// Pure-function tests for the anchor-disagreement guard.
+//
+// The guard is the second half of the median-of-3 pipeline (slice #5
+// of PRD #99 — issue #104). After `reader.ts` computes a median MM:SS
+// from three parallel VLM reads, the guard checks the median against
+// the EXIF anchor and against the individual read pattern, and either
+// accepts or rejects/flags the result.
+//
+// Two failure modes the guard catches:
+//
+//   1. **anchor disagreement**: median MM:SS diverges from the
+//      anchor by > 60s on the wrap-aware [0, 3600) MM:SS circle.
+//      Mirrors the bake-off's `_signed_error_seconds` math but on the
+//      MM:SS-only axis (3600s circle, 1800s half).
+//
+//   2. **anchor echo (cheat-flag)**: ALL three individual reads are
+//      byte-identical to the anchor's MM:SS. The bake-off saw
+//      Claude-style models do this — they ignore the dial entirely
+//      and just echo the anchor we passed in the prompt as a "sanity
+//      check". With three identical-to-anchor reads the probability
+//      that a real dial coincidentally landed on exactly the anchor
+//      MM:SS three times in a row is vanishingly small. Two of two
+//      identical-to-anchor reads is NOT distinguishable from a real
+//      read landing on the anchor by chance, so the cheat-flag only
+//      fires when there are three reads.
+//
+// `accept` is the default — anything else routes to a rejection in
+// the verifier.
+
+import { describe, expect, it } from "vitest";
+import { checkAnchor } from "./anchor-guard";
+
+describe("checkAnchor", () => {
+  describe("accept", () => {
+    it("accepts when median matches anchor exactly and reads vary", () => {
+      // Median is 19:30, anchor is 19:30. Individual reads diverge
+      // from the anchor (so it's not a cheat). Real-world: three
+      // independent reads of the same dial happened to land on the
+      // anchor MM:SS — fine, just lucky.
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 30 },
+        anchorMmSs: { m: 19, s: 30 },
+        individualReads: [
+          { m: 19, s: 28 },
+          { m: 19, s: 30 },
+          { m: 19, s: 32 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("accepts when median is within 60s of anchor", () => {
+      // dial 19:30, anchor 19:00 → +30s
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 30 },
+        anchorMmSs: { m: 19, s: 0 },
+        individualReads: [
+          { m: 19, s: 28 },
+          { m: 19, s: 30 },
+          { m: 19, s: 32 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("accepts at the +60s boundary (boundary is inclusive)", () => {
+      // dial 20:00, anchor 19:00 → +60s
+      const result = checkAnchor({
+        medianMmSs: { m: 20, s: 0 },
+        anchorMmSs: { m: 19, s: 0 },
+        individualReads: [
+          { m: 19, s: 58 },
+          { m: 20, s: 0 },
+          { m: 20, s: 2 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("accepts at the -60s boundary (boundary is inclusive)", () => {
+      // dial 19:00, anchor 20:00 → -60s
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 0 },
+        anchorMmSs: { m: 20, s: 0 },
+        individualReads: [
+          { m: 18, s: 58 },
+          { m: 19, s: 0 },
+          { m: 19, s: 2 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("accepts when only 2 reads are present (cheat-flag does not fire on 2)", () => {
+      // 2 of 2 reads byte-identical to anchor — by PRD design we
+      // don't flag this because it's statistically indistinguishable
+      // from two real reads coincidentally hitting the anchor.
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 30 },
+        anchorMmSs: { m: 19, s: 30 },
+        individualReads: [
+          { m: 19, s: 30 },
+          { m: 19, s: 30 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("accepts wrap-around proximity (dial 59:30, anchor 0:30 → -60s)", () => {
+      // The MM:SS circle wraps; the shortest distance between 59:30
+      // and 0:30 is -60s, NOT +3540s.
+      const result = checkAnchor({
+        medianMmSs: { m: 59, s: 30 },
+        anchorMmSs: { m: 0, s: 30 },
+        individualReads: [
+          { m: 59, s: 28 },
+          { m: 59, s: 30 },
+          { m: 59, s: 32 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+  });
+
+  describe("reject_anchor_disagreement", () => {
+    it("rejects when median is +90s ahead of anchor", () => {
+      // dial 20:30, anchor 19:00 → +90s, > 60s threshold
+      const result = checkAnchor({
+        medianMmSs: { m: 20, s: 30 },
+        anchorMmSs: { m: 19, s: 0 },
+        individualReads: [
+          { m: 20, s: 28 },
+          { m: 20, s: 30 },
+          { m: 20, s: 32 },
+        ],
+      });
+      expect(result.kind).toBe("reject_anchor_disagreement");
+      if (result.kind === "reject_anchor_disagreement") {
+        expect(result.delta_seconds).toBe(90);
+      }
+    });
+
+    it("rejects when median is -90s behind anchor", () => {
+      // dial 19:00, anchor 20:30 → -90s, |delta| > 60s
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 0 },
+        anchorMmSs: { m: 20, s: 30 },
+        individualReads: [
+          { m: 18, s: 58 },
+          { m: 19, s: 0 },
+          { m: 19, s: 2 },
+        ],
+      });
+      expect(result.kind).toBe("reject_anchor_disagreement");
+      if (result.kind === "reject_anchor_disagreement") {
+        expect(result.delta_seconds).toBe(-90);
+      }
+    });
+
+    it("rejects with wrap-aware delta (dial 30:00, anchor 0:00 → +1800s, picks shorter way → -1800s)", () => {
+      // 30:00 vs 0:00 — half the circle. Shortest signed distance
+      // could be either +1800 or -1800; convention from
+      // _signed_error_seconds: pick the one that is ≤ 1800. We
+      // settle on +1800 (anything 1800+ flips). |1800| > 60 → reject.
+      const result = checkAnchor({
+        medianMmSs: { m: 30, s: 0 },
+        anchorMmSs: { m: 0, s: 0 },
+        individualReads: [
+          { m: 30, s: 0 },
+          { m: 30, s: 0 },
+          { m: 30, s: 0 },
+        ],
+      });
+      expect(result.kind).toBe("reject_anchor_disagreement");
+    });
+
+    it("rejects just above the +60s threshold (61s diverged → reject)", () => {
+      const result = checkAnchor({
+        medianMmSs: { m: 20, s: 1 },
+        anchorMmSs: { m: 19, s: 0 },
+        individualReads: [
+          { m: 20, s: 0 },
+          { m: 20, s: 1 },
+          { m: 20, s: 2 },
+        ],
+      });
+      expect(result.kind).toBe("reject_anchor_disagreement");
+      if (result.kind === "reject_anchor_disagreement") {
+        expect(result.delta_seconds).toBe(61);
+      }
+    });
+  });
+
+  describe("flag_suspicious_anchor_echo", () => {
+    it("flags when ALL THREE reads are byte-identical to the anchor", () => {
+      // Classic Claude cheat: model echoes the anchor as its answer
+      // three times in a row. Probability of three independent dial
+      // reads coincidentally landing on exactly the anchor MM:SS is
+      // ~(1/3600)^2 ≈ 7e-8. Flag and reject.
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 24 },
+        anchorMmSs: { m: 19, s: 24 },
+        individualReads: [
+          { m: 19, s: 24 },
+          { m: 19, s: 24 },
+          { m: 19, s: 24 },
+        ],
+      });
+      expect(result.kind).toBe("flag_suspicious_anchor_echo");
+    });
+
+    it("does NOT flag when only 2 reads match the anchor (third diverges)", () => {
+      // The cheat-flag heuristic requires all three to be identical
+      // to the anchor. If even one read diverges, we treat it as a
+      // real read pattern and rely on the disagreement check.
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 24 },
+        anchorMmSs: { m: 19, s: 24 },
+        individualReads: [
+          { m: 19, s: 24 },
+          { m: 19, s: 24 },
+          { m: 19, s: 30 }, // differs
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+
+    it("does NOT flag with only 2 reads even if both match the anchor", () => {
+      // PRD design: cheat-flag requires three reads. Two reads
+      // matching the anchor is statistically plausible.
+      const result = checkAnchor({
+        medianMmSs: { m: 19, s: 24 },
+        anchorMmSs: { m: 19, s: 24 },
+        individualReads: [
+          { m: 19, s: 24 },
+          { m: 19, s: 24 },
+        ],
+      });
+      expect(result.kind).toBe("accept");
+    });
+  });
+});

--- a/src/domain/dial-reader-vlm/anchor-guard.ts
+++ b/src/domain/dial-reader-vlm/anchor-guard.ts
@@ -1,0 +1,115 @@
+// Anchor-disagreement guard.
+//
+// Slice #5 of PRD #99 (issue #104). The reader fans out three
+// parallel VLM calls, computes a median MM:SS, and then asks this
+// module: "Is the median trustworthy given the anchor and the
+// individual read pattern?"
+//
+// Two checks:
+//
+//   1. **anchor disagreement** — the median MM:SS diverges from the
+//      EXIF anchor MM:SS by more than 60 s on the wrap-aware
+//      [0, 3600) MM:SS circle. A real watch in a tracked session is
+//      bounded to a few minutes of drift; > 60 s on a single capture
+//      means either the model misread the dial, or the anchor is
+//      wrong. Either way the reading isn't safe to write.
+//
+//      The 60 s threshold is PRD-specified (issue #104 acceptance
+//      criteria). The wrap-aware delta math mirrors
+//      `scripts/vlm-bakeoff/bakeoff.py::_signed_error_seconds` —
+//      mapped down from the 12-hour 43200 s circle to the MM:SS-only
+//      3600 s circle. Picking the shorter way around the circle
+//      means a dial straddling the minute boundary (dial 59:58 vs
+//      anchor 0:02) reads as -4 s rather than +3596 s.
+//
+//   2. **anchor echo (cheat-flag)** — all three individual reads are
+//      byte-identical to the anchor MM:SS. The bake-off saw
+//      Claude-style models do this: they ignore the dial entirely
+//      and just echo the anchor we passed in the prompt as a sanity
+//      check. With three independent reads the joint probability of
+//      coincidentally hitting exactly the anchor MM:SS three times
+//      is ~(1/3600)² ≈ 7e-8, so we treat this pattern as a guaranteed
+//      cheat and flag.
+//
+//      With only two reads (the median-of-2 fallback when one read
+//      is unparseable) we do NOT fire the cheat-flag — two reads
+//      matching the anchor isn't statistically distinguishable from
+//      two real reads coincidentally landing on it.
+//
+// Pure function. No env, no I/O. The verifier is the only caller.
+
+/**
+ * Outcome of the guard. The verifier maps each variant to an error
+ * code (or, for `accept`, lets the reading through to deviation
+ * computation).
+ */
+export type GuardResult =
+  | { kind: "accept" }
+  | { kind: "reject_anchor_disagreement"; delta_seconds: number }
+  | { kind: "flag_suspicious_anchor_echo" };
+
+/** MM:SS pair — m ∈ [0, 59], s ∈ [0, 59]. */
+interface MmSs {
+  m: number;
+  s: number;
+}
+
+/** Inputs to the guard. */
+export interface CheckAnchorInput {
+  medianMmSs: MmSs;
+  anchorMmSs: MmSs;
+  individualReads: MmSs[];
+}
+
+const SECONDS_PER_HOUR = 3600;
+const HALF_HOUR_SECONDS = 1800;
+
+/** Signed delta in seconds, wrapped into [-1800, +1800] on the MM:SS circle. */
+function signedMmSsDelta(a: MmSs, b: MmSs): number {
+  const aTotal = a.m * 60 + a.s;
+  const bTotal = b.m * 60 + b.s;
+  const diff =
+    (((aTotal - bTotal) % SECONDS_PER_HOUR) + SECONDS_PER_HOUR) % SECONDS_PER_HOUR;
+  // Pick the shorter way around the circle. > 1800 wraps the other
+  // direction; the half-circle (=1800) stays positive so a dial 30
+  // minutes off the anchor reports as +1800 (rejected anyway).
+  return diff > HALF_HOUR_SECONDS ? diff - SECONDS_PER_HOUR : diff;
+}
+
+/** True iff `a` and `b` are byte-identical MM:SS pairs. */
+function mmSsEqual(a: MmSs, b: MmSs): boolean {
+  return a.m === b.m && a.s === b.s;
+}
+
+/**
+ * Run the guard. Pure; never throws.
+ *
+ * Order of checks:
+ *   1. anchor-echo cheat-flag (only when there are ≥ 3 reads)
+ *   2. anchor-disagreement (> 60 s on the wrap-aware MM:SS circle)
+ *   3. accept
+ *
+ * The cheat-flag fires before the disagreement check because an
+ * all-anchor-echo set of reads is, by definition, in agreement with
+ * the anchor — the disagreement check would let it through. We want
+ * to surface "this is suspicious" instead of "this is fine".
+ */
+export function checkAnchor(input: CheckAnchorInput): GuardResult {
+  const { medianMmSs, anchorMmSs, individualReads } = input;
+
+  // Cheat-flag: three reads, all identical to the anchor.
+  if (
+    individualReads.length >= 3 &&
+    individualReads.every((r) => mmSsEqual(r, anchorMmSs))
+  ) {
+    return { kind: "flag_suspicious_anchor_echo" };
+  }
+
+  // Disagreement: |median - anchor| > 60s on the wrap-aware circle.
+  const delta = signedMmSsDelta(medianMmSs, anchorMmSs);
+  if (Math.abs(delta) > 60) {
+    return { kind: "reject_anchor_disagreement", delta_seconds: delta };
+  }
+
+  return { kind: "accept" };
+}

--- a/src/domain/dial-reader-vlm/reader.test.ts
+++ b/src/domain/dial-reader-vlm/reader.test.ts
@@ -1,9 +1,12 @@
-// Reader-level tests for the single-VLM-call path.
+// Reader-level tests for the median-of-3 + anchor-guard pipeline
+// (slice #5 of PRD #99 — issue #104).
 //
 // CI MUST NOT make real AI Gateway calls. All tests use a
 // hand-rolled mock `AiClient` that returns canned responses.
-// Real-API integration testing happens in slice #4 (the
-// tracer bullet).
+// Real-API integration testing happens in the slice-#4 tracer
+// bullet (`tests/integration/readings.verified.test.ts`) — that
+// file uses `__setTestReadDial` to short-circuit the reader entirely
+// and is unaffected by this slice.
 
 import { describe, expect, it } from "vitest";
 import { readDial } from "./reader";
@@ -17,29 +20,42 @@ import type { ReadDialInput } from "./types";
 const FAKE_IMAGE = new ArrayBuffer(8); // 8 bytes is fine — the mock never reads it
 const FAKE_INPUT: ReadDialInput = {
   croppedImage: FAKE_IMAGE,
+  // Anchor at 19:24 — close to "10:19:34" so the dial reads land
+  // within the 60s anchor-guard threshold by default.
   exifAnchor: { h: 10, m: 19, s: 24 },
   runId: "run-1",
 };
 
 interface MockState {
-  /** Last request seen by the mock — for prompt assertions. */
-  lastRequest: ChatCompletionRequest | null;
+  /** Every request the mock has seen, in call order. */
+  requests: ChatCompletionRequest[];
   /**
-   * Function that produces the canned response. Tests can swap in
-   * different behaviours (success, gibberish, throw) per case.
+   * Function that produces the canned response. Called once per
+   * parallel call. Tests can swap in a counter-based or
+   * always-the-same responder.
    */
-  respond: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>;
+  respond: (
+    req: ChatCompletionRequest,
+    callIndex: number,
+  ) => Promise<ChatCompletionResponse>;
 }
 
+/**
+ * Build a mock AI client. The default responder returns the same
+ * response for every call. Tests override `state.respond` to model
+ * per-call divergence (mixed parsing failures, transport throws,
+ * etc.).
+ */
 function makeMockClient(): { client: AiClient; state: MockState } {
   const state: MockState = {
-    lastRequest: null,
+    requests: [],
     respond: () => Promise.resolve(textResponse("10:19:34")),
   };
   const client: AiClient = {
     runChatCompletion(req) {
-      state.lastRequest = req;
-      return state.respond(req);
+      const idx = state.requests.length;
+      state.requests.push(req);
+      return state.respond(req, idx);
     },
   };
   return { client, state };
@@ -55,55 +71,34 @@ function textResponse(
   };
 }
 
-describe("readDial", () => {
-  describe("happy path", () => {
-    it("returns success with parsed MM:SS when the model emits HH:MM:SS", async () => {
-      const { client } = makeMockClient();
-      const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("success");
-      if (result.kind === "success") {
-        // The hour (10) is dropped — the verifier owns the hour.
-        expect(result.mm_ss).toEqual({ m: 19, s: 34 });
-        expect(result.raw_response).toBe("10:19:34");
-      }
-    });
+/**
+ * Build a responder that returns one canned content string per call,
+ * cycling at the end of the list. Tests pass a list shorter than the
+ * fan-out only when they intentionally want the wrap.
+ */
+function fixedResponder(contents: string[]): MockState["respond"] {
+  return (_req, idx) => Promise.resolve(textResponse(contents[idx % contents.length]!));
+}
 
-    it("propagates token usage when the model reports it", async () => {
+describe("readDial — median-of-3", () => {
+  describe("happy path (3 of 3 successes within anchor)", () => {
+    it("returns success with the median MM:SS when all 3 reads succeed", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () =>
-        Promise.resolve(textResponse("10:19:34", { in: 1234, out: 56 }));
-      const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("success");
-      if (result.kind === "success") {
-        expect(result.tokens_in).toBe(1234);
-        expect(result.tokens_out).toBe(56);
-      }
-    });
-
-    it("tolerates surrounding prose around the HH:MM:SS", async () => {
-      const { client, state } = makeMockClient();
-      state.respond = () =>
-        Promise.resolve(textResponse("Final answer: 10:19:34. Confidence: high."));
+      // Three reads at 19:32, 19:34, 19:36 → median = 19:34.
+      state.respond = fixedResponder(["10:19:32", "10:19:34", "10:19:36"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
       expect(result.kind).toBe("success");
       if (result.kind === "success") {
         expect(result.mm_ss).toEqual({ m: 19, s: 34 });
+        expect(result.raw_responses).toEqual(["10:19:32", "10:19:34", "10:19:36"]);
       }
+      expect(state.requests).toHaveLength(3);
     });
 
-    it("handles content returned as an array of parts (compat layer variation)", async () => {
+    it("computes the median by sorting (unsorted reads still produce the middle value)", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () =>
-        Promise.resolve({
-          choices: [
-            {
-              message: {
-                role: "assistant",
-                content: [{ type: "text", text: "10:19:34" }],
-              },
-            },
-          ],
-        });
+      // 19:36, 19:32, 19:34 unsorted → sorted = 32, 34, 36 → median 19:34
+      state.respond = fixedResponder(["10:19:36", "10:19:32", "10:19:34"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
       expect(result.kind).toBe("success");
       if (result.kind === "success") {
@@ -111,65 +106,119 @@ describe("readDial", () => {
       }
     });
 
-    it("treats a content-array with no text parts as unparseable", async () => {
-      // Defensive — the OpenAI compat layer doesn't emit pure-image
-      // assistant content in our flow, but be safe in case a future
-      // model does. We expect `unparseable`, not a crash.
+    it("sums token usage across all 3 successful calls", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () =>
-        Promise.resolve({
-          choices: [
-            {
-              message: {
-                role: "assistant",
-                content: [{ type: "image_url", image_url: { url: "data:..." } }],
-              },
-            },
-          ],
-        });
+      let i = 0;
+      state.respond = () => {
+        const tokens = [
+          { in: 100, out: 5 },
+          { in: 110, out: 6 },
+          { in: 120, out: 7 },
+        ];
+        const t = tokens[i++]!;
+        return Promise.resolve(textResponse("10:19:34", t));
+      };
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("unparseable");
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.tokens_in_total).toBe(330);
+        expect(result.tokens_out_total).toBe(18);
+      }
+    });
+
+    it("omits token totals when the model never reports usage", async () => {
+      const { client, state } = makeMockClient();
+      state.respond = fixedResponder(["10:19:34", "10:19:34", "10:19:34"]);
+      const result = await readDial(FAKE_INPUT, { ai: client });
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.tokens_in_total).toBeUndefined();
+        expect(result.tokens_out_total).toBeUndefined();
+      }
     });
   });
 
-  describe("unparseable", () => {
-    it("returns unparseable when the model emits gibberish", async () => {
+  describe("median-of-2 fallback (2 of 3 successes)", () => {
+    it("averages the 2 parsed reads when 1 returns gibberish", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () => Promise.resolve(textResponse("I cannot read this dial"));
+      // 19:30 + 19:36 → average 19:33; third call gibberish.
+      state.respond = fixedResponder(["10:19:30", "I cannot read this", "10:19:36"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("unparseable");
-      if (result.kind === "unparseable") {
-        expect(result.raw_response).toBe("I cannot read this dial");
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.mm_ss).toEqual({ m: 19, s: 33 });
       }
     });
 
-    it("returns unparseable when the model emits an out-of-range time", async () => {
+    it("rounds the 2-read average (19:30 + 19:33 → 19:32)", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () => Promise.resolve(textResponse("25:99:99"));
+      // 19:30 (1770s) + 19:33 (1773s) → avg 1771.5 → round 1772 → 19:32
+      state.respond = fixedResponder(["10:19:30", "huh?", "10:19:33"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("unparseable");
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.mm_ss).toEqual({ m: 19, s: 32 });
+      }
+    });
+  });
+
+  describe("rejection — unparseable_majority (≤ 1 of 3 successes)", () => {
+    it("returns rejection: unparseable_majority when 2 of 3 are gibberish", async () => {
+      const { client, state } = makeMockClient();
+      state.respond = fixedResponder(["10:19:34", "I cannot read", "still cannot"]);
+      const result = await readDial(FAKE_INPUT, { ai: client });
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("unparseable_majority");
+      }
+    });
+  });
+
+  describe("rejection — all_runs_failed (0 of 3 successes, mixed)", () => {
+    it("returns rejection: all_runs_failed when all 3 reads are gibberish", async () => {
+      const { client, state } = makeMockClient();
+      state.respond = fixedResponder(["nope", "no idea", "I refuse"]);
+      const result = await readDial(FAKE_INPUT, { ai: client });
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("all_runs_failed");
+      }
     });
 
-    it("returns unparseable when content is null/empty", async () => {
+    it("treats null/empty content as a parse failure and reaches all_runs_failed", async () => {
       const { client, state } = makeMockClient();
       state.respond = () =>
         Promise.resolve({
           choices: [{ message: { role: "assistant", content: null } }],
         });
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("unparseable");
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("all_runs_failed");
+      }
     });
 
-    it("returns unparseable when the response has no choices", async () => {
+    it("returns all_runs_failed when 1 call throws but 2 are unparseable (mixed)", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () => Promise.resolve({ choices: [] });
+      let i = 0;
+      state.respond = () => {
+        const idx = i++;
+        if (idx === 0) {
+          return Promise.reject(new Error("AI Gateway 503"));
+        }
+        return Promise.resolve(textResponse("nope"));
+      };
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("unparseable");
+      // 0 successes, but not ALL transport failures → all_runs_failed.
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("all_runs_failed");
+      }
     });
   });
 
-  describe("transport error", () => {
-    it("returns transport_error when the AI client throws", async () => {
+  describe("transport_error (3 of 3 throw)", () => {
+    it("returns transport_error when all 3 calls throw", async () => {
       const { client, state } = makeMockClient();
       state.respond = () => Promise.reject(new Error("AI Gateway 503"));
       const result = await readDial(FAKE_INPUT, { ai: client });
@@ -188,98 +237,124 @@ describe("readDial", () => {
         expect(result.message).toContain("just a string");
       }
     });
+  });
 
-    it("JSON-stringifies non-Error non-string throws", async () => {
+  describe("rejection — anchor_disagreement", () => {
+    it("rejects when median MM:SS diverges > 60s from anchor", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () => Promise.reject({ code: 503, msg: "gateway down" });
+      // Anchor is 19:24. Median of 21:00, 21:00, 21:00 = 21:00 →
+      // 21:00 - 19:24 = +96s, > 60s → reject.
+      state.respond = fixedResponder(["10:21:00", "10:21:00", "10:21:00"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("transport_error");
-      if (result.kind === "transport_error") {
-        expect(result.message).toContain("503");
-        expect(result.message).toContain("gateway down");
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("anchor_disagreement");
+        expect(result.details?.delta_seconds).toBe(96);
       }
     });
 
-    it("falls back to String() when JSON.stringify throws", async () => {
-      // Build a circular object that JSON.stringify refuses.
-      const circular: { self?: unknown } = {};
-      circular.self = circular;
+    it("rejects 90s ahead even when reads are tight", async () => {
       const { client, state } = makeMockClient();
-      state.respond = () => Promise.reject(circular);
+      // Median 20:54 vs anchor 19:24 → +90s
+      state.respond = fixedResponder(["10:20:53", "10:20:54", "10:20:55"]);
       const result = await readDial(FAKE_INPUT, { ai: client });
-      expect(result.kind).toBe("transport_error");
-      if (result.kind === "transport_error") {
-        // String({}) → "[object Object]" — we don't care about the
-        // exact string, just that we got a non-empty fallback.
-        expect(result.message.length).toBeGreaterThan(0);
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("anchor_disagreement");
       }
     });
   });
 
-  describe("request shape", () => {
-    it("sends the prompt that contains the anchor and chain-of-thought instructions", async () => {
+  describe("rejection — anchor_echo_suspicious", () => {
+    it("flags when ALL THREE reads are byte-identical to the anchor MM:SS", async () => {
       const { client, state } = makeMockClient();
-      await readDial(FAKE_INPUT, { ai: client });
-      expect(state.lastRequest).not.toBeNull();
-      const req = state.lastRequest!;
-
-      const userMsg = req.messages.find((m) => m.role === "user");
-      expect(userMsg).toBeDefined();
-      const textParts = userMsg!.content.filter(
-        (p): p is { type: "text"; text: string } => p.type === "text",
-      );
-      expect(textParts.length).toBeGreaterThan(0);
-      const promptText = textParts.map((p) => p.text).join("\n");
-
-      // The anchor is included verbatim.
-      expect(promptText).toContain("10:19:24");
-      // Chain-of-thought hand-identification instructions are present.
-      expect(promptText).toContain("IDENTIFY THE THREE HANDS");
-      expect(promptText).toContain("DO NOT just echo");
+      // Anchor is 19:24. Three reads echo it back exactly.
+      state.respond = fixedResponder(["10:19:24", "10:19:24", "10:19:24"]);
+      const result = await readDial(FAKE_INPUT, { ai: client });
+      expect(result.kind).toBe("rejection");
+      if (result.kind === "rejection") {
+        expect(result.reason).toBe("anchor_echo_suspicious");
+      }
     });
 
-    it("attaches the cropped image as an OpenAI-compat data: URL", async () => {
+    it("does NOT flag when only 2 of 3 reads echo the anchor (third diverges)", async () => {
       const { client, state } = makeMockClient();
-      // Use a buffer with recognisable bytes so we can verify the
-      // base64 round-trip didn't mangle the image.
+      // Two echo the anchor, one diverges by a few seconds. The
+      // median still lands close to the anchor → success.
+      state.respond = fixedResponder(["10:19:24", "10:19:24", "10:19:30"]);
+      const result = await readDial(FAKE_INPUT, { ai: client });
+      expect(result.kind).toBe("success");
+    });
+  });
+
+  describe("request shape", () => {
+    it("sends the prompt that contains the anchor and chain-of-thought instructions to all 3 calls", async () => {
+      const { client, state } = makeMockClient();
+      await readDial(FAKE_INPUT, { ai: client });
+      expect(state.requests).toHaveLength(3);
+      for (const req of state.requests) {
+        const userMsg = req.messages.find((m) => m.role === "user");
+        expect(userMsg).toBeDefined();
+        const textParts = userMsg!.content.filter(
+          (p): p is { type: "text"; text: string } => p.type === "text",
+        );
+        const promptText = textParts.map((p) => p.text).join("\n");
+        expect(promptText).toContain("10:19:24");
+        expect(promptText).toContain("IDENTIFY THE THREE HANDS");
+        expect(promptText).toContain("DO NOT just echo");
+      }
+    });
+
+    it("attaches the same cropped image as an OpenAI-compat data: URL on every call", async () => {
+      const { client, state } = makeMockClient();
       const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x12, 0x34]);
       const input: ReadDialInput = { ...FAKE_INPUT, croppedImage: bytes.buffer };
       await readDial(input, { ai: client });
-
-      const req = state.lastRequest!;
-      const userMsg = req.messages.find((m) => m.role === "user")!;
-      const imagePart = userMsg.content.find(
-        (p): p is { type: "image_url"; image_url: { url: string } } =>
-          p.type === "image_url",
-      );
-      expect(imagePart).toBeDefined();
-      expect(imagePart!.image_url.url.startsWith("data:image/jpeg;base64,")).toBe(true);
-      // The base64 segment after the prefix must decode back to the
-      // original bytes.
-      const b64 = imagePart!.image_url.url.replace(/^data:image\/jpeg;base64,/, "");
-      const decoded = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
-      expect(Array.from(decoded)).toEqual(Array.from(bytes));
+      expect(state.requests).toHaveLength(3);
+      for (const req of state.requests) {
+        const userMsg = req.messages.find((m) => m.role === "user")!;
+        const imagePart = userMsg.content.find(
+          (p): p is { type: "image_url"; image_url: { url: string } } =>
+            p.type === "image_url",
+        );
+        expect(imagePart).toBeDefined();
+        expect(imagePart!.image_url.url.startsWith("data:image/jpeg;base64,")).toBe(true);
+        const b64 = imagePart!.image_url.url.replace(/^data:image\/jpeg;base64,/, "");
+        const decoded = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+        expect(Array.from(decoded)).toEqual(Array.from(bytes));
+      }
     });
 
-    it("requests model openai/gpt-5.2 with reasoning_effort=low and 4000 tokens", async () => {
+    it("requests model openai/gpt-5.2 with reasoning_effort=low and 4000 tokens (all calls)", async () => {
       const { client, state } = makeMockClient();
       await readDial(FAKE_INPUT, { ai: client });
-      const req = state.lastRequest!;
-      expect(req.model).toBe("openai/gpt-5.2");
-      expect(req.reasoning_effort).toBe("low");
-      expect(req.max_completion_tokens).toBe(4000);
+      for (const req of state.requests) {
+        expect(req.model).toBe("openai/gpt-5.2");
+        expect(req.reasoning_effort).toBe("low");
+        expect(req.max_completion_tokens).toBe(4000);
+      }
     });
 
-    it("forwards the gateway id from deps", async () => {
+    it("forwards the gateway id from deps to all 3 calls", async () => {
       const { client, state } = makeMockClient();
       await readDial(FAKE_INPUT, { ai: client, gatewayId: "ratedwatch-vlm-test" });
-      expect(state.lastRequest!.gateway_id).toBe("ratedwatch-vlm-test");
+      for (const req of state.requests) {
+        expect(req.gateway_id).toBe("ratedwatch-vlm-test");
+      }
     });
 
     it("defaults the gateway id to dial-reader-bakeoff when deps don't override", async () => {
       const { client, state } = makeMockClient();
       await readDial(FAKE_INPUT, { ai: client });
-      expect(state.lastRequest!.gateway_id).toBe("dial-reader-bakeoff");
+      for (const req of state.requests) {
+        expect(req.gateway_id).toBe("dial-reader-bakeoff");
+      }
+    });
+
+    it("fans out exactly 3 parallel calls", async () => {
+      const { client, state } = makeMockClient();
+      await readDial(FAKE_INPUT, { ai: client });
+      expect(state.requests).toHaveLength(3);
     });
   });
 });

--- a/src/domain/dial-reader-vlm/reader.ts
+++ b/src/domain/dial-reader-vlm/reader.ts
@@ -1,25 +1,43 @@
-// Worker-side VLM dial reader — single-call entry point.
+// Worker-side VLM dial reader — median-of-3 + anchor-guard pipeline.
 //
-// Slice #3 of PRD #99 (issue #102). Takes a cropped 768×768 dial
-// JPEG + an EXIF anchor, runs ONE chat-completion call against
-// GPT-5.2 via Cloudflare AI Gateway, and returns a structured
-// `DialReadResult`.
+// Slice #5 of PRD #99 (issue #104) replaces the slice-#3 single-call
+// reader with three parallel chat-completion calls, a median MM:SS
+// computation, and the anchor-disagreement guard from
+// `./anchor-guard.ts`.
 //
-// Median-of-3 and the anchor-disagreement guard are NOT implemented
-// here — they land in slice #5. This module is intentionally
-// minimal so the tracer-bullet integration in slice #4 can wire it
-// up without dragging in the median pipeline.
+// Pipeline:
 //
-// Production wiring (slice #4) will:
-//   1. Call the dial cropper from slice #2 to get a 768×768 JPEG.
-//   2. Call `readDial({ croppedImage, exifAnchor, runId },
-//                     { ai: createWorkersAiClient(env.AI),
-//                       gatewayId: env.AI_GATEWAY_ID })`.
-//   3. Branch on the result.kind to decide what to write to D1 /
-//      surface to the user.
+//   1. Build a single prompt + image once.
+//   2. Fan out THREE concurrent `runChatCompletion` calls with the
+//      same request body. Same image, same prompt, same anchor — the
+//      diversity comes from the model's stochastic decoding.
+//   3. For each result: parse via `./parse.ts`. Successes go into a
+//      pool of `{ m, s }` reads; failures (transport throws, empty
+//      content, gibberish) are tracked separately.
+//   4. Compute the median over the parsed reads:
+//        * 3 of 3 parsed → sort by seconds-within-the-hour and take
+//          index [1].
+//        * 2 of 3 parsed → average them (rounded). Two values are
+//          their own median.
+//        * 1 of 3 parsed → return rejection: unparseable_majority.
+//        * 0 of 3 parsed → if all 3 threw → transport_error;
+//                          otherwise → rejection: all_runs_failed.
+//   5. Pass the median + anchor + individual reads through
+//      `checkAnchor`. The guard's outcome maps 1-to-1 onto the
+//      reader's result variants:
+//        * accept                       → success
+//        * reject_anchor_disagreement   → rejection (anchor_disagreement)
+//        * flag_suspicious_anchor_echo  → rejection (anchor_echo_suspicious)
+//
+// Production wiring (the route handler in `src/server/routes/readings.ts`)
+// calls this once per verified-reading attempt. Three parallel calls
+// roughly triples the upstream cost per attempt — accepted; the bake-off
+// data shows median-of-3 closes the gap from "78 % of individual reads
+// within ±5 s" to "5/6 fixture medians within ±5 s".
 
 import { buildPrompt } from "./prompt";
-import { parseHmsResponse } from "./parse";
+import { parseHmsResponse, type ParsedHms } from "./parse";
+import { checkAnchor } from "./anchor-guard";
 import type {
   AiClient,
   ChatCompletionRequest,
@@ -48,6 +66,9 @@ const MODEL = "openai/gpt-5.2";
  * hidden reasoning before emitting any visible output.
  */
 const MAX_COMPLETION_TOKENS = 4000;
+
+/** How many parallel calls to fan out per dial read. */
+const PARALLEL_CALLS = 3;
 
 /** Inputs the reader needs from the host environment. */
 export interface ReadDialDeps {
@@ -87,10 +108,96 @@ export function __setTestReadDial(fn: ReadDialFn | null): void {
 }
 
 /**
- * Run a single VLM dial-read.
+ * Per-call outcome inside the median-of-3 fan-out. We retain the
+ * full failure context so the orchestrator can decide between
+ * `unparseable_majority`, `all_runs_failed`, and `transport_error`.
+ */
+type ParallelOutcome =
+  | {
+      ok: true;
+      parsed: ParsedHms;
+      rawContent: string;
+      tokensIn?: number;
+      tokensOut?: number;
+    }
+  | { ok: false; reason: "transport"; message: string }
+  | { ok: false; reason: "unparseable"; rawContent: string };
+
+/**
+ * Run a single VLM chat-completion call and lift the outcome into a
+ * `ParallelOutcome`. Pure helper; never throws.
+ */
+async function runOne(
+  ai: AiClient,
+  req: ChatCompletionRequest,
+): Promise<ParallelOutcome> {
+  let response: ChatCompletionResponse;
+  try {
+    response = await ai.runChatCompletion(req);
+  } catch (err) {
+    return { ok: false, reason: "transport", message: errorMessage(err) };
+  }
+
+  const rawContent = extractContent(response);
+  if (rawContent === null) {
+    return { ok: false, reason: "unparseable", rawContent: "" };
+  }
+
+  const parsed = parseHmsResponse(rawContent);
+  if (!parsed) {
+    return { ok: false, reason: "unparseable", rawContent };
+  }
+
+  const usage = response.usage ?? {};
+  const out: ParallelOutcome = { ok: true, parsed, rawContent };
+  if (typeof usage.prompt_tokens === "number") {
+    out.tokensIn = usage.prompt_tokens;
+  }
+  if (typeof usage.completion_tokens === "number") {
+    out.tokensOut = usage.completion_tokens;
+  }
+  return out;
+}
+
+/**
+ * Compute the median MM:SS across 1-3 parsed reads. Returns `null`
+ * for an empty input — the caller has already decided that's a
+ * rejection by the time it reaches this helper.
  *
- * Always resolves; never throws. Transport / network failures
- * surface as `{ kind: "transport_error" }`.
+ * For 3 reads: convert each to seconds-within-the-hour, sort, take
+ * the middle. For 2 reads: average them (rounded). For 1 read:
+ * the call-site never invokes this helper with a single read — the
+ * orchestrator routes straight to `unparseable_majority` instead —
+ * so this branch is only here for completeness.
+ */
+function medianMmSs(reads: ParsedHms[]): { m: number; s: number } | null {
+  if (reads.length === 0) {
+    return null;
+  }
+  const totals = reads.map((r) => r.m * 60 + r.s);
+  totals.sort((a, b) => a - b);
+  let median: number;
+  if (totals.length === 3) {
+    median = totals[1]!;
+  } else if (totals.length === 2) {
+    // `(a + b) / 2` rounded. With integer inputs in [0, 3599] this
+    // is safe — no overflow.
+    median = Math.round((totals[0]! + totals[1]!) / 2);
+  } else {
+    // length === 1
+    median = totals[0]!;
+  }
+  return { m: Math.floor(median / 60), s: median % 60 };
+}
+
+/**
+ * Run a verified dial-read.
+ *
+ * Always resolves; never throws. Transport / network failures (when
+ * ALL parallel calls fail at the network layer) surface as
+ * `{ kind: "transport_error" }`. Mixed failures (some transport, some
+ * unparseable) collapse into `unparseable_majority` or
+ * `all_runs_failed` per the median rules above.
  */
 export async function readDial(
   input: ReadDialInput,
@@ -118,42 +225,121 @@ export async function readDial(
     gateway_id: deps.gatewayId ?? DEFAULT_GATEWAY_ID,
   };
 
-  let response: ChatCompletionResponse;
-  try {
-    response = await deps.ai.runChatCompletion(req);
-  } catch (err) {
+  // Fan out PARALLEL_CALLS concurrent calls. We use Promise.all
+  // (not Promise.allSettled) because `runOne` already lifts every
+  // failure into a structured `ParallelOutcome` — there are no
+  // unhandled rejections to worry about.
+  const calls: Array<Promise<ParallelOutcome>> = [];
+  for (let i = 0; i < PARALLEL_CALLS; i++) {
+    calls.push(runOne(deps.ai, req));
+  }
+  const outcomes = await Promise.all(calls);
+
+  // Tally the outcome buckets.
+  const successes = outcomes.filter(
+    (o): o is Extract<ParallelOutcome, { ok: true }> => o.ok,
+  );
+  const transportFailures = outcomes.filter(
+    (o): o is Extract<ParallelOutcome, { ok: false; reason: "transport" }> =>
+      !o.ok && o.reason === "transport",
+  );
+  const unparseableFailures = outcomes.filter(
+    (o): o is Extract<ParallelOutcome, { ok: false; reason: "unparseable" }> =>
+      !o.ok && o.reason === "unparseable",
+  );
+
+  // 0 successes — pick between transport_error and all_runs_failed.
+  if (successes.length === 0) {
+    if (transportFailures.length === outcomes.length) {
+      // All three threw at the network layer. Surface the first
+      // message — they're typically the same anyway, and the caller
+      // doesn't get to retry per-call.
+      return {
+        kind: "transport_error",
+        message: transportFailures[0]!.message,
+      };
+    }
+    // Mixed (or all unparseable). Treat as a model-side refusal.
     return {
-      kind: "transport_error",
-      message: errorMessage(err),
+      kind: "rejection",
+      reason: "all_runs_failed",
     };
   }
 
-  const rawContent = extractContent(response);
-  if (rawContent === null) {
-    // The model returned an empty / null content. Treat as
-    // unparseable so the caller can surface a "please retake"
-    // message rather than a generic transport error.
-    return { kind: "unparseable", raw_response: "" };
+  // 1 of 3 successes — not enough signal for a median.
+  if (successes.length === 1) {
+    return {
+      kind: "rejection",
+      reason: "unparseable_majority",
+    };
   }
 
-  const parsed = parseHmsResponse(rawContent);
-  if (!parsed) {
-    return { kind: "unparseable", raw_response: rawContent };
+  // 2-or-3 successes — compute the median.
+  const parsedReads = successes.map((s) => s.parsed);
+  const median = medianMmSs(parsedReads);
+  if (!median) {
+    // Defensive: medianMmSs only returns null for an empty input,
+    // and we're in the ≥ 2 success branch. If we ever land here it
+    // means the helper changed shape — fail closed.
+    return {
+      kind: "rejection",
+      reason: "unparseable_majority",
+    };
   }
 
-  const usage = response.usage ?? {};
+  // Apply the anchor guard. The anchor's hour is irrelevant on the
+  // MM:SS axis — we only pass the m/s components.
+  const anchorMmSs = { m: input.exifAnchor.m, s: input.exifAnchor.s };
+  const guardResult = checkAnchor({
+    medianMmSs: median,
+    anchorMmSs,
+    individualReads: parsedReads.map((r) => ({ m: r.m, s: r.s })),
+  });
+
+  if (guardResult.kind === "reject_anchor_disagreement") {
+    return {
+      kind: "rejection",
+      reason: "anchor_disagreement",
+      details: { delta_seconds: guardResult.delta_seconds },
+    };
+  }
+  if (guardResult.kind === "flag_suspicious_anchor_echo") {
+    return {
+      kind: "rejection",
+      reason: "anchor_echo_suspicious",
+    };
+  }
+
+  // accept — build the success result.
+  const rawResponses = successes.map((s) => s.rawContent);
+  const tokensInTotal = sumDefined(successes.map((s) => s.tokensIn));
+  const tokensOutTotal = sumDefined(successes.map((s) => s.tokensOut));
+
   const result: DialReadResult = {
     kind: "success",
-    mm_ss: { m: parsed.m, s: parsed.s },
-    raw_response: rawContent,
+    mm_ss: median,
+    raw_responses: rawResponses,
   };
-  if (typeof usage.prompt_tokens === "number") {
-    result.tokens_in = usage.prompt_tokens;
+  if (tokensInTotal !== undefined) {
+    result.tokens_in_total = tokensInTotal;
   }
-  if (typeof usage.completion_tokens === "number") {
-    result.tokens_out = usage.completion_tokens;
+  if (tokensOutTotal !== undefined) {
+    result.tokens_out_total = tokensOutTotal;
   }
   return result;
+}
+
+/** Sum the defined numbers in an array; returns `undefined` if all are undefined. */
+function sumDefined(xs: Array<number | undefined>): number | undefined {
+  let total = 0;
+  let any = false;
+  for (const x of xs) {
+    if (typeof x === "number") {
+      total += x;
+      any = true;
+    }
+  }
+  return any ? total : undefined;
 }
 
 /**

--- a/src/domain/dial-reader-vlm/types.ts
+++ b/src/domain/dial-reader-vlm/types.ts
@@ -1,44 +1,61 @@
 // Worker-side VLM dial reader — public types.
 //
-// Slice #3 of PRD #99 (issue #102). Replaces the decommissioned Python
-// container reader with a single VLM call to GPT-5.2 via Cloudflare's
-// AI Gateway (unified billing).
+// Slice #3 of PRD #99 (issue #102) introduced the single-call shape
+// (`success | unparseable | transport_error`). Slice #5 (issue #104)
+// rebuilds the reader as a parallel median-of-3 pipeline guarded by
+// the anchor-disagreement check, and replaces the single `unparseable`
+// variant with a more granular `rejection` variant that distinguishes:
 //
-// This slice ships the bare minimum result shape: success, unparseable
-// model output, and transport error. The two anchor-related variants
-// (`anchor_disagreement`, `anchor_echo_suspicious`) are added in
-// slice #5 once the median-of-3 + anchor-guard pipeline is in place.
+//   * `anchor_disagreement`     — median MM:SS diverges > 60 s from
+//                                 the EXIF anchor on the wrap-aware
+//                                 MM:SS circle.
+//   * `anchor_echo_suspicious`  — all 3 reads byte-identical to the
+//                                 anchor (Claude-style cheat).
+//   * `unparseable_majority`    — 2 of 3 (or 1 of 1) reads were
+//                                 unparseable. The remaining read(s)
+//                                 are not enough signal for a median.
+//   * `all_runs_failed`         — all 3 reads were unparseable. The
+//                                 model is fundamentally refusing to
+//                                 emit HH:MM:SS for this image.
+//
+// The `transport_error` variant remains unchanged (network /
+// gateway failures still surface as transport errors).
 
 /**
- * Outcome of a single `readDial` call.
+ * Outcome of a `readDial` call (median-of-3).
  *
- * The kind discriminator means call-sites must exhaustively branch on
- * the result, which is the whole point — we don't want a `success` row
- * to silently leak `unparseable`-shaped data into the verified-reading
- * persistence layer.
+ * Call-sites must exhaustively branch on the `kind` discriminator;
+ * we don't want a `success` row to silently leak rejection-shaped
+ * data into the verified-reading persistence layer.
  *
- *   * `success` — the model returned a parseable HH:MM:SS and we have
- *     a `{ m, s }` for the verifier. The hour is dropped: the server
- *     clock owns the hour because verified readings are always within
- *     a session whose hour is known from the EXIF anchor / server time.
- *   * `unparseable` — the model returned, but the response did not
- *     contain an HH:MM:SS-shaped substring. Caller should reject the
- *     reading with a "we couldn't read the dial — please retake" UX.
- *   * `transport_error` — the AI binding (or the underlying gateway)
- *     threw before producing a response. Caller should retry once or
- *     surface a generic "service unavailable" message.
+ *   * `success` — the median MM:SS is trustworthy. `mm_ss` is the
+ *     median; `raw_responses` is the array of all three model
+ *     responses (kept for log/debug, never surfaced to users); token
+ *     totals are summed across the three calls.
+ *   * `rejection` — the median couldn't be trusted. `reason` tells
+ *     the caller which specific check failed; `details.delta_seconds`
+ *     is populated when `reason = "anchor_disagreement"` so the
+ *     caller can log how far off we were.
+ *   * `transport_error` — every parallel call threw before
+ *     producing a response. Caller should retry once or surface a
+ *     generic "service unavailable" message.
  */
 export type DialReadResult =
   | {
       kind: "success";
       mm_ss: { m: number; s: number };
-      raw_response: string;
-      tokens_in?: number;
-      tokens_out?: number;
+      raw_responses: string[];
+      tokens_in_total?: number;
+      tokens_out_total?: number;
     }
   | {
-      kind: "unparseable";
-      raw_response: string;
+      kind: "rejection";
+      reason:
+        | "anchor_disagreement"
+        | "all_runs_failed"
+        | "unparseable_majority"
+        | "anchor_echo_suspicious";
+      details?: { delta_seconds?: number };
     }
   | {
       kind: "transport_error";

--- a/src/domain/reading-verifier/verifier.test.ts
+++ b/src/domain/reading-verifier/verifier.test.ts
@@ -45,12 +45,16 @@ function fakeCropResult(): CropToDialResult {
 }
 
 function vlmSuccess(m: number, s: number, model = "openai/gpt-5.2"): DialReadResult {
+  // The slice-#5 reader returns `raw_responses: string[]` (one entry
+  // per parallel call) plus aggregated token totals. The verifier
+  // collapses this into a single `raw_response` for the route layer.
+  const raw = `10:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
   return {
     kind: "success",
     mm_ss: { m, s },
-    raw_response: `10:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`,
-    tokens_in: 100,
-    tokens_out: 5,
+    raw_responses: [raw, raw, raw],
+    tokens_in_total: 300,
+    tokens_out_total: 15,
   };
   // (model is captured by the deps below, not the result — kept here
   // for prose clarity.)
@@ -177,9 +181,9 @@ describe("verifyVlmReading", () => {
     expect(result.error).toBe("exif_clock_skew");
   });
 
-  it("maps VLM unparseable to error: ai_unparseable with raw_response", async () => {
+  it("maps VLM rejection (unparseable_majority) to error: ai_unparseable", async () => {
     const deps = makeDeps({
-      readDial: async () => ({ kind: "unparseable", raw_response: "huh?" }),
+      readDial: async () => ({ kind: "rejection", reason: "unparseable_majority" }),
     });
     const result = await verifyVlmReading(
       {
@@ -193,7 +197,67 @@ describe("verifyVlmReading", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBe("ai_unparseable");
-    expect(result.raw_response).toBe("huh?");
+  });
+
+  it("maps VLM rejection (all_runs_failed) to error: ai_refused", async () => {
+    const deps = makeDeps({
+      readDial: async () => ({ kind: "rejection", reason: "all_runs_failed" }),
+    });
+    const result = await verifyVlmReading(
+      {
+        photoBytes: FAKE_IMAGE,
+        watchId: "w",
+        userId: "u",
+        serverArrivalAtMs: SERVER_ARRIVAL_MS,
+      },
+      deps,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("ai_refused");
+  });
+
+  it("maps VLM rejection (anchor_disagreement) to error: dial_reader_anchor_disagreement", async () => {
+    const deps = makeDeps({
+      readDial: async () => ({
+        kind: "rejection",
+        reason: "anchor_disagreement",
+        details: { delta_seconds: 90 },
+      }),
+    });
+    const result = await verifyVlmReading(
+      {
+        photoBytes: FAKE_IMAGE,
+        watchId: "w",
+        userId: "u",
+        serverArrivalAtMs: SERVER_ARRIVAL_MS,
+      },
+      deps,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("dial_reader_anchor_disagreement");
+  });
+
+  it("maps VLM rejection (anchor_echo_suspicious) to error: dial_reader_anchor_echo_flagged", async () => {
+    const deps = makeDeps({
+      readDial: async () => ({
+        kind: "rejection",
+        reason: "anchor_echo_suspicious",
+      }),
+    });
+    const result = await verifyVlmReading(
+      {
+        photoBytes: FAKE_IMAGE,
+        watchId: "w",
+        userId: "u",
+        serverArrivalAtMs: SERVER_ARRIVAL_MS,
+      },
+      deps,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("dial_reader_anchor_echo_flagged");
   });
 
   it("maps VLM transport_error to error: dial_reader_transport_error", async () => {

--- a/src/domain/reading-verifier/verifier.ts
+++ b/src/domain/reading-verifier/verifier.ts
@@ -1,11 +1,12 @@
-// Reading verifier — orchestrates the new VLM-backed verified-reading
-// pipeline introduced in slice #4 of PRD #99 (issue #103).
+// Reading verifier — orchestrates the VLM-backed verified-reading
+// pipeline introduced in slice #4 of PRD #99 (issue #103) and
+// extended by slice #5 (issue #104) with median-of-3 + anchor guard.
 //
 // The previous Python-container-backed verifier was decommissioned in
 // slice #1 of PRD #99 (issue #100). This file is the rebuilt
 // orchestrator wired to the slice-#2 dial cropper
-// (`@/domain/dial-cropper`) and the slice-#3 single-VLM-call dial
-// reader (`@/domain/dial-reader-vlm`).
+// (`@/domain/dial-cropper`) and the slice-#3-then-#5 VLM dial reader
+// (`@/domain/dial-reader-vlm`).
 //
 // Pipeline:
 //
@@ -31,17 +32,21 @@
 //      contract — see `scripts/vlm-bakeoff/bakeoff.py::_anchor_with_offset`
 //      and the prompt's "12-hour clock" output instruction.
 //
-//   4. Call `readDial(...)` once. Result-mapping:
+//   4. Call `readDial(...)` (median-of-3 with anchor guard).
+//      Result-mapping:
 //      * `kind: "success"` → compute the MM:SS-modulo-60min deviation
 //        and return `ok: true`.
-//      * `kind: "unparseable"` → `ok: false, error: "ai_unparseable"`.
+//      * `kind: "rejection"`:
+//          - `reason: "anchor_disagreement"` → error code
+//            `dial_reader_anchor_disagreement` (route → 422).
+//          - `reason: "anchor_echo_suspicious"` → error code
+//            `dial_reader_anchor_echo_flagged` (route → 422). The
+//            user-facing copy says "inconclusive read, please retake"
+//            — we deliberately don't surface "we caught you cheating".
+//          - `reason: "all_runs_failed"` → existing `ai_refused`.
+//          - `reason: "unparseable_majority"` → existing `ai_unparseable`.
 //      * `kind: "transport_error"` → `ok: false,
 //        error: "dial_reader_transport_error"`.
-//
-// Median-of-3 + the anchor-disagreement guard land in slice #5. For
-// this tracer-bullet slice the verifier is deliberately a single-call
-// pipeline so we can prove end-to-end wiring without dragging in the
-// sample/agreement plumbing.
 //
 // Deviation contract (MM:SS modulo 60 minutes):
 //
@@ -90,7 +95,10 @@ export interface VerifyVlmReadingInput {
 
 export type VerifyReadingErrorCode =
   | "exif_clock_skew"
+  | "ai_refused"
   | "ai_unparseable"
+  | "dial_reader_anchor_disagreement"
+  | "dial_reader_anchor_echo_flagged"
   | "dial_reader_transport_error";
 
 export type VerifyVlmReadingResult =
@@ -200,12 +208,15 @@ export async function verifyVlmReading(
       raw_response: dialResult.message,
     };
   }
-  if (dialResult.kind === "unparseable") {
-    return {
-      ok: false,
-      error: "ai_unparseable",
-      raw_response: dialResult.raw_response,
-    };
+  if (dialResult.kind === "rejection") {
+    // Map each guard/median rejection reason onto a wire-format
+    // error code. We DON'T leak `raw_response` for these because
+    // the slice-#5 reader doesn't keep a single canonical raw
+    // string for the rejection paths (the median is a synthetic
+    // value, and the anchor-echo case has three identical strings
+    // that aren't useful to surface).
+    const error = mapRejectionReason(dialResult.reason);
+    return { ok: false, error };
   }
 
   // Success — compute deviation against the reference's MM:SS.
@@ -216,6 +227,13 @@ export async function verifyVlmReading(
   };
   const deviation = computeMmSsDeviation(dialResult.mm_ss, refMmSs);
 
+  // The reader exposes `raw_responses: string[]` — the verifier's
+  // result keeps a single `raw_response` field for back-compat with
+  // the route handler. We pick the first response (the underlying
+  // strings are typically identical or close, and we only use this
+  // for debug logs).
+  const rawResponse = dialResult.raw_responses[0] ?? "";
+
   return {
     ok: true,
     vlm_model: deps.model,
@@ -224,8 +242,32 @@ export async function verifyVlmReading(
     reference_source: ref.source,
     deviation_seconds: deviation,
     crop_found: crop.found,
-    raw_response: dialResult.raw_response,
+    raw_response: rawResponse,
   };
+}
+
+/**
+ * Map a `DialReadResult.rejection.reason` to a wire-format
+ * `VerifyReadingErrorCode`. Pure helper extracted so the route layer
+ * can stay agnostic about the reader's internal naming.
+ */
+function mapRejectionReason(
+  reason:
+    | "anchor_disagreement"
+    | "all_runs_failed"
+    | "unparseable_majority"
+    | "anchor_echo_suspicious",
+): VerifyReadingErrorCode {
+  switch (reason) {
+    case "anchor_disagreement":
+      return "dial_reader_anchor_disagreement";
+    case "anchor_echo_suspicious":
+      return "dial_reader_anchor_echo_flagged";
+    case "all_runs_failed":
+      return "ai_refused";
+    case "unparseable_majority":
+      return "ai_unparseable";
+  }
 }
 
 /**

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -568,6 +568,17 @@ readingsByWatchRoute.post("/verified", async (c) => {
  * leak `raw_response` for the AI errors (it can include the full
  * model output, which is excessive for the SPA) but we keep it on
  * the EXIF-skew branch where the legacy shape carries a debug hint.
+ *
+ * Slice #5 of PRD #99 (issue #104) added the median-of-3 + anchor
+ * guard error codes:
+ *   * `dial_reader_anchor_disagreement` — median MM:SS diverges
+ *     > 60 s from the EXIF anchor. 422; user retakes.
+ *   * `dial_reader_anchor_echo_flagged` — all 3 reads echoed the
+ *     anchor (suspicious cheat pattern). 422; copy says
+ *     "inconclusive read, please retake" — we deliberately don't
+ *     surface "we caught you cheating".
+ *   * `ai_refused` — all 3 reads were unparseable (model fully
+ *     refused). 422; same retake UX.
  */
 function verifiedReadingErrorResponse(
   c: {
@@ -586,6 +597,35 @@ function verifiedReadingErrorResponse(
         ux_hint: "Connection failed while reading dial. Please try again.",
       },
       502,
+    );
+  }
+  if (code === "dial_reader_anchor_disagreement") {
+    return c.json(
+      {
+        error_code: code,
+        ux_hint:
+          "We couldn't reconcile the dial with your phone's clock. Please retake the photo.",
+      },
+      422,
+    );
+  }
+  if (code === "dial_reader_anchor_echo_flagged") {
+    return c.json(
+      {
+        error_code: code,
+        ux_hint: "Inconclusive read — please retake the photo.",
+      },
+      422,
+    );
+  }
+  if (code === "ai_refused") {
+    return c.json(
+      {
+        error_code: code,
+        ux_hint:
+          "We couldn't read the dial in your photo — try a clearer shot or log manually.",
+      },
+      422,
     );
   }
   // ai_unparseable

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -218,12 +218,17 @@ interface PersistedRow {
  */
 function installVlmMock(answer: { m: number; s: number }): void {
   __setTestReadDial(async (_input: ReadDialInput) => {
+    // Slice #5 reader returns `raw_responses: string[]` (one per
+    // parallel call). The mock builds three identical entries —
+    // matches what the median-of-3 pipeline produces when the model
+    // is stable.
+    const raw = `10:${String(answer.m).padStart(2, "0")}:${String(answer.s).padStart(2, "0")}`;
     const result: DialReadResult = {
       kind: "success",
       mm_ss: answer,
-      raw_response: `10:${String(answer.m).padStart(2, "0")}:${String(answer.s).padStart(2, "0")}`,
-      tokens_in: 100,
-      tokens_out: 5,
+      raw_responses: [raw, raw, raw],
+      tokens_in_total: 300,
+      tokens_out_total: 15,
     };
     return result;
   });
@@ -336,9 +341,12 @@ describe("POST /api/v1/watches/:id/readings/verified", () => {
     "returns 422 ai_unparseable when the VLM returns gibberish",
     async () => {
       __setTestExifReader(async () => Date.now());
+      // Slice #5: 2-or-more unparseable reads collapse into a
+      // `rejection: unparseable_majority`. The verifier maps that to
+      // `ai_unparseable` for back-compat with the SPA.
       __setTestReadDial(async () => ({
-        kind: "unparseable",
-        raw_response: "what is a watch",
+        kind: "rejection",
+        reason: "unparseable_majority",
       }));
 
       const owner = await registerAndGetCookie();


### PR DESCRIPTION
Closes #104. Refs #99.

## Summary

Replaces the slice-#3 single-call VLM dial reader with a **parallel median-of-3 pipeline + anchor-disagreement guard**, closing the gap from "78 % of individual reads within ±5 s" (bake-off data) toward "5/6 fixture medians within ±5 s" per PRD #99.

## Changes

### `src/domain/dial-reader-vlm/anchor-guard.ts` (new)

Pure function `checkAnchor()` returning one of three outcomes:
- `accept` — median trustworthy
- `reject_anchor_disagreement` (with signed `delta_seconds`) — `|median - anchor| > 60s` on the wrap-aware `[0, 3600)` MM:SS circle. Wrap math mirrors `scripts/vlm-bakeoff/bakeoff.py::_signed_error_seconds`, scaled from the 12 h 43200 s circle to MM:SS-only.
- `flag_suspicious_anchor_echo` — all 3 reads byte-identical to the anchor (Claude-style cheat). Only fires with ≥ 3 reads; the 2-read fallback can't distinguish a cheat from coincidence.

13 scenario tests cover both rejection paths, the 60 s boundary (inclusive), wrap-around proximity, and the 2-vs-3-read distinction.

### `src/domain/dial-reader-vlm/reader.ts` (rewritten)

Now fans out **3 parallel** `runChatCompletion` calls with the same image / prompt / anchor. Behaviour matrix:

| Successes | Outcome |
|-----------|---------|
| 3 of 3 | sort by seconds-within-the-hour, take index `[1]` → median |
| 2 of 3 | average rounded → median |
| 1 of 3 | `rejection: unparseable_majority` |
| 0 of 3 (mixed) | `rejection: all_runs_failed` |
| 0 of 3 (all transport throw) | `transport_error` |

Median + anchor + individual reads then go through `checkAnchor()`. Rejections from the guard map onto `rejection` variants; accept builds the success result with `raw_responses: string[]` (one per call) and summed `tokens_in_total` / `tokens_out_total`.

24 reader tests cover every median + guard branch, request-shape assertions for all 3 calls, and the fan-out count.

### `src/domain/dial-reader-vlm/types.ts`

`DialReadResult` union refactored:

```ts
// before
success | unparseable | transport_error

// after
success | rejection (4 reasons) | transport_error
```

`success.raw_response: string` → `success.raw_responses: string[]`. Token fields renamed to `tokens_in_total` / `tokens_out_total`.

### `src/domain/reading-verifier/verifier.ts`

Maps each new rejection reason to a wire-format `VerifyReadingErrorCode`:

| reader rejection reason | error code |
|-------------------------|------------|
| `anchor_disagreement` | `dial_reader_anchor_disagreement` (new) |
| `anchor_echo_suspicious` | `dial_reader_anchor_echo_flagged` (new) |
| `all_runs_failed` | `ai_refused` |
| `unparseable_majority` | `ai_unparseable` |

4 new verifier tests cover each mapping. Existing tests updated for the new `DialReadResult` shape.

### `src/server/routes/readings.ts`

`verifiedReadingErrorResponse()` exhaustively branches on every code now. The two new codes return 422 + `error_code` + `ux_hint`:
- `dial_reader_anchor_disagreement` → "We couldn't reconcile the dial with your phone's clock. Please retake the photo."
- `dial_reader_anchor_echo_flagged` → "Inconclusive read — please retake the photo." (deliberately neutral copy — we do **not** surface "we caught the model cheating" to users.)

### `src/app/watches/verifiedReadingErrors.{ts,test.ts}`

SPA mapper recognises both new server codes and returns retake-only UX (`canRetry=false` because the same photo will hit the same rejection). 2 new tests, including an explicit assertion that the anchor-echo copy doesn't leak internal cheat-detection vocabulary.

### `tests/integration/readings.verified.test.ts`

`installVlmMock()` updated to build a `success` result with three `raw_responses` entries (matches what the median-of-3 pipeline produces in steady state). The unparseable test now mocks `rejection: unparseable_majority`. No behavioural change to the integration suite.

## CI / quality gates

- `npm run typecheck` — clean
- `npm test` — 543/543 tests pass (3 new files, 39 new tests; existing test counts preserved)
- `npm run build` — clean

## Notes for review

- **No breaking change to the route's external contract.** The two new error codes are additive; existing codes (`ai_unparseable`, `ai_refused`, `dial_reader_transport_error`, `exif_clock_skew`) keep the same wire shape.
- **No real AI Gateway calls in CI** — every test uses a mock `AiClient` or the `__setTestReadDial` short-circuit.
- **Cost note**: 3 parallel calls per attempt roughly triples upstream spend per verified-reading attempt vs. slice #3. Bake-off data justifies the trade-off; the rate-limit gating from a later slice will cap blast radius.
- **DO NOT MERGE** until parallel slices #105 and #107 are also reviewed.

## Acceptance checklist (from issue #104)

- [x] `anchor-guard.ts` module + tests
- [x] `reader.ts` does parallel median-of-3 with guard application
- [x] `DialReadResult` extended with new variants
- [x] `verifier.ts` maps new rejection variants to error codes
- [x] All existing tests still pass (543/543)
- [x] New unit tests cover all median + guard branches
- [x] `npm run typecheck` clean, `npm run test` green