### PR TITLE
fix(verified-reading): serve draft photos + show full HH:MM:SS on confirmation

### DIFF
--- a/src/app/watches/VerifiedReadingConfirmation.tsx
+++ b/src/app/watches/VerifiedReadingConfirmation.tsx
@@ -119,12 +119,28 @@ export function VerifiedReadingConfirmation({
     onConfirmed(result.reading);
   }
 
-  // Hour display: rendered in a small "Reading at HH:" prefix above
-  // the prediction. Deliberately separated from the MM:SS so the
-  // user can't trivially compose hh:mm:ss in their head and compare
-  // against the EXIF reference (which they don't have anyway). The
-  // hour is always padded to 2 digits to avoid different visual
-  // widths between e.g. "9" and "10".
+  // Hour display. Comes from the server clock (the SPA cannot
+  // change it; only the seconds are user-editable) and is rendered
+  // as the leftmost component of the predicted time so the user can
+  // verify it matches what their watch actually shows on the dial.
+  // Critical for the rollover edge cases (e.g. server hour = 11
+  // while the watch reads 10:59:30 — without seeing "10" beside the
+  // ":59:30" prediction, the user can't distinguish the system's
+  // hour assumption from their dial's actual hour).
+  //
+  // ## Anti-cheat tradeoff vs the original "small prefix" design
+  //
+  // The original slice-#7 layout rendered "Reading at HH:" as a tiny
+  // separated label so the user couldn't trivially compose HH:MM:SS
+  // in their head and compare against the EXIF anchor. In practice
+  // the user already knows the rough current time from their phone
+  // clock, so hiding the system's hour assumption added confusion
+  // (rollover ambiguity) without preventing cheating. Showing the
+  // hour does NOT leak the precise computed deviation — that comes
+  // from a HH:MM:SS - HH:MM:SS subtraction the user would have to
+  // do mentally with the EXIF reference (which they still don't
+  // have). The seconds-only ±30s adjustment cap remains the
+  // primary cheat barrier.
   const hourLabel = String(draft.hour_from_server_clock).padStart(2, "0");
 
   return (
@@ -148,28 +164,44 @@ export function VerifiedReadingConfirmation({
       />
 
       <div className="flex flex-col items-center gap-1 py-2">
-        {/* The "Reading at HH:" prefix sits ABOVE the MM:SS, not
-            beside it, so the user's eye doesn't read across as a
-            single HH:MM:SS triple. Deliberate UX choice — see the
-            anti-cheat note at the top of this file. */}
-        <span className="text-xs uppercase tracking-wide text-ink-muted">
-          Reading at {hourLabel}:
-        </span>
         <div
-          data-testid="prediction-mm-ss"
-          aria-label={`Reading shows ${formatMmSs(current)}`}
+          data-testid="prediction-hh-mm-ss"
+          aria-label={`Reading shows ${hourLabel}:${formatMmSs(current)}`}
           className="font-mono text-5xl font-light tabular-nums text-ink"
         >
+          {/* Hour: non-editable, comes from the server reference clock
+              (slice #6 of PRD #99). Shown prominently — same size as
+              MM:SS — so the user can verify the rollover-side at a
+              glance against what's on their dial. */}
+          <span data-testid="confirmation-hours" className="text-ink-muted">
+            {hourLabel}
+          </span>
+          <span aria-hidden="true" className="mx-1 text-ink-muted">
+            :
+          </span>
+          {/* Minutes: predicted by the VLM, NOT user-adjustable. If
+              the dial's minute reading doesn't match what's
+              displayed here, the user retakes — minutes-off-by-one
+              is outside the ±30s seconds nudge. */}
           <span data-testid="confirmation-minutes">
             {String(current.m).padStart(2, "0")}
           </span>
           <span aria-hidden="true" className="mx-1 text-ink-muted">
             :
           </span>
+          {/* Seconds: predicted by the VLM, user-adjustable via ±
+              buttons within ±30s of the prediction. Visually
+              accent-coloured so it's clearly the actionable element. */}
           <span data-testid="confirmation-seconds" className="text-accent">
             {String(current.s).padStart(2, "0")}
           </span>
         </div>
+        <span className="text-xs uppercase tracking-wide text-ink-muted">
+          {/* Plain English caption — orients the user without
+              giving away any deviation hint. Doesn't match the
+              anti-cheat regex /drift|deviation|[+-]\d+s/i. */}
+          Tap ± to nudge seconds to match your dial
+        </span>
       </div>
 
       <div className="flex items-center justify-center gap-4">

--- a/src/server/routes/images.ts
+++ b/src/server/routes/images.ts
@@ -218,3 +218,74 @@ watchImagePublicRoute.get("/:id", async (c) => {
   );
   return new Response(object.body, { status: 200, headers });
 });
+
+// -------------------------------------------------------------------
+// Authed (owner-only): GET /images/drafts/:userId/:filename
+// -------------------------------------------------------------------
+//
+// Serves the draft photo persisted by `POST
+// /api/v1/watches/:id/readings/verified/draft` (slice #6 of PRD #99 —
+// issue #105). The /draft handler returns
+// `photo_url = "${origin}/images/drafts/${user_id}/${uuid}.jpg"`; the
+// SPA's confirmation page (slice #7 — issue #106) renders that URL in
+// an `<img>` tag so the user can verify the captured dial before
+// confirming.
+//
+// Without this route the photo URL 404s and the user can't see what
+// the VLM read — they're flying blind. PR following this issue adds
+// the missing route handler.
+//
+// Access control:
+//   * Anonymous → 404 (don't even leak that the URL exists).
+//   * Authed but `userId` segment !== caller's user.id → 404.
+//   * Owner → 200 + the JPEG bytes, with a `private, no-store`
+//     Cache-Control because drafts are short-lived (24h R2
+//     lifecycle expiry, 5-min reading-token TTL — see slice #6).
+//   * R2 object missing → 404. This happens after `/confirm` moves
+//     the photo to `verified/{user_id}/{reading_id}.jpg`, or after
+//     the 24h lifecycle rule expires an abandoned draft.
+//
+// Filename validation:
+//   * Reject any filename outside the `/^[a-f0-9-]{36}\.jpg$/`
+//     UUID-v4 + .jpg shape we mint in /draft. Prevents path traversal
+//     and arbitrary R2 key probing.
+//
+// Cache-Control: `private, no-store` — drafts are ephemeral and
+// owner-specific; we don't want any cache (browser, Cloudflare edge,
+// or otherwise) to serve a stale draft after the user's confirmed
+// the reading.
+
+const DRAFT_FILENAME_PATTERN = /^[a-f0-9-]{36}\.jpg$/i;
+
+export const verifiedDraftImageRoute = new Hono<{ Bindings: Bindings }>();
+
+verifiedDraftImageRoute.get("/:userId/:filename", async (c) => {
+  const userIdSegment = c.req.param("userId");
+  const filename = c.req.param("filename");
+  if (!userIdSegment || !filename || !DRAFT_FILENAME_PATTERN.test(filename)) {
+    return c.body(null, 404);
+  }
+
+  // Resolve session without forcing one — owner check below decides.
+  const auth = getAuth(c.env);
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const callerId = (session?.user as { id: string } | undefined)?.id ?? null;
+  if (callerId === null || callerId !== userIdSegment) {
+    return c.body(null, 404);
+  }
+
+  const r2Key = `drafts/${userIdSegment}/${filename}`;
+  const object = await c.env.WATCH_IMAGES.get(r2Key);
+  if (!object) {
+    return c.body(null, 404);
+  }
+
+  const headers = new Headers();
+  headers.set("content-type", object.httpMetadata?.contentType ?? "image/jpeg");
+  if (object.httpEtag) {
+    headers.set("etag", object.httpEtag);
+  }
+  // No-store on drafts: ephemeral + owner-specific.
+  headers.set("cache-control", "private, no-store");
+  return new Response(object.body, { status: 200, headers });
+});

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -22,7 +22,11 @@ import {
 import { loadPublicWatch } from "@/public/watch/load";
 import { WatchNotFoundPage, WatchPage } from "@/public/watch/page";
 import { getAuth, type AuthEnv } from "@/server/auth";
-import { watchImagePublicRoute, watchImageRoute } from "@/server/routes/images";
+import {
+  verifiedDraftImageRoute,
+  watchImagePublicRoute,
+  watchImageRoute,
+} from "@/server/routes/images";
 import { leaderboardRoute } from "@/server/routes/leaderboard";
 import { meRoute } from "@/server/routes/me";
 import { movementsRoute } from "@/server/routes/movements";
@@ -319,6 +323,15 @@ app.route("/api/v1/watches", watchesRoute);
 // <img src> references it directly and a future CDN cache rule will
 // key off the stable /images/* prefix.
 app.route("/images/watches", watchImagePublicRoute);
+
+// Owner-only draft-photo serving for the verified-reading two-step
+// flow. The /verified/draft endpoint (slice #6 of PRD #99) returns
+// `photo_url = "${origin}/images/drafts/${user_id}/${uuid}.jpg"`;
+// the SPA confirmation page (slice #7) renders that URL in an
+// `<img>`. The route handler validates session ownership before
+// streaming the JPEG out of the WATCH_IMAGES bucket. See
+// src/server/routes/images.ts for the access-control rationale.
+app.route("/images/drafts", verifiedDraftImageRoute);
 
 // Outbound click-tracking redirects — /out/chrono24/:movementId and
 // friends. See src/server/routes/out.ts. Owned by the Worker (see

--- a/tests/e2e/verified-reading-confirmation.smoke.test.ts
+++ b/tests/e2e/verified-reading-confirmation.smoke.test.ts
@@ -158,10 +158,16 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
   // the data-URL we returned in the mock or any other URL would do.
   await expect(confirmation.getByTestId("confirmation-photo")).toBeVisible();
 
-  // Prediction display shows the predicted MM:SS verbatim.
-  const predictionEl = confirmation.getByTestId("prediction-mm-ss");
+  // Prediction display shows the predicted HH:MM:SS verbatim. Hour
+  // is the server-clock hour from the /draft response (14:xx:xx in
+  // this fixture); minutes + seconds come from the VLM's read.
+  const predictionEl = confirmation.getByTestId("prediction-hh-mm-ss");
+  await expect(predictionEl).toContainText("14");
   await expect(predictionEl).toContainText("19");
   await expect(predictionEl).toContainText("34");
+  // The hour element is its own testid so the rollover-edge-case
+  // verification is independent of the MM:SS sub-elements.
+  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("14");
 
   // ---- 4. Anti-cheat DOM probe -----------------------------------
   //

--- a/tests/e2e/verified-reading.smoke.test.ts
+++ b/tests/e2e/verified-reading.smoke.test.ts
@@ -137,8 +137,16 @@ test("register → add watch → verified-reading flow renders and surfaces flag
   // E2E against the real container.
   await submitBtn.click();
   const outcome = panel.locator('[role="alert"], [role="status"]');
+  // Widened the regex with the new VLM-pipeline error vocabulary
+  // introduced by PRD #99 (slices #4–#6). Any of these outcomes is
+  // acceptable; the smoke only checks that *some* human-readable
+  // outcome surfaces, regardless of which preview-side path the
+  // dial reader lands on (flag-off, transport error, model
+  // refusal, anchor mismatch, etc.). When the flag-off vs flag-on
+  // behaviour matters specifically, write an integration test with
+  // a faked reader rather than an E2E against the real gateway.
   await expect(outcome.first()).toContainText(
-    /verified readings aren't enabled|ai returned an unexpected response|couldn't read the dial|reading looked off|saved\.\s*dial read/i,
+    /verified readings aren't enabled|ai returned an unexpected response|couldn't read the dial|reading looked off|saved\.\s*dial read|connection failed while reading dial|reconcile the dial with your phone's clock|inconclusive read|please retake the photo|reading session expired/i,
     { timeout: 20_000 },
   );
 });

--- a/tests/integration/verified-draft-images.test.ts
+++ b/tests/integration/verified-draft-images.test.ts
@@ -1,0 +1,183 @@
+// Integration tests for the GET /images/drafts/:userId/:filename
+// route added in this PR. The route serves the draft photos that
+// `POST /verified/draft` (slice #6 of PRD #99) writes to R2 at
+// `drafts/{user_id}/{uuid}.jpg`. The SPA's confirmation page renders
+// the URL in an `<img>` so the user can verify the captured dial
+// before tapping Confirm.
+//
+// The handler is owner-only — callerId === userIdSegment in the URL.
+// Non-owners and anonymous callers get 404 (NOT 401/403) so a probe
+// can't distinguish "this draft exists but isn't yours" from "no
+// draft here at all". Filename is validated against a strict
+// `^[a-f0-9-]{36}\.jpg$` pattern so the URL can't be twisted into
+// path-traversal or arbitrary R2 key reads.
+
+import { env } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+
+function makeEmail(prefix = "draft-images"): string {
+  return `${prefix}-${crypto.randomUUID()}@ratedwatch.test`;
+}
+
+async function signUp(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: email.split("@")[0]!, email, password }),
+    }),
+  );
+}
+
+async function signIn(email: string, password: string): Promise<Response> {
+  return exports.default.fetch(
+    new Request("https://ratedwatch.test/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+}
+
+interface TestUser {
+  cookie: string;
+  userId: string;
+}
+
+async function registerAndGetCookie(): Promise<TestUser> {
+  const email = makeEmail();
+  const password = "correct-horse-42";
+  const reg = await signUp(email, password);
+  expect(reg.status).toBe(200);
+  const regBody = (await reg.json()) as { user: { id: string } };
+  const loginRes = await signIn(email, password);
+  expect(loginRes.status).toBe(200);
+  const rawCookie = loginRes.headers.get("set-cookie") ?? "";
+  const cookie = rawCookie.split(";")[0] ?? "";
+  return { cookie, userId: regBody.user.id };
+}
+
+/** Plant a fake draft photo in R2 at the canonical key. */
+async function plantDraft(userId: string, filename: string): Promise<string> {
+  const key = `drafts/${userId}/${filename}`;
+  const bytes = new Uint8Array([
+    0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+  ]);
+  const r2 = (env as unknown as { WATCH_IMAGES: R2Bucket }).WATCH_IMAGES;
+  await r2.put(key, bytes, { httpMetadata: { contentType: "image/jpeg" } });
+  return key;
+}
+
+async function fetchDraftImage(
+  userId: string,
+  filename: string,
+  cookie?: string,
+): Promise<Response> {
+  return exports.default.fetch(
+    new Request(`https://ratedwatch.test/images/drafts/${userId}/${filename}`, {
+      method: "GET",
+      headers: cookie ? { cookie } : undefined,
+    }),
+  );
+}
+
+const TIMEOUT = 30_000;
+
+describe("GET /images/drafts/:userId/:filename", () => {
+  it(
+    "owner gets the JPEG with private/no-store cache headers",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const filename = `${crypto.randomUUID()}.jpg`;
+      await plantDraft(owner.userId, filename);
+
+      const res = await fetchDraftImage(owner.userId, filename, owner.cookie);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/jpeg");
+      // Drafts are short-lived + owner-specific — no caching anywhere.
+      expect(res.headers.get("cache-control")).toBe("private, no-store");
+
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      expect(bytes[0]).toBe(0xff);
+      expect(bytes[1]).toBe(0xd8); // JPEG magic preserved
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "anonymous caller gets 404 (does not leak existence)",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const filename = `${crypto.randomUUID()}.jpg`;
+      await plantDraft(owner.userId, filename);
+
+      const res = await fetchDraftImage(owner.userId, filename, undefined);
+      expect(res.status).toBe(404);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "non-owner authed caller gets 404 even when the draft exists",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const intruder = await registerAndGetCookie();
+      const filename = `${crypto.randomUUID()}.jpg`;
+      await plantDraft(owner.userId, filename);
+
+      const res = await fetchDraftImage(owner.userId, filename, intruder.cookie);
+      expect(res.status).toBe(404);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "404 when the R2 object is missing (e.g. confirmed and moved, or expired)",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const filename = `${crypto.randomUUID()}.jpg`;
+      // Note: NOT planting the object — this exercises the missing-object branch.
+
+      const res = await fetchDraftImage(owner.userId, filename, owner.cookie);
+      expect(res.status).toBe(404);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "rejects non-UUID filenames (path-traversal probe) with 404",
+    async () => {
+      const owner = await registerAndGetCookie();
+
+      // Each of these MUST 404 without ever touching R2.
+      const malformed = [
+        "..%2F..%2Fwatches%2Fsome-id%2Fimage", // escaped path traversal
+        "image.png", // wrong extension
+        "deadbeef.jpg", // too short to be a UUID
+        "%2e%2e%2fblob.jpg", // escaped ../
+      ];
+      for (const filename of malformed) {
+        const res = await fetchDraftImage(owner.userId, filename, owner.cookie);
+        expect(res.status, `filename=${filename}`).toBe(404);
+      }
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "rejects when the userId segment doesn't look like a session user",
+    async () => {
+      const owner = await registerAndGetCookie();
+      const filename = `${crypto.randomUUID()}.jpg`;
+      await plantDraft(owner.userId, filename);
+
+      // Right filename, but the userId segment is some other arbitrary
+      // string that's not the caller's session userId. Must 404.
+      const fakeUserId = "not-the-caller";
+      const res = await fetchDraftImage(fakeUserId, filename, owner.cookie);
+      expect(res.status).toBe(404);
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
See commit message for full context. Two fixes: the /images/drafts/* route was missing (so the SPA <img> 404'd) and the hour wasn't prominent enough for rollover edge cases. New integration test + E2E update. 600 tests green. Refs #99