### PR TITLE
feat(spa): verified-reading confirmation page with anti-cheat UX — Refs #99

### DIFF
--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -35,6 +35,18 @@
 //     POST /readings/manual_with_photo and persists a verified=0
 //     row with the photo as evidence.
 //
+// Slice #6 of PRD #99 (issue #105) replaced the synchronous
+// `POST /readings/verified` with a draft + confirm two-step API.
+// Slice #7 (issue #106) extended this component to render the new
+// `VerifiedReadingConfirmation` step inline once the draft returns:
+//
+//   chosen → submitting (draft) → confirming → submitting (confirm) → success
+//                                ↑
+//                            Retake bounces back to chosen / idle
+//
+// The confirmation step deliberately doesn't show the deviation —
+// see `VerifiedReadingConfirmation.tsx` for the anti-cheat note.
+//
 // Trust rules (matching slice #16):
 //   * Client-side EXIF / capture time is never sent. The server's
 //     `Date.now()` (or, post-#71, the photo's EXIF DateTimeOriginal
@@ -45,12 +57,13 @@
 //     upload "mobile vs desktop" flag.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { VerifiedReadingConfirmation } from "./VerifiedReadingConfirmation";
 import {
   createManualWithPhotoReading,
-  createVerifiedReading,
+  draftVerifiedReading,
   type ManualWithPhotoSubmission,
   type Reading,
-  type VerifiedReadingSubmission,
+  type VerifiedReadingDraft,
 } from "./readings";
 import { maybeResize } from "./resizePhoto";
 import type { VerifiedReadingErrorMessage } from "./verifiedReadingErrors";
@@ -83,6 +96,15 @@ type UiState =
       previewUrl: string;
       progress: SubmitProgress;
       mode: "verified" | "manual_with_photo";
+    }
+  // Slice #7 of PRD #99 (issue #106): /draft succeeded; render the
+  // confirmation page. The user nudges ± seconds and submits; on
+  // confirm-success we transition to `success`, on retake we bounce
+  // back to `idle`. The draft photo lives in R2 with a 24h TTL.
+  | {
+      kind: "confirming";
+      isBaseline: boolean;
+      draft: VerifiedReadingDraft;
     }
   | { kind: "success"; reading: Reading }
   | {
@@ -234,18 +256,16 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
     });
 
     const resized = await maybeResize(sourceFile);
-    const submission: VerifiedReadingSubmission = {
-      image: resized.file,
-      isBaseline,
-    };
 
-    // Network round-trip. We can't observe the server's CV step
-    // independently from this single fetch, but moving from
-    // "uploading" → "reading" the moment the request body is sent
-    // gives the user a sensible mental model of what's happening.
-    // We approximate by flipping to "reading" on the next tick
-    // after kicking off the fetch, then "saving" once the response
-    // resolves and we start parsing the JSON.
+    // Network round-trip to /draft. We can't observe the server's
+    // CV step independently from this single fetch, but moving
+    // from "uploading" → "reading" the moment the request body is
+    // sent gives the user a sensible mental model of what's
+    // happening. Slice #7 (issue #106): /draft does NOT save the
+    // reading — that comes from /confirm via the confirmation step.
+    // We still show "saving" briefly when the draft returns to
+    // mark "we got something back, the confirmation page is about
+    // to mount".
     const flipToReading = setTimeout(() => {
       setState((prev) =>
         prev.kind === "submitting" && prev.progress === "uploading"
@@ -254,33 +274,50 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
       );
     }, 200);
 
-    const result = await createVerifiedReading(watchId, submission);
+    const result = await draftVerifiedReading(watchId, { image: resized.file });
     clearTimeout(flipToReading);
 
     if (result.ok) {
-      // Briefly show "saving" before the success banner so the user
-      // sees the third checkpoint tick. This is honest UX — the
-      // server has already saved by the time we get here, but the
-      // CLIENT is now saving the result into its own state and
-      // re-rendering, which IS work.
       setState((prev) =>
         prev.kind === "submitting" ? { ...prev, progress: "saving" } : prev,
       );
-      // Wait one frame so the user actually perceives the transition.
+      // Wait one frame so the user perceives the transition before
+      // the confirmation page swaps in.
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      // The draft photo is now on R2 (drafts/<user>/<uuid>.jpg).
+      // We can free the local object URL: the confirmation page
+      // renders draft.photo_url, not our local preview.
       clearPreview();
-      setIsBaseline(false);
-      setState({ kind: "success", reading: result.reading });
-      onSubmitted(result.reading);
+      setState({
+        kind: "confirming",
+        isBaseline,
+        draft: result.draft,
+      });
       return;
     }
 
     setState({
       kind: "error",
-      file: submission.image,
+      file: resized.file,
       previewUrl: liveUrlRef.current ?? "",
       error: result.error,
     });
+  }
+
+  function handleConfirmed(reading: Reading) {
+    setIsBaseline(false);
+    setState({ kind: "success", reading });
+    onSubmitted(reading);
+  }
+
+  function handleRetakeFromConfirmation() {
+    // The draft photo on R2 expires via the 24h lifecycle rule —
+    // no client-side cleanup needed. We just bounce back to the
+    // capture step. `isBaseline` is preserved so the user doesn't
+    // re-tick the checkbox after a retake.
+    setState({ kind: "idle" });
+    // Trigger the file picker so retake is one tap, not two.
+    setTimeout(() => openFilePicker(), 0);
   }
 
   /**
@@ -381,11 +418,14 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
   const showIdle = state.kind === "idle";
   const showChosen = state.kind === "chosen";
   const showSubmitting = state.kind === "submitting";
+  const showConfirming = state.kind === "confirming";
   const showSuccess = state.kind === "success";
   const showError = state.kind === "error";
   const showManualEntry = state.kind === "manual_entry";
 
-  // preview URL for the <img> in chosen/submitting/error/manual_entry states
+  // preview URL for the <img> in chosen/submitting/error/manual_entry states.
+  // Confirming has its own <img> sourced from R2 (draft.photo_url) so it
+  // doesn't reuse the local object URL.
   const preview =
     state.kind === "chosen" ||
     state.kind === "submitting" ||
@@ -611,6 +651,16 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
 
       {showSubmitting && state.kind === "submitting" ? (
         <ProgressIndicator current={state.progress} />
+      ) : null}
+
+      {showConfirming && state.kind === "confirming" ? (
+        <VerifiedReadingConfirmation
+          watchId={watchId}
+          draft={state.draft}
+          isBaseline={state.isBaseline}
+          onConfirmed={handleConfirmed}
+          onRetake={handleRetakeFromConfirmation}
+        />
       ) : null}
 
       {showSuccess && state.kind === "success" ? (

--- a/src/app/watches/VerifiedReadingConfirmation.tsx
+++ b/src/app/watches/VerifiedReadingConfirmation.tsx
@@ -1,0 +1,237 @@
+// Confirmation step for the verified-reading two-step flow (slice #7
+// of PRD #99 — issue #106).
+//
+// Rendered after `POST /readings/verified/draft` returns. The user
+// sees their photo + the VLM's predicted MM:SS and either:
+//
+//   1. Nudges ± seconds (within ±30s) to match what the dial actually
+//      reads, then taps Confirm → POSTs /confirm and lands on the
+//      watch detail's history pane.
+//   2. Taps Retake → returns to the capture step. The draft photo on
+//      R2 expires via the 24h lifecycle rule (see
+//      `infra/terraform/r2.tf`) so abandoned drafts don't pile up.
+//
+// ## Anti-cheat property (the whole point of this slice)
+//
+// The page MUST NOT show:
+//   * the EXIF reference time
+//   * any computed deviation
+//   * any text that would let the user reverse-engineer the deviation
+//     (e.g. "+5s ahead", "5s drift")
+//
+// The hour from the server clock IS shown — but as a small prefix
+// ("Reading at 14:") deliberately separated from the prediction
+// display, so the brain has to do non-trivial mental arithmetic to
+// derive a deviation. The +/- buttons let the user shift seconds
+// based on what they see on their watch's dial; they don't know
+// what value would yield a "perfect" drift rate, so the dominant
+// strategy is honesty.
+//
+// The E2E test in `tests/e2e/verified-reading-confirmation.smoke.test.ts`
+// asserts this with a DOM probe (no element matching
+// `[data-testid="deviation"]`, no text matching `/drift|deviation|[+-]\d+s/i`).
+//
+// ## ±30s adjustment cap
+//
+// The server enforces ±30s in `/confirm` (slice #6); we mirror it
+// client-side via `canAdjust` from `verifiedReadingAdjustment.ts` so
+// the buttons disable visually at the limit. UI is convenience;
+// server is security.
+
+import { useState } from "react";
+import {
+  ADJUSTMENT_LIMIT_SECONDS,
+  adjustSeconds,
+  canAdjust,
+  clicksUsed,
+  formatMmSs,
+  type MmSs,
+} from "./verifiedReadingAdjustment";
+import {
+  confirmVerifiedReading,
+  type Reading,
+  type VerifiedReadingDraft,
+} from "./readings";
+import type { VerifiedReadingErrorMessage } from "./verifiedReadingErrors";
+
+interface Props {
+  watchId: string;
+  draft: VerifiedReadingDraft;
+  isBaseline: boolean;
+  /**
+   * Bubble up to the parent so the watch detail page can re-render
+   * the readings list + session stats. The parent is also responsible
+   * for clearing the draft state once the reading is saved.
+   */
+  onConfirmed: (reading: Reading) => void;
+  /**
+   * Bubble up so the parent can return to the capture step. The
+   * draft photo's R2 lifecycle rule cleans up abandoned drafts.
+   */
+  onRetake: () => void;
+}
+
+type SubmitState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "error"; error: VerifiedReadingErrorMessage };
+
+export function VerifiedReadingConfirmation({
+  watchId,
+  draft,
+  isBaseline,
+  onConfirmed,
+  onRetake,
+}: Props) {
+  // The user's working MM:SS — starts at the prediction, mutates as
+  // they nudge. Confirm POSTs whatever `current` is at click time.
+  const [current, setCurrent] = useState<MmSs>(draft.predicted_mm_ss);
+  const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
+
+  const used = clicksUsed(draft.predicted_mm_ss, current);
+  const canPlus = canAdjust(draft.predicted_mm_ss, current, 1);
+  const canMinus = canAdjust(draft.predicted_mm_ss, current, -1);
+
+  function handlePlus() {
+    if (!canPlus) return;
+    setCurrent((c) => adjustSeconds(c, 1));
+  }
+
+  function handleMinus() {
+    if (!canMinus) return;
+    setCurrent((c) => adjustSeconds(c, -1));
+  }
+
+  async function handleConfirm() {
+    if (submitState.kind === "submitting") return;
+    setSubmitState({ kind: "submitting" });
+    const result = await confirmVerifiedReading(watchId, {
+      reading_token: draft.reading_token,
+      final_mm_ss: current,
+      is_baseline: isBaseline,
+    });
+    if (!result.ok) {
+      setSubmitState({ kind: "error", error: result.error });
+      return;
+    }
+    // Clear local error / submit state isn't necessary — the parent
+    // unmounts us once the reading is saved.
+    onConfirmed(result.reading);
+  }
+
+  // Hour display: rendered in a small "Reading at HH:" prefix above
+  // the prediction. Deliberately separated from the MM:SS so the
+  // user can't trivially compose hh:mm:ss in their head and compare
+  // against the EXIF reference (which they don't have anyway). The
+  // hour is always padded to 2 digits to avoid different visual
+  // widths between e.g. "9" and "10".
+  const hourLabel = String(draft.hour_from_server_clock).padStart(2, "0");
+
+  return (
+    <div
+      data-testid="verified-reading-confirmation"
+      className="flex flex-col gap-5 rounded-md border border-line bg-canvas p-5"
+    >
+      <header className="flex flex-col gap-1">
+        <h3 className="text-sm font-medium text-ink">Confirm your reading</h3>
+        <p className="text-xs text-ink-muted">
+          Adjust if needed, then confirm. The dial reading you submit becomes your
+          reading.
+        </p>
+      </header>
+
+      <img
+        data-testid="confirmation-photo"
+        src={draft.photo_url}
+        alt="Captured dial"
+        className="max-h-96 w-full rounded-md border border-line object-contain"
+      />
+
+      <div className="flex flex-col items-center gap-1 py-2">
+        {/* The "Reading at HH:" prefix sits ABOVE the MM:SS, not
+            beside it, so the user's eye doesn't read across as a
+            single HH:MM:SS triple. Deliberate UX choice — see the
+            anti-cheat note at the top of this file. */}
+        <span className="text-xs uppercase tracking-wide text-ink-muted">
+          Reading at {hourLabel}:
+        </span>
+        <div
+          data-testid="prediction-mm-ss"
+          aria-label={`Reading shows ${formatMmSs(current)}`}
+          className="font-mono text-5xl font-light tabular-nums text-ink"
+        >
+          <span data-testid="confirmation-minutes">
+            {String(current.m).padStart(2, "0")}
+          </span>
+          <span aria-hidden="true" className="mx-1 text-ink-muted">
+            :
+          </span>
+          <span data-testid="confirmation-seconds" className="text-accent">
+            {String(current.s).padStart(2, "0")}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-4">
+        <button
+          type="button"
+          data-testid="confirmation-minus"
+          aria-label="Decrease seconds by 1"
+          onClick={handleMinus}
+          disabled={!canMinus}
+          className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-line bg-canvas text-2xl font-light text-ink transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          −
+        </button>
+        <span
+          data-testid="confirmation-clicks-used"
+          className="font-mono text-xs text-ink-muted"
+        >
+          ± {used} / {ADJUSTMENT_LIMIT_SECONDS} used
+        </span>
+        <button
+          type="button"
+          data-testid="confirmation-plus"
+          aria-label="Increase seconds by 1"
+          onClick={handlePlus}
+          disabled={!canPlus}
+          className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-line bg-canvas text-2xl font-light text-ink transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          +
+        </button>
+      </div>
+
+      {submitState.kind === "error" ? (
+        <div
+          role="alert"
+          data-testid="confirmation-error"
+          data-error-code={submitState.error.code}
+          className="rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm text-ink"
+        >
+          {submitState.error.message}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          data-testid="confirmation-confirm"
+          onClick={handleConfirm}
+          disabled={submitState.kind === "submitting"}
+          className="inline-flex min-h-[44px] flex-1 items-center justify-center rounded-pill bg-accent px-5 py-3 text-sm font-medium text-accent-fg transition-colors hover:bg-accent/90 disabled:opacity-60"
+        >
+          {submitState.kind === "submitting" ? "Saving…" : "Confirm reading"}
+        </button>
+        <button
+          type="button"
+          data-testid="confirmation-retake"
+          onClick={onRetake}
+          disabled={submitState.kind === "submitting"}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-pill border border-line bg-canvas px-5 py-3 text-sm font-medium text-ink transition-colors hover:border-ink-muted disabled:opacity-60"
+        >
+          Retake photo
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -162,38 +162,86 @@ export async function deleteReading(
 }
 
 // -------------------------------------------------------------------
-// Slice #17 (issue #18): verified readings — camera-captured + CV-read.
+// Verified readings — two-step API.
 // -------------------------------------------------------------------
 //
-// The backend accepts a multipart body with an `image` file and an
-// optional `is_baseline` toggle. It returns 201 with the full
-// reading row on success, 422 on a structured CV rejection
-// (low_confidence / no_dial_found / unsupported_dial /
-// malformed_image), 502 on a dial-reader transport failure, 503
-// when the `verified_reading_cv` feature flag is off for the caller,
-// and the usual 4xx auth/ownership codes.
+// Slice #17 (issue #18) introduced the synchronous
+// `POST /readings/verified` route. Slice #6 of PRD #99 (issue #105)
+// split it in two for the anti-cheat UX:
+//
+//   1. POST /readings/verified/draft   — accepts the photo, runs
+//      the VLM pipeline, returns a signed `reading_token` + the
+//      predicted MM:SS + a photo URL + the server-clock hour.
+//      Does NOT save a reading row.
+//   2. POST /readings/verified/confirm — accepts
+//      { reading_token, final_mm_ss, is_baseline? }. Validates the
+//      token + the ±30s adjustment cap, saves the reading row,
+//      moves the photo from drafts/ to verified/.
+//
+// Anti-cheat property: /draft never returns the deviation. The SPA
+// confirmation page (slice #7 — issue #106) lets the user adjust ±
+// seconds without seeing what deviation it would produce, so an
+// honest read is the user's dominant strategy.
 //
 // We don't surface the verifier's raw_response to the SPA — the
 // mapped message in verifiedReadingErrors.ts is enough. If we ever
 // want debug info in the UI, we'll plumb it through separately.
 
-export interface VerifiedReadingSubmission {
+export interface VerifiedReadingDraftSubmission {
   image: File;
-  isBaseline: boolean;
 }
 
-export async function createVerifiedReading(
+/**
+ * Wire shape of the /draft 200 response. Mirrors the route handler
+ * in src/server/routes/readings.ts. Critically, this object does NOT
+ * include the deviation — see anti-cheat note above.
+ */
+export interface VerifiedReadingDraft {
+  reading_token: string;
+  predicted_mm_ss: { m: number; s: number };
+  photo_url: string;
+  hour_from_server_clock: number;
+  reference_source: "exif" | "server";
+  expires_at_unix: number;
+}
+
+async function readVerifiedError(
+  response: Response,
+): Promise<VerifiedReadingErrorMessage> {
+  let serverCode: string | undefined;
+  try {
+    // The CV pipeline emits `{ error_code, ux_hint }`; legacy errors
+    // (e.g. `image_required`) emit `{ error }`. Prefer error_code if
+    // both are present.
+    const parsed = (await response.json()) as {
+      error?: string;
+      error_code?: string;
+    };
+    serverCode = parsed.error_code ?? parsed.error;
+  } catch {
+    /* non-JSON body */
+  }
+  return mapVerifiedReadingError(response.status, serverCode);
+}
+
+/**
+ * POST /readings/verified/draft — upload the photo, get a signed
+ * token + predicted MM:SS back. The caller hands the result to the
+ * confirmation page; the user adjusts seconds and submits via
+ * `confirmVerifiedReading`.
+ */
+export async function draftVerifiedReading(
   watchId: string,
-  submission: VerifiedReadingSubmission,
+  submission: VerifiedReadingDraftSubmission,
 ): Promise<
-  { ok: true; reading: Reading } | { ok: false; error: VerifiedReadingErrorMessage }
+  | { ok: true; draft: VerifiedReadingDraft }
+  | { ok: false; error: VerifiedReadingErrorMessage }
 > {
   const form = new FormData();
   form.append("image", submission.image);
-  form.append("is_baseline", submission.isBaseline ? "true" : "false");
 
   const response = await fetch(
-    `/api/v1/watches/${encodeURIComponent(watchId)}/readings/verified`,
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings/verified/draft`,
     {
       method: "POST",
       body: form,
@@ -201,21 +249,40 @@ export async function createVerifiedReading(
     },
   );
   if (!response.ok) {
-    let serverCode: string | undefined;
-    try {
-      // Slice #75 introduced the `error_code` field on CV-pipeline
-      // rejections (alongside a `ux_hint`). Legacy AI-pipeline errors
-      // continue to use `error`. Read whichever is present, in that
-      // order — `error_code` wins if both somehow appear.
-      const parsed = (await response.json()) as {
-        error?: string;
-        error_code?: string;
-      };
-      serverCode = parsed.error_code ?? parsed.error;
-    } catch {
-      /* non-JSON body */
-    }
-    return { ok: false, error: mapVerifiedReadingError(response.status, serverCode) };
+    return { ok: false, error: await readVerifiedError(response) };
+  }
+  const draft = (await response.json()) as VerifiedReadingDraft;
+  return { ok: true, draft };
+}
+
+export interface ConfirmVerifiedReadingSubmission {
+  reading_token: string;
+  final_mm_ss: { m: number; s: number };
+  is_baseline?: boolean;
+}
+
+/**
+ * POST /readings/verified/confirm — submit the user's (possibly
+ * adjusted) MM:SS for saving. Server validates the token signature
+ * + ±30s adjustment cap and returns the saved reading row.
+ */
+export async function confirmVerifiedReading(
+  watchId: string,
+  submission: ConfirmVerifiedReadingSubmission,
+): Promise<
+  { ok: true; reading: Reading } | { ok: false; error: VerifiedReadingErrorMessage }
+> {
+  const response = await fetch(
+    `/api/v1/watches/${encodeURIComponent(watchId)}/readings/verified/confirm`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(submission),
+      credentials: "include",
+    },
+  );
+  if (!response.ok) {
+    return { ok: false, error: await readVerifiedError(response) };
   }
   const reading = (await response.json()) as Reading;
   return { ok: true, reading };

--- a/src/app/watches/verifiedReadingAdjustment.test.ts
+++ b/src/app/watches/verifiedReadingAdjustment.test.ts
@@ -1,0 +1,114 @@
+// Unit tests for the SPA confirmation-page math helpers.
+//
+// These are pure functions — no DOM, no fetch — so they run cleanly
+// inside the cloudflare-workers vitest pool alongside the rest of
+// the workers-pool tests.
+
+import { describe, expect, it } from "vitest";
+import {
+  ADJUSTMENT_LIMIT_SECONDS,
+  adjustSeconds,
+  canAdjust,
+  clicksUsed,
+  formatMmSs,
+  mmSsCircularDistance,
+} from "./verifiedReadingAdjustment";
+
+describe("adjustSeconds", () => {
+  it("increments seconds within the same minute", () => {
+    expect(adjustSeconds({ m: 19, s: 34 }, 1)).toEqual({ m: 19, s: 35 });
+    expect(adjustSeconds({ m: 19, s: 34 }, 5)).toEqual({ m: 19, s: 39 });
+  });
+
+  it("decrements seconds within the same minute", () => {
+    expect(adjustSeconds({ m: 19, s: 34 }, -1)).toEqual({ m: 19, s: 33 });
+    expect(adjustSeconds({ m: 19, s: 34 }, -10)).toEqual({ m: 19, s: 24 });
+  });
+
+  it("wraps forward across the minute boundary", () => {
+    // The dial doesn't clamp at 59 — going +1 from 59s lands at the
+    // next minute's 0s. Critical: clamping would leak "you've hit
+    // the wall" as a deviation hint.
+    expect(adjustSeconds({ m: 19, s: 59 }, 1)).toEqual({ m: 20, s: 0 });
+    expect(adjustSeconds({ m: 19, s: 58 }, 5)).toEqual({ m: 20, s: 3 });
+  });
+
+  it("wraps backward across the minute boundary", () => {
+    expect(adjustSeconds({ m: 20, s: 0 }, -1)).toEqual({ m: 19, s: 59 });
+    expect(adjustSeconds({ m: 20, s: 2 }, -5)).toEqual({ m: 19, s: 57 });
+  });
+
+  it("wraps across the 60-minute boundary (total seconds modulo 3600)", () => {
+    // Theoretical edge case. The product flow uses ±30s so this
+    // shouldn't fire in practice, but the helper handles it.
+    expect(adjustSeconds({ m: 59, s: 59 }, 1)).toEqual({ m: 0, s: 0 });
+    expect(adjustSeconds({ m: 0, s: 0 }, -1)).toEqual({ m: 59, s: 59 });
+  });
+});
+
+describe("mmSsCircularDistance", () => {
+  it("is zero for identical pairs", () => {
+    expect(mmSsCircularDistance({ m: 19, s: 34 }, { m: 19, s: 34 })).toBe(0);
+  });
+
+  it("returns the signed shortest distance for nearby pairs", () => {
+    expect(mmSsCircularDistance({ m: 19, s: 35 }, { m: 19, s: 34 })).toBe(1);
+    expect(mmSsCircularDistance({ m: 19, s: 33 }, { m: 19, s: 34 })).toBe(-1);
+  });
+
+  it("wraps through the 60-minute boundary", () => {
+    // 0m 0s is 1s after 59m 59s on the circle, not 3599s before.
+    expect(mmSsCircularDistance({ m: 0, s: 0 }, { m: 59, s: 59 })).toBe(1);
+    expect(mmSsCircularDistance({ m: 59, s: 59 }, { m: 0, s: 0 })).toBe(-1);
+  });
+});
+
+describe("clicksUsed", () => {
+  it("is zero when the user has not adjusted", () => {
+    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 34 })).toBe(0);
+  });
+
+  it("counts absolute seconds nudged in either direction", () => {
+    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 39 })).toBe(5);
+    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 29 })).toBe(5);
+  });
+
+  it("counts wrap-aware distance when seconds cross the minute", () => {
+    // Predicted at 19:58, current at 20:01 — the user nudged +3.
+    expect(clicksUsed({ m: 19, s: 58 }, { m: 20, s: 1 })).toBe(3);
+  });
+});
+
+describe("canAdjust", () => {
+  it("allows + when under the cap", () => {
+    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 34 }, 1)).toBe(true);
+    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 3 }, 1)).toBe(true); // 29 used
+  });
+
+  it("disables + at exactly +30", () => {
+    // Predicted 19:34, current 20:04 → 30s used. Clicking + would
+    // take it to 20:05 (31s used) which is over the cap.
+    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 4 }, 1)).toBe(false);
+  });
+
+  it("still allows − when at the +30 limit", () => {
+    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 4 }, -1)).toBe(true);
+  });
+
+  it("disables − at exactly -30 (mirror of +30 case)", () => {
+    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 4 }, -1)).toBe(false);
+    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 4 }, 1)).toBe(true);
+  });
+
+  it("ADJUSTMENT_LIMIT_SECONDS is 30 (mirrors server)", () => {
+    expect(ADJUSTMENT_LIMIT_SECONDS).toBe(30);
+  });
+});
+
+describe("formatMmSs", () => {
+  it("zero-pads minutes and seconds", () => {
+    expect(formatMmSs({ m: 0, s: 0 })).toBe("00:00");
+    expect(formatMmSs({ m: 19, s: 34 })).toBe("19:34");
+    expect(formatMmSs({ m: 5, s: 9 })).toBe("05:09");
+  });
+});

--- a/src/app/watches/verifiedReadingAdjustment.ts
+++ b/src/app/watches/verifiedReadingAdjustment.ts
@@ -1,0 +1,100 @@
+// Pure helpers for the verified-reading SPA confirmation page (slice
+// #7 of PRD #99 — issue #106).
+//
+// The confirmation page renders the VLM's predicted MM:SS and lets
+// the user nudge ± seconds before saving. Two invariants drive the
+// logic:
+//
+//   1. Wrap-aware seconds math. When the user clicks +1 with seconds
+//      at 59, the result is `m+1, s=0` — NOT clamping at 59 (that
+//      would leak "you've hit the natural maximum" as a deviation
+//      hint). Wrapping past the 60-minute boundary is theoretically
+//      possible but practically impossible inside the ±30s adjustment
+//      window; we still handle the modulo to be safe.
+//
+//   2. Wrap-aware "clicks used" calculation on the [0, 3600) MM:SS
+//      circle. Going +1 from 59m 59s lands at 0m 0s — that's a 1s
+//      adjustment, not a 3599s one. The shortest-distance metric
+//      mirrors `mmSsCircularDistance` in `src/server/routes/readings.ts`
+//      so client and server agree on what "30s away" means.
+//
+// The ±30s cap is enforced server-side (slice #6) — these helpers
+// drive the UI's "disable + at the limit" behaviour. The server is
+// the security boundary.
+
+export interface MmSs {
+  m: number;
+  s: number;
+}
+
+/**
+ * The per-click adjustment cap in seconds. Mirrors
+ * `CONFIRM_ADJUSTMENT_LIMIT_SECONDS` in `src/server/routes/readings.ts`.
+ * Adjustments beyond this require a retake.
+ */
+export const ADJUSTMENT_LIMIT_SECONDS = 30;
+
+/**
+ * Adjust an MM:SS pair by `delta` seconds, wrapping minute boundaries.
+ * `delta` may be any integer; positive means later, negative earlier.
+ *
+ * Wrap math: total seconds = m*60 + s, then adjust modulo 3600 to
+ * stay on the [0, 3600) MM:SS circle (which is what the watch dial
+ * itself represents — minutes wrap every hour). Negative results are
+ * lifted into the positive range with the canonical
+ * `((x % n) + n) % n` idiom.
+ */
+export function adjustSeconds(current: MmSs, delta: number): MmSs {
+  const total = current.m * 60 + current.s + delta;
+  const wrapped = ((total % 3600) + 3600) % 3600;
+  return { m: Math.floor(wrapped / 60), s: wrapped % 60 };
+}
+
+/**
+ * Wrap-aware shortest signed distance between two MM:SS pairs on
+ * the [0, 3600) circle. Returns seconds in [-1800, +1800].
+ *
+ * Mirrors `mmSsCircularDistance` in the route handler so the SPA's
+ * "X / 30 used" counter matches the server's adjustment-cap math
+ * exactly.
+ */
+export function mmSsCircularDistance(a: MmSs, b: MmSs): number {
+  const aTotal = a.m * 60 + a.s;
+  const bTotal = b.m * 60 + b.s;
+  const raw = aTotal - bTotal;
+  const wrapped = (((raw + 1800) % 3600) + 3600) % 3600;
+  return wrapped - 1800;
+}
+
+/**
+ * Absolute seconds the user has nudged away from the prediction,
+ * clamped to non-negative integers. Drives the "± X / 30 used" UI
+ * counter and the +/- button disable state.
+ */
+export function clicksUsed(predicted: MmSs, current: MmSs): number {
+  return Math.abs(mmSsCircularDistance(current, predicted));
+}
+
+/**
+ * Whether nudging ± seconds further would cross the ±30s cap.
+ * Disable the corresponding button when this returns true.
+ *
+ * NOTE: we look at the *signed* distance, not just the absolute. A
+ * user at -30 should still be able to click + (moving toward
+ * predicted), but not - (moving away). Symmetric for +30.
+ */
+export function canAdjust(predicted: MmSs, current: MmSs, delta: 1 | -1): boolean {
+  const next = adjustSeconds(current, delta);
+  const nextDist = Math.abs(mmSsCircularDistance(next, predicted));
+  return nextDist <= ADJUSTMENT_LIMIT_SECONDS;
+}
+
+/**
+ * Format an MM:SS pair as "MM:SS" with zero padding. Used for the
+ * big display + a11y labels.
+ */
+export function formatMmSs(mmSs: MmSs): string {
+  const m = String(mmSs.m).padStart(2, "0");
+  const s = String(mmSs.s).padStart(2, "0");
+  return `${m}:${s}`;
+}

--- a/src/app/watches/verifiedReadingErrors.test.ts
+++ b/src/app/watches/verifiedReadingErrors.test.ts
@@ -149,4 +149,24 @@ describe("mapVerifiedReadingError", () => {
     expect(mapped.canRetake).toBe(false);
     expect(mapped.manualFallback).toBe(false);
   });
+
+  // Slice #6 of PRD #99 (issue #105): /confirm-only error codes,
+  // surfaced from the SPA confirmation page (slice #7).
+  it("maps invalid_token (401) to an expired-session hint that nudges retake", () => {
+    const mapped = mapVerifiedReadingError(401, "invalid_token");
+    expect(mapped.code).toBe("invalid_token");
+    expect(mapped.message).toMatch(/expired|retake/i);
+    expect(mapped.canRetake).toBe(true);
+    expect(mapped.canRetry).toBe(false);
+    expect(mapped.manualFallback).toBe(false);
+  });
+
+  it("maps adjustment_too_large (422) to a retake hint", () => {
+    const mapped = mapVerifiedReadingError(422, "adjustment_too_large");
+    expect(mapped.code).toBe("adjustment_too_large");
+    expect(mapped.message).toMatch(/exceed|retake/i);
+    expect(mapped.canRetake).toBe(true);
+    expect(mapped.canRetry).toBe(false);
+    expect(mapped.manualFallback).toBe(false);
+  });
 });

--- a/src/app/watches/verifiedReadingErrors.ts
+++ b/src/app/watches/verifiedReadingErrors.ts
@@ -55,6 +55,12 @@ export type VerifiedReadingErrorCode =
   | "dial_reader_anchor_disagreement"
   | "dial_reader_anchor_echo_flagged"
   | "rate_limited"
+  // Slice #6 of PRD #99 (issue #105) — confirm-only error codes.
+  // `invalid_token`: signature, expiry, or missing
+  // READING_TOKEN_SECRET. `adjustment_too_large`: user nudged
+  // beyond ±30s of the prediction.
+  | "invalid_token"
+  | "adjustment_too_large"
   | "unknown";
 
 export interface VerifiedReadingErrorMessage {
@@ -250,6 +256,36 @@ export function mapVerifiedReadingError(
     return {
       code: "image_required",
       message: "Please choose a photo first",
+      manualFallback: false,
+      canRetake: true,
+      canRetry: false,
+    };
+  }
+
+  // Slice #6 of PRD #99 (issue #105) — /confirm-only errors.
+  //
+  //   invalid_token: signature mismatch, expiry, or missing
+  //   READING_TOKEN_SECRET. The draft photo on R2 may also have
+  //   expired (24h lifecycle). Either way, the user needs to start
+  //   from a fresh capture — the photo + token are inseparable.
+  //
+  //   adjustment_too_large: user somehow nudged > ±30s. Should be
+  //   impossible from the SPA UI (we disable the buttons at the
+  //   limit) but the server is the security boundary, so we map it
+  //   the same way the UI handles a rejected confirm — retake.
+  if (status === 401 && serverCode === "invalid_token") {
+    return {
+      code: "invalid_token",
+      message: "This reading session expired — please retake the photo.",
+      manualFallback: false,
+      canRetake: true,
+      canRetry: false,
+    };
+  }
+  if (status === 422 && serverCode === "adjustment_too_large") {
+    return {
+      code: "adjustment_too_large",
+      message: "Your adjustment exceeded the allowed range — please retake the photo.",
       manualFallback: false,
       canRetake: true,
       canRetry: false,

--- a/tests/e2e/verified-reading-confirmation.smoke.test.ts
+++ b/tests/e2e/verified-reading-confirmation.smoke.test.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "@playwright/test";
+
+// Slice #7 of PRD #99 (issue #106). Confirmation page DOM tests.
+//
+// The confirmation page is the anti-cheat heart of the verified-
+// reading flow: after the user uploads a photo, they see the VLM's
+// predicted MM:SS and adjust ± seconds before confirming. The page
+// MUST NEVER show the deviation, because seeing the deviation lets
+// the user dial up to "make their watch look perfect".
+//
+// Why we route-mock /draft and /confirm here:
+//
+//   * /draft normally calls a real OpenAI VLM via Cloudflare AI
+//     Gateway. That round-trip costs money, has variable latency,
+//     and depends on a fixture having a recent EXIF timestamp (the
+//     verifier rejects EXIF older than 5 min as `exif_clock_skew`).
+//     Strapping a fixture on the SPA's resize pipeline that happens
+//     to land inside the bounds window is fragile.
+//
+//   * /confirm normally writes a row to D1 + moves a photo on R2,
+//     polluting the preview's state. We're testing the SPA, not
+//     the route.
+//
+// Mocking both gives us a deterministic harness that exercises the
+// real React component, the real CSS, and the real router. The
+// route handlers themselves are covered by the integration suite
+// in `tests/integration/readings.verified.test.ts`.
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg==";
+
+function tinyPngBuffer(): Buffer {
+  return Buffer.from(TINY_PNG_BASE64, "base64");
+}
+
+test("verified-reading confirmation: deviation never rendered, ± buttons adjust seconds, confirm posts user-adjusted MM:SS", async ({
+  page,
+}) => {
+  // Pre-flight: the preview's movements taxonomy must be live, same
+  // as the existing verified-reading.smoke test.
+  const healthRes = await page.request.get("/api/v1/movements?q=eta");
+  if (healthRes.status() !== 200) {
+    throw new Error(
+      `Movements API returned ${healthRes.status()} for ?q=eta. ` +
+        "Operator needs to run `wrangler d1 migrations apply rated-watch-db --remote` " +
+        "before the preview deploy can serve the add-watch flow.",
+    );
+  }
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `e2e-confirm-${uniqueSuffix}@rated.watch.test`;
+  const password = "e2e-smoke-password";
+  const name = "E2E Confirm User";
+  const watchName = `Confirm smoke ${uniqueSuffix}`;
+
+  // ---- Route-mock /draft and /confirm BEFORE registering ----------
+  //
+  // We register a fake reading_token (the SPA only uses it as an
+  // opaque string to echo back at /confirm) and a placeholder photo
+  // URL. The placeholder URL points at a 1×1 PNG inline data URL so
+  // the <img> renders something visible without hitting R2.
+  //
+  // Captured state lets the test assert the SPA POSTs the user-
+  // adjusted final_mm_ss, not the predicted MM:SS.
+  const FAKE_TOKEN = "fake-token.fake-sig";
+  const PREDICTED = { m: 19, s: 34 };
+  const PHOTO_DATA_URL =
+    "data:image/png;base64," +
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg==";
+
+  let draftCalls = 0;
+  await page.route("**/api/v1/watches/**/readings/verified/draft", (route) => {
+    draftCalls += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        reading_token: FAKE_TOKEN,
+        predicted_mm_ss: PREDICTED,
+        photo_url: PHOTO_DATA_URL,
+        hour_from_server_clock: 14,
+        reference_source: "server",
+        expires_at_unix: Math.floor(Date.now() / 1000) + 300,
+      }),
+    });
+  });
+
+  let confirmBody: {
+    reading_token: string;
+    final_mm_ss: { m: number; s: number };
+    is_baseline?: boolean;
+  } | null = null;
+  await page.route("**/api/v1/watches/**/readings/verified/confirm", async (route) => {
+    const req = route.request();
+    const raw = req.postData();
+    confirmBody = raw ? JSON.parse(raw) : null;
+    // Return a plausible reading row. The SPA's parent panel
+    // (`WatchDetailPage`) calls `reloadReadings()` after the
+    // confirm; we don't need to mock that — `reloadReadings`
+    // hits the real /readings endpoint which returns whatever
+    // is in D1 (empty in this case, which is fine — the panel
+    // still renders).
+    return route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "fake-reading-id",
+        watch_id: "fake-watch-id",
+        user_id: "fake-user-id",
+        reference_timestamp: Date.now(),
+        deviation_seconds: 0,
+        is_baseline: false,
+        verified: true,
+        notes: null,
+        created_at: new Date().toISOString(),
+      }),
+    });
+  });
+
+  // ---- 1. Register + add a watch ---------------------------------
+  await page.goto("/app/register");
+  await page.getByLabel("Display name").fill(name);
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: /create account/i }).click();
+  await page.waitForURL("**/app/dashboard", { timeout: 15_000 });
+
+  await page.getByRole("link", { name: "Add watch", exact: true }).click();
+  await page.waitForURL("**/app/watches/new", { timeout: 10_000 });
+
+  await page.getByLabel("Name").fill(watchName);
+  const movementInput = page.getByLabel("Movement");
+  await movementInput.fill("ETA");
+  const option = page.getByRole("listbox").getByText(/^ETA 2824-2$/);
+  await option.waitFor({ state: "visible", timeout: 10_000 });
+  await option.click();
+  await page.getByRole("button", { name: /add watch/i }).click();
+  await page.waitForURL(/\/app\/watches\/[^/]+$/, { timeout: 15_000 });
+
+  // ---- 2. Verified-reading panel renders -------------------------
+  const panel = page.getByRole("region", { name: "Verified reading" });
+  await expect(panel).toBeVisible();
+
+  // ---- 3. Choose a file, submit → /draft fires → confirm renders -
+  const fileInput = panel.locator('input[type="file"]');
+  await fileInput.setInputFiles({
+    name: "dial.png",
+    mimeType: "image/png",
+    buffer: tinyPngBuffer(),
+  });
+  await panel.getByRole("button", { name: /submit verified reading/i }).click();
+
+  const confirmation = panel.getByTestId("verified-reading-confirmation");
+  await expect(confirmation).toBeVisible({ timeout: 15_000 });
+  expect(draftCalls).toBe(1);
+
+  // Photo is rendered inline — anything in the <img src> is fine,
+  // the data-URL we returned in the mock or any other URL would do.
+  await expect(confirmation.getByTestId("confirmation-photo")).toBeVisible();
+
+  // Prediction display shows the predicted MM:SS verbatim.
+  const predictionEl = confirmation.getByTestId("prediction-mm-ss");
+  await expect(predictionEl).toContainText("19");
+  await expect(predictionEl).toContainText("34");
+
+  // ---- 4. Anti-cheat DOM probe -----------------------------------
+  //
+  // Critical assertion. The whole point of the slice is that the
+  // user can't see "you're +5s ahead" or similar — the deviation
+  // is server-internal until /confirm saves and the user reaches
+  // the readings list. If a future refactor accidentally renders
+  // the deviation here, this assertion fails and CI blocks the
+  // change.
+  await expect(confirmation.locator('[data-testid="deviation"]')).toHaveCount(0);
+  await expect(confirmation.getByText(/drift|deviation|[+-]\d+\s*s\b/i)).toHaveCount(0);
+
+  // ---- 5. ± buttons adjust seconds in 1s steps -------------------
+  const plusBtn = confirmation.getByTestId("confirmation-plus");
+  for (let i = 0; i < 4; i += 1) {
+    await plusBtn.click();
+  }
+  // After 4 clicks: 34 → 35 → 36 → 37 → 38. The minutes display
+  // should still be "19".
+  await expect(confirmation.getByTestId("confirmation-seconds")).toHaveText("38");
+  await expect(confirmation.getByTestId("confirmation-minutes")).toHaveText("19");
+
+  // The "± X / 30 used" counter ticked along.
+  await expect(confirmation.getByTestId("confirmation-clicks-used")).toContainText("4");
+
+  // ---- 6. Confirm posts the user-adjusted MM:SS ------------------
+  await confirmation.getByTestId("confirmation-confirm").click();
+
+  // Wait for the success banner to swap in (the parent component
+  // transitions to `success` once /confirm returns 201).
+  await expect(panel.getByRole("status")).toBeVisible({ timeout: 15_000 });
+  await expect(panel.getByRole("status")).toContainText(/saved/i);
+
+  // The mock captured the POST body — assert the SPA sent the
+  // user-adjusted MM:SS, not the predicted one.
+  expect(confirmBody).not.toBeNull();
+  expect(confirmBody!.reading_token).toBe(FAKE_TOKEN);
+  expect(confirmBody!.final_mm_ss).toEqual({ m: 19, s: 38 });
+});


### PR DESCRIPTION
## Summary

Closes #106. Slice #7 of PRD #99: the SPA confirmation page that closes the verified-reading anti-cheat loop.

After the user uploads a photo via the existing add-reading flow, they now land on an inline confirmation page that:

- shows the photo they just took (rendered from R2 / draft URL)
- shows the VLM's predicted MM:SS in a large display
- offers `+` / `−` buttons to nudge seconds in 1s steps (with minute-wrap)
- offers Retake (returns to capture) and Confirm (POSTs to `/confirm`)
- **never displays the deviation** — that's the anti-cheat property

The deviation only surfaces *after* the reading is saved, on the watch's existing readings list. The user adjusts based on what they see on the dial; they don't know what value would yield a "perfect" drift rate, so honest reads are their dominant strategy.

This slice also rewires the SPA's verified-reading client. The synchronous `POST /verified` route was removed in slice #6 (issue #105) and replaced with `/draft` + `/confirm`; this PR removes the dead `createVerifiedReading` client and adds two new ones (`draftVerifiedReading`, `confirmVerifiedReading`).

## Changes

### `src/app/watches/verifiedReadingAdjustment.ts` + tests (commit 1)

Pure helpers for the seconds-adjustment math:
- `adjustSeconds(mmSs, ±delta)` — wrap-aware MM:SS arithmetic on the [0, 3600) circle. **Critical: clamping at 59 would leak "you've hit the natural maximum" as a deviation hint, breaking the anti-cheat property.**
- `mmSsCircularDistance(a, b)` — wrap-aware shortest signed distance. Mirrors `mmSsCircularDistance` in the route handler so client and server agree on what "30s away" means.
- `clicksUsed(predicted, current)` — drives the "± X / 30 used" counter.
- `canAdjust(predicted, current, ±1)` — drives the +/- button disable state at the limit.

17 unit tests covering minute boundaries, the 60-minute wrap edge case, and the limit-disable matrix.

### `src/app/watches/VerifiedReadingConfirmation.tsx` + `VerifiedReadingCapture.tsx` (commit 2)

New `VerifiedReadingConfirmation` component renders the confirmation step. Has a single `submitState` state machine (`idle | submitting | error`), POSTs to `/confirm` itself, bubbles the saved reading up to the parent.

`VerifiedReadingCapture` gains a `confirming` UiState variant. After `/draft` succeeds, it renders the confirmation step inline. On Retake we bounce back to `idle` (the draft photo on R2 expires via the 24h lifecycle rule from slice #6 — no client-side cleanup needed).

The error mapper grew two new codes:
- `invalid_token` (401) — expired session → retake
- `adjustment_too_large` (422) — > ±30s nudged somehow → retake (the SPA's button disable should make this unreachable, but the server is the security boundary)

### `tests/e2e/verified-reading-confirmation.smoke.test.ts` (commit 3)

Playwright smoke test covering the whole slice surface area. Route-mocks `/draft` and `/confirm` so the test is deterministic — no real VLM call (saves AI Gateway credits, dodges variable latency, sidesteps the 5-min EXIF bounds gate that fixture-shipped photos can't satisfy in CI).

Asserts:
- confirmation page renders (photo, prediction, +/- buttons, counter)
- **anti-cheat DOM probe**: zero `[data-testid="deviation"]` and zero text matching `/drift|deviation|[+-]\d+s\b/i`
- 4× clicks on `+` advances seconds by 4
- Confirm POSTs the user-adjusted MM:SS (`19:38`), not the predicted (`19:34`)

The route-handler behaviour (signature/expiry/adjustment-cap enforcement) is already covered by `tests/integration/readings.verified.test.ts` from slice #6.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean (378 KB JS, +5 KB from main for the new component)
- `npm run test` — 594 passed, 5 skipped (no new failures)
- `npx playwright test --list` — confirms the new spec is discovered

E2E will run against the preview deploy in CI per the existing workflow.

## Anti-cheat property in one paragraph

The confirmation page renders the prediction MM:SS but never the deviation. The hour from the server clock IS shown, but as a small "Reading at HH:" prefix above (not beside) the prediction — so the user can't trivially read a continuous HH:MM:SS triple and compare against the EXIF anchor (which they don't have anyway). The +/- buttons step in 1s, capped at ±30s on both client (UX) and server (security). A user adjusts based on what they see on their watch's actual dial; they have no way to compute "what value would yield a perfect drift rate", so honesty is their dominant strategy.