### PR TITLE
feat(verified-reading): per-component HH:MM:SS adjustment + drop ±30s cap

### DIFF
--- a/src/app/watches/VerifiedReadingConfirmation.tsx
+++ b/src/app/watches/VerifiedReadingConfirmation.tsx
@@ -1,51 +1,44 @@
-// Confirmation step for the verified-reading two-step flow (slice #7
-// of PRD #99 — issue #106).
+// Confirmation step for the verified-reading two-step flow (slice
+// #7 of PRD #99 — issue #106). Reworked in PR #122 to:
 //
-// Rendered after `POST /readings/verified/draft` returns. The user
-// sees their photo + the VLM's predicted MM:SS and either:
+//   1. Render full HH:MM:SS in a single row at large size, with
+//      independent up/down adjusters under each component (matches
+//      the user's mental model: "set each digit to what your
+//      watch shows").
 //
-//   1. Nudges ± seconds (within ±30s) to match what the dial actually
-//      reads, then taps Confirm → POSTs /confirm and lands on the
-//      watch detail's history pane.
-//   2. Taps Retake → returns to the capture step. The draft photo on
-//      R2 expires via the 24h lifecycle rule (see
-//      `infra/terraform/r2.tf`) so abandoned drafts don't pile up.
+//   2. Drop the ±30s seconds-only adjustment cap. The cap was
+//      always more about UI nudge than fraud prevention — a
+//      determined cheater knows the rough current time from their
+//      phone clock and can game the value either direction. The
+//      photo audit trail and the rate-limit are the real
+//      defences.
+//
+//   3. Use the new `predicted_hms` from /draft (replacing
+//      `predicted_mm_ss` + `hour_from_server_clock` returned
+//      separately).
 //
 // ## Anti-cheat property (the whole point of this slice)
 //
 // The page MUST NOT show:
 //   * the EXIF reference time
 //   * any computed deviation
-//   * any text that would let the user reverse-engineer the deviation
-//     (e.g. "+5s ahead", "5s drift")
+//   * any text that would let the user reverse-engineer the
+//     deviation (e.g. "+5s ahead", "5s drift")
 //
-// The hour from the server clock IS shown — but as a small prefix
-// ("Reading at 14:") deliberately separated from the prediction
-// display, so the brain has to do non-trivial mental arithmetic to
-// derive a deviation. The +/- buttons let the user shift seconds
-// based on what they see on their watch's dial; they don't know
-// what value would yield a "perfect" drift rate, so the dominant
-// strategy is honesty.
-//
-// The E2E test in `tests/e2e/verified-reading-confirmation.smoke.test.ts`
-// asserts this with a DOM probe (no element matching
-// `[data-testid="deviation"]`, no text matching `/drift|deviation|[+-]\d+s/i`).
-//
-// ## ±30s adjustment cap
-//
-// The server enforces ±30s in `/confirm` (slice #6); we mirror it
-// client-side via `canAdjust` from `verifiedReadingAdjustment.ts` so
-// the buttons disable visually at the limit. UI is convenience;
-// server is security.
+// Showing the full HH:MM:SS doesn't violate this — the user
+// already knows the rough current time from their phone clock,
+// so showing the system's read of their watch doesn't leak the
+// (server-internal) deviation. The E2E test in
+// `tests/e2e/verified-reading-confirmation.smoke.test.ts` asserts
+// no `[data-testid="deviation"]` and no text matching
+// `/drift|deviation|[+-]\d+s/i` — both still hold under the new
+// layout.
 
 import { useState } from "react";
 import {
-  ADJUSTMENT_LIMIT_SECONDS,
-  adjustSeconds,
-  canAdjust,
-  clicksUsed,
-  formatMmSs,
-  type MmSs,
+  adjustComponent,
+  type Hms,
+  type HmsComponent,
 } from "./verifiedReadingAdjustment";
 import {
   confirmVerifiedReading,
@@ -83,23 +76,14 @@ export function VerifiedReadingConfirmation({
   onConfirmed,
   onRetake,
 }: Props) {
-  // The user's working MM:SS — starts at the prediction, mutates as
-  // they nudge. Confirm POSTs whatever `current` is at click time.
-  const [current, setCurrent] = useState<MmSs>(draft.predicted_mm_ss);
+  // The user's working HMS — starts at the prediction, mutates per
+  // component as they tap up/down. Confirm POSTs whatever `current`
+  // is at click time.
+  const [current, setCurrent] = useState<Hms>(draft.predicted_hms);
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
 
-  const used = clicksUsed(draft.predicted_mm_ss, current);
-  const canPlus = canAdjust(draft.predicted_mm_ss, current, 1);
-  const canMinus = canAdjust(draft.predicted_mm_ss, current, -1);
-
-  function handlePlus() {
-    if (!canPlus) return;
-    setCurrent((c) => adjustSeconds(c, 1));
-  }
-
-  function handleMinus() {
-    if (!canMinus) return;
-    setCurrent((c) => adjustSeconds(c, -1));
+  function handleAdjust(component: HmsComponent, delta: 1 | -1) {
+    setCurrent((c) => adjustComponent(c, component, delta));
   }
 
   async function handleConfirm() {
@@ -107,7 +91,7 @@ export function VerifiedReadingConfirmation({
     setSubmitState({ kind: "submitting" });
     const result = await confirmVerifiedReading(watchId, {
       reading_token: draft.reading_token,
-      final_mm_ss: current,
+      final_hms: current,
       is_baseline: isBaseline,
     });
     if (!result.ok) {
@@ -119,30 +103,6 @@ export function VerifiedReadingConfirmation({
     onConfirmed(result.reading);
   }
 
-  // Hour display. Comes from the server clock (the SPA cannot
-  // change it; only the seconds are user-editable) and is rendered
-  // as the leftmost component of the predicted time so the user can
-  // verify it matches what their watch actually shows on the dial.
-  // Critical for the rollover edge cases (e.g. server hour = 11
-  // while the watch reads 10:59:30 — without seeing "10" beside the
-  // ":59:30" prediction, the user can't distinguish the system's
-  // hour assumption from their dial's actual hour).
-  //
-  // ## Anti-cheat tradeoff vs the original "small prefix" design
-  //
-  // The original slice-#7 layout rendered "Reading at HH:" as a tiny
-  // separated label so the user couldn't trivially compose HH:MM:SS
-  // in their head and compare against the EXIF anchor. In practice
-  // the user already knows the rough current time from their phone
-  // clock, so hiding the system's hour assumption added confusion
-  // (rollover ambiguity) without preventing cheating. Showing the
-  // hour does NOT leak the precise computed deviation — that comes
-  // from a HH:MM:SS - HH:MM:SS subtraction the user would have to
-  // do mentally with the EXIF reference (which they still don't
-  // have). The seconds-only ±30s adjustment cap remains the
-  // primary cheat barrier.
-  const hourLabel = String(draft.hour_from_server_clock).padStart(2, "0");
-
   return (
     <div
       data-testid="verified-reading-confirmation"
@@ -151,8 +111,7 @@ export function VerifiedReadingConfirmation({
       <header className="flex flex-col gap-1">
         <h3 className="text-sm font-medium text-ink">Confirm your reading</h3>
         <p className="text-xs text-ink-muted">
-          Adjust if needed, then confirm. The dial reading you submit becomes your
-          reading.
+          Adjust each value to match what your dial shows, then confirm.
         </p>
       </header>
 
@@ -163,74 +122,49 @@ export function VerifiedReadingConfirmation({
         className="max-h-96 w-full rounded-md border border-line object-contain"
       />
 
-      <div className="flex flex-col items-center gap-1 py-2">
-        <div
-          data-testid="prediction-hh-mm-ss"
-          aria-label={`Reading shows ${hourLabel}:${formatMmSs(current)}`}
-          className="font-mono text-5xl font-light tabular-nums text-ink"
-        >
-          {/* Hour: non-editable, comes from the server reference clock
-              (slice #6 of PRD #99). Shown prominently — same size as
-              MM:SS — so the user can verify the rollover-side at a
-              glance against what's on their dial. */}
-          <span data-testid="confirmation-hours" className="text-ink-muted">
-            {hourLabel}
-          </span>
-          <span aria-hidden="true" className="mx-1 text-ink-muted">
+      {/* Big HH:MM:SS row with up/down arrows beneath each
+          component. We render each {▲, NN, ▼} as a column so the
+          buttons line up directly under the digit they affect. */}
+      <div
+        data-testid="prediction-hh-mm-ss"
+        aria-label={`Reading shows ${formatHmsLabel(current)}`}
+        className="flex flex-col items-center gap-2 py-2"
+      >
+        <div className="flex items-center justify-center gap-2 font-mono text-5xl font-light tabular-nums text-ink">
+          <HmsColumn
+            component="h"
+            value={current.h}
+            label="hour"
+            testId="confirmation-hours"
+            onAdjust={handleAdjust}
+          />
+          <span aria-hidden="true" className="self-center text-ink-muted">
             :
           </span>
-          {/* Minutes: predicted by the VLM, NOT user-adjustable. If
-              the dial's minute reading doesn't match what's
-              displayed here, the user retakes — minutes-off-by-one
-              is outside the ±30s seconds nudge. */}
-          <span data-testid="confirmation-minutes">
-            {String(current.m).padStart(2, "0")}
-          </span>
-          <span aria-hidden="true" className="mx-1 text-ink-muted">
+          <HmsColumn
+            component="m"
+            value={current.m}
+            label="minute"
+            testId="confirmation-minutes"
+            onAdjust={handleAdjust}
+          />
+          <span aria-hidden="true" className="self-center text-ink-muted">
             :
           </span>
-          {/* Seconds: predicted by the VLM, user-adjustable via ±
-              buttons within ±30s of the prediction. Visually
-              accent-coloured so it's clearly the actionable element. */}
-          <span data-testid="confirmation-seconds" className="text-accent">
-            {String(current.s).padStart(2, "0")}
-          </span>
+          <HmsColumn
+            component="s"
+            value={current.s}
+            label="second"
+            testId="confirmation-seconds"
+            onAdjust={handleAdjust}
+          />
         </div>
         <span className="text-xs uppercase tracking-wide text-ink-muted">
           {/* Plain English caption — orients the user without
               giving away any deviation hint. Doesn't match the
               anti-cheat regex /drift|deviation|[+-]\d+s/i. */}
-          Tap ± to nudge seconds to match your dial
+          Tap ▲ or ▼ under each digit to match your dial
         </span>
-      </div>
-
-      <div className="flex items-center justify-center gap-4">
-        <button
-          type="button"
-          data-testid="confirmation-minus"
-          aria-label="Decrease seconds by 1"
-          onClick={handleMinus}
-          disabled={!canMinus}
-          className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-line bg-canvas text-2xl font-light text-ink transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          −
-        </button>
-        <span
-          data-testid="confirmation-clicks-used"
-          className="font-mono text-xs text-ink-muted"
-        >
-          ± {used} / {ADJUSTMENT_LIMIT_SECONDS} used
-        </span>
-        <button
-          type="button"
-          data-testid="confirmation-plus"
-          aria-label="Increase seconds by 1"
-          onClick={handlePlus}
-          disabled={!canPlus}
-          className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-line bg-canvas text-2xl font-light text-ink transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          +
-        </button>
       </div>
 
       {submitState.kind === "error" ? (
@@ -266,4 +200,55 @@ export function VerifiedReadingConfirmation({
       </div>
     </div>
   );
+}
+
+interface HmsColumnProps {
+  component: HmsComponent;
+  value: number;
+  /** Plural label for a11y ("hour" / "minute" / "second"). */
+  label: string;
+  /** Test ID applied to the digit element so E2E can assert text. */
+  testId: string;
+  onAdjust: (component: HmsComponent, delta: 1 | -1) => void;
+}
+
+/**
+ * One column of the HH:MM:SS row: ▲ on top, the two-digit value in
+ * the middle, ▼ on the bottom. Each button is a 36×28 tap target
+ * — slightly tighter than the 44×44 a11y minimum, but the column
+ * grid wraps the digit in the middle so the entire column is a
+ * comfortable thumb zone on mobile. The accent colour denotes
+ * "this is the user-actionable part" — same convention as the
+ * pre-PR-#122 design's seconds-only highlighting.
+ */
+function HmsColumn({ component, value, label, testId, onAdjust }: HmsColumnProps) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <button
+        type="button"
+        data-testid={`${testId}-up`}
+        aria-label={`Increase ${label} by 1`}
+        onClick={() => onAdjust(component, 1)}
+        className="inline-flex h-9 w-12 items-center justify-center rounded-md border border-line bg-canvas text-sm text-ink transition-colors hover:border-accent hover:text-accent"
+      >
+        ▲
+      </button>
+      <span data-testid={testId} className="text-accent">
+        {String(value).padStart(2, "0")}
+      </span>
+      <button
+        type="button"
+        data-testid={`${testId}-down`}
+        aria-label={`Decrease ${label} by 1`}
+        onClick={() => onAdjust(component, -1)}
+        className="inline-flex h-9 w-12 items-center justify-center rounded-md border border-line bg-canvas text-sm text-ink transition-colors hover:border-accent hover:text-accent"
+      >
+        ▼
+      </button>
+    </div>
+  );
+}
+
+function formatHmsLabel(hms: Hms): string {
+  return `${String(hms.h).padStart(2, "0")}:${String(hms.m).padStart(2, "0")}:${String(hms.s).padStart(2, "0")}`;
 }

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -195,12 +195,17 @@ export interface VerifiedReadingDraftSubmission {
  * Wire shape of the /draft 200 response. Mirrors the route handler
  * in src/server/routes/readings.ts. Critically, this object does NOT
  * include the deviation — see anti-cheat note above.
+ *
+ * PR #122 reworked this from `predicted_mm_ss` + separate
+ * `hour_from_server_clock` (24-hour UTC) into a single
+ * `predicted_hms` (12-hour analog) so the SPA's confirmation page
+ * can pre-populate per-component up/down adjusters in a single
+ * step.
  */
 export interface VerifiedReadingDraft {
   reading_token: string;
-  predicted_mm_ss: { m: number; s: number };
+  predicted_hms: { h: number; m: number; s: number };
   photo_url: string;
-  hour_from_server_clock: number;
   reference_source: "exif" | "server";
   expires_at_unix: number;
 }
@@ -257,7 +262,13 @@ export async function draftVerifiedReading(
 
 export interface ConfirmVerifiedReadingSubmission {
   reading_token: string;
-  final_mm_ss: { m: number; s: number };
+  /**
+   * Full HH:MM:SS the user is asserting their watch displays
+   * (12-hour analog clock — h ∈ [1, 12], m/s ∈ [0, 59]). PR #122
+   * replaced the seconds-only `final_mm_ss` to support
+   * per-component adjustment.
+   */
+  final_hms: { h: number; m: number; s: number };
   is_baseline?: boolean;
 }
 

--- a/src/app/watches/verifiedReadingAdjustment.test.ts
+++ b/src/app/watches/verifiedReadingAdjustment.test.ts
@@ -3,112 +3,193 @@
 // These are pure functions — no DOM, no fetch — so they run cleanly
 // inside the cloudflare-workers vitest pool alongside the rest of
 // the workers-pool tests.
+//
+// PR #122 reworked the helpers from seconds-only ±30s nudges into
+// per-component HH:MM:SS independent up/down. The old
+// `adjustSeconds` / `clicksUsed` / `canAdjust` / `mmSsCircularDistance`
+// surface area is gone; new tests cover `adjustComponent`,
+// `formatHms`, and `parseHms`.
 
 import { describe, expect, it } from "vitest";
 import {
-  ADJUSTMENT_LIMIT_SECONDS,
-  adjustSeconds,
-  canAdjust,
-  clicksUsed,
-  formatMmSs,
-  mmSsCircularDistance,
+  adjustComponent,
+  formatHms,
+  parseHms,
+  type Hms,
 } from "./verifiedReadingAdjustment";
 
-describe("adjustSeconds", () => {
-  it("increments seconds within the same minute", () => {
-    expect(adjustSeconds({ m: 19, s: 34 }, 1)).toEqual({ m: 19, s: 35 });
-    expect(adjustSeconds({ m: 19, s: 34 }, 5)).toEqual({ m: 19, s: 39 });
+describe("adjustComponent — seconds slot", () => {
+  it("increments seconds without touching minutes or hours", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "s", 1)).toEqual({
+      h: 10,
+      m: 19,
+      s: 35,
+    });
   });
 
-  it("decrements seconds within the same minute", () => {
-    expect(adjustSeconds({ m: 19, s: 34 }, -1)).toEqual({ m: 19, s: 33 });
-    expect(adjustSeconds({ m: 19, s: 34 }, -10)).toEqual({ m: 19, s: 24 });
+  it("decrements seconds without touching minutes or hours", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "s", -1)).toEqual({
+      h: 10,
+      m: 19,
+      s: 33,
+    });
   });
 
-  it("wraps forward across the minute boundary", () => {
-    // The dial doesn't clamp at 59 — going +1 from 59s lands at the
-    // next minute's 0s. Critical: clamping would leak "you've hit
-    // the wall" as a deviation hint.
-    expect(adjustSeconds({ m: 19, s: 59 }, 1)).toEqual({ m: 20, s: 0 });
-    expect(adjustSeconds({ m: 19, s: 58 }, 5)).toEqual({ m: 20, s: 3 });
+  it("wraps seconds 59 -> 0 WITHOUT carrying into minutes", () => {
+    // Critical: the watch crown analogy is "set each digit
+    // independently". Carrying would surprise the user when they
+    // wanted to fix a seconds misread without disturbing the minute.
+    expect(adjustComponent({ h: 10, m: 19, s: 59 }, "s", 1)).toEqual({
+      h: 10,
+      m: 19,
+      s: 0,
+    });
   });
 
-  it("wraps backward across the minute boundary", () => {
-    expect(adjustSeconds({ m: 20, s: 0 }, -1)).toEqual({ m: 19, s: 59 });
-    expect(adjustSeconds({ m: 20, s: 2 }, -5)).toEqual({ m: 19, s: 57 });
+  it("wraps seconds 0 -> 59 WITHOUT carrying into minutes", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 0 }, "s", -1)).toEqual({
+      h: 10,
+      m: 19,
+      s: 59,
+    });
   });
 
-  it("wraps across the 60-minute boundary (total seconds modulo 3600)", () => {
-    // Theoretical edge case. The product flow uses ±30s so this
-    // shouldn't fire in practice, but the helper handles it.
-    expect(adjustSeconds({ m: 59, s: 59 }, 1)).toEqual({ m: 0, s: 0 });
-    expect(adjustSeconds({ m: 0, s: 0 }, -1)).toEqual({ m: 59, s: 59 });
-  });
-});
-
-describe("mmSsCircularDistance", () => {
-  it("is zero for identical pairs", () => {
-    expect(mmSsCircularDistance({ m: 19, s: 34 }, { m: 19, s: 34 })).toBe(0);
+  it("handles large positive deltas with modulo", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 30 }, "s", 65)).toEqual({
+      h: 10,
+      m: 19,
+      s: (30 + 65) % 60, // 35
+    });
   });
 
-  it("returns the signed shortest distance for nearby pairs", () => {
-    expect(mmSsCircularDistance({ m: 19, s: 35 }, { m: 19, s: 34 })).toBe(1);
-    expect(mmSsCircularDistance({ m: 19, s: 33 }, { m: 19, s: 34 })).toBe(-1);
-  });
-
-  it("wraps through the 60-minute boundary", () => {
-    // 0m 0s is 1s after 59m 59s on the circle, not 3599s before.
-    expect(mmSsCircularDistance({ m: 0, s: 0 }, { m: 59, s: 59 })).toBe(1);
-    expect(mmSsCircularDistance({ m: 59, s: 59 }, { m: 0, s: 0 })).toBe(-1);
-  });
-});
-
-describe("clicksUsed", () => {
-  it("is zero when the user has not adjusted", () => {
-    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 34 })).toBe(0);
-  });
-
-  it("counts absolute seconds nudged in either direction", () => {
-    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 39 })).toBe(5);
-    expect(clicksUsed({ m: 19, s: 34 }, { m: 19, s: 29 })).toBe(5);
-  });
-
-  it("counts wrap-aware distance when seconds cross the minute", () => {
-    // Predicted at 19:58, current at 20:01 — the user nudged +3.
-    expect(clicksUsed({ m: 19, s: 58 }, { m: 20, s: 1 })).toBe(3);
+  it("handles large negative deltas with modulo", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 5 }, "s", -65)).toEqual({
+      h: 10,
+      m: 19,
+      s: (((5 - 65) % 60) + 60) % 60, // 0
+    });
   });
 });
 
-describe("canAdjust", () => {
-  it("allows + when under the cap", () => {
-    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 34 }, 1)).toBe(true);
-    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 3 }, 1)).toBe(true); // 29 used
+describe("adjustComponent — minutes slot", () => {
+  it("increments minutes without touching seconds or hours", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "m", 1)).toEqual({
+      h: 10,
+      m: 20,
+      s: 34,
+    });
   });
 
-  it("disables + at exactly +30", () => {
-    // Predicted 19:34, current 20:04 → 30s used. Clicking + would
-    // take it to 20:05 (31s used) which is over the cap.
-    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 4 }, 1)).toBe(false);
+  it("decrements minutes without touching seconds or hours", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "m", -1)).toEqual({
+      h: 10,
+      m: 18,
+      s: 34,
+    });
   });
 
-  it("still allows − when at the +30 limit", () => {
-    expect(canAdjust({ m: 19, s: 34 }, { m: 20, s: 4 }, -1)).toBe(true);
+  it("wraps minutes 59 -> 0 WITHOUT carrying into hours", () => {
+    expect(adjustComponent({ h: 10, m: 59, s: 34 }, "m", 1)).toEqual({
+      h: 10,
+      m: 0,
+      s: 34,
+    });
   });
 
-  it("disables − at exactly -30 (mirror of +30 case)", () => {
-    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 4 }, -1)).toBe(false);
-    expect(canAdjust({ m: 19, s: 34 }, { m: 19, s: 4 }, 1)).toBe(true);
-  });
-
-  it("ADJUSTMENT_LIMIT_SECONDS is 30 (mirrors server)", () => {
-    expect(ADJUSTMENT_LIMIT_SECONDS).toBe(30);
+  it("wraps minutes 0 -> 59 WITHOUT carrying into hours", () => {
+    expect(adjustComponent({ h: 10, m: 0, s: 34 }, "m", -1)).toEqual({
+      h: 10,
+      m: 59,
+      s: 34,
+    });
   });
 });
 
-describe("formatMmSs", () => {
-  it("zero-pads minutes and seconds", () => {
-    expect(formatMmSs({ m: 0, s: 0 })).toBe("00:00");
-    expect(formatMmSs({ m: 19, s: 34 })).toBe("19:34");
-    expect(formatMmSs({ m: 5, s: 9 })).toBe("05:09");
+describe("adjustComponent — hours slot", () => {
+  it("increments hours within 1..12", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "h", 1)).toEqual({
+      h: 11,
+      m: 19,
+      s: 34,
+    });
+  });
+
+  it("decrements hours within 1..12", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "h", -1)).toEqual({
+      h: 9,
+      m: 19,
+      s: 34,
+    });
+  });
+
+  it("wraps hours 12 -> 1 (12-hour analog cycle)", () => {
+    expect(adjustComponent({ h: 12, m: 0, s: 0 }, "h", 1)).toEqual({
+      h: 1,
+      m: 0,
+      s: 0,
+    });
+  });
+
+  it("wraps hours 1 -> 12 (12-hour analog cycle)", () => {
+    expect(adjustComponent({ h: 1, m: 0, s: 0 }, "h", -1)).toEqual({
+      h: 12,
+      m: 0,
+      s: 0,
+    });
+  });
+
+  it("handles a 12-step delta as identity", () => {
+    expect(adjustComponent({ h: 10, m: 19, s: 34 }, "h", 12)).toEqual({
+      h: 10,
+      m: 19,
+      s: 34,
+    });
+  });
+});
+
+describe("formatHms", () => {
+  it("zero-pads each component to two digits", () => {
+    expect(formatHms({ h: 1, m: 2, s: 3 })).toBe("01:02:03");
+    expect(formatHms({ h: 12, m: 59, s: 59 })).toBe("12:59:59");
+  });
+});
+
+describe("parseHms", () => {
+  it("accepts a well-formed object", () => {
+    const input = { h: 10, m: 19, s: 34 };
+    expect(parseHms(input)).toEqual(input);
+  });
+
+  it("rejects out-of-range hours", () => {
+    expect(parseHms({ h: 0, m: 0, s: 0 })).toBeNull();
+    expect(parseHms({ h: 13, m: 0, s: 0 })).toBeNull();
+    expect(parseHms({ h: -1, m: 0, s: 0 })).toBeNull();
+  });
+
+  it("rejects out-of-range minutes/seconds", () => {
+    expect(parseHms({ h: 10, m: 60, s: 0 })).toBeNull();
+    expect(parseHms({ h: 10, m: -1, s: 0 })).toBeNull();
+    expect(parseHms({ h: 10, m: 0, s: 60 })).toBeNull();
+    expect(parseHms({ h: 10, m: 0, s: -1 })).toBeNull();
+  });
+
+  it("rejects non-integers", () => {
+    expect(parseHms({ h: 10.5, m: 0, s: 0 })).toBeNull();
+    expect(parseHms({ h: NaN, m: 0, s: 0 })).toBeNull();
+  });
+
+  it("rejects non-objects + missing fields", () => {
+    expect(parseHms(null)).toBeNull();
+    expect(parseHms("10:19:34")).toBeNull();
+    expect(parseHms({ m: 19, s: 34 })).toBeNull();
+    expect(parseHms({ h: "10", m: 19, s: 34 })).toBeNull();
+  });
+});
+
+// A tiny sanity check that the type is exported and usable.
+describe("Hms type", () => {
+  it("can be constructed from literals", () => {
+    const x: Hms = { h: 10, m: 19, s: 34 };
+    expect(x.h + x.m + x.s).toBe(63);
   });
 });

--- a/src/app/watches/verifiedReadingAdjustment.ts
+++ b/src/app/watches/verifiedReadingAdjustment.ts
@@ -1,100 +1,118 @@
-// Pure helpers for the verified-reading SPA confirmation page (slice
-// #7 of PRD #99 — issue #106).
+// Pure helpers for the verified-reading SPA confirmation page.
 //
-// The confirmation page renders the VLM's predicted MM:SS and lets
-// the user nudge ± seconds before saving. Two invariants drive the
-// logic:
+// Originally added in slice #7 of PRD #99 (issue #106) with a
+// seconds-only ±30s adjustment cap. PR #122 reworks the UX into
+// per-component HH:MM:SS up/down arrows with no cap, after the
+// observation that:
 //
-//   1. Wrap-aware seconds math. When the user clicks +1 with seconds
-//      at 59, the result is `m+1, s=0` — NOT clamping at 59 (that
-//      would leak "you've hit the natural maximum" as a deviation
-//      hint). Wrapping past the 60-minute boundary is theoretically
-//      possible but practically impossible inside the ±30s adjustment
-//      window; we still handle the modulo to be safe.
+//   1. The seconds-only cap couldn't actually prevent fraud — a
+//      determined cheater knows the rough current time from their
+//      phone and can game the value either way regardless of
+//      whether the cap is ±30s, ±5s, or unbounded. The cap was
+//      always more about gentle UI nudge than security.
 //
-//   2. Wrap-aware "clicks used" calculation on the [0, 3600) MM:SS
-//      circle. Going +1 from 59m 59s lands at 0m 0s — that's a 1s
-//      adjustment, not a 3599s one. The shortest-distance metric
-//      mirrors `mmSsCircularDistance` in `src/server/routes/readings.ts`
-//      so client and server agree on what "30s away" means.
+//   2. The hour shown to the user in the original UI was derived
+//      from the server reference timestamp's UTC hour, which is
+//      WRONG when EXIF is missing and the user is in a non-UTC
+//      timezone (e.g. Lisbon DST = UTC+1 means the watch reads 14
+//      while the server says 13). The user couldn't override it,
+//      so the deviation calc silently used the wrong hour.
 //
-// The ±30s cap is enforced server-side (slice #6) — these helpers
-// drive the UI's "disable + at the limit" behaviour. The server is
-// the security boundary.
+//   3. Real watch deviations come in three shapes: seconds (typical
+//      mechanical drift), minutes (model misread or watch needs
+//      regulation), and hours (model picked the wrong rollover side
+//      or DST mismatch). All three need an adjustment knob.
+//
+// The new design: each of HH / MM / SS gets independent up/down
+// arrows. Pressing "MM ▲" at 59 wraps to 00 within the minutes
+// component only — it does NOT carry into hours. This keeps the
+// mental model dead simple ("set each digit to match what your
+// dial reads") and matches the way most setting crowns work on
+// real watches.
+//
+// The photo is still stored for audit (slice #6), the rate limiter
+// is still in front (slice #82 of PRD #73), and the SPA still
+// hides the deviation. Honest users enter what they see; cheaters
+// have always been able to cheat — the photo is the audit trail.
 
-export interface MmSs {
+/**
+ * 12-hour-clock HH:MM:SS triple, matching what an analog watch
+ * displays. `h` is 1..12 (no AM/PM signal — analog dials don't
+ * show one). `m` and `s` are 0..59.
+ */
+export interface Hms {
+  h: number;
   m: number;
   s: number;
 }
 
-/**
- * The per-click adjustment cap in seconds. Mirrors
- * `CONFIRM_ADJUSTMENT_LIMIT_SECONDS` in `src/server/routes/readings.ts`.
- * Adjustments beyond this require a retake.
- */
-export const ADJUSTMENT_LIMIT_SECONDS = 30;
+/** Which component the up/down button targets. */
+export type HmsComponent = "h" | "m" | "s";
 
 /**
- * Adjust an MM:SS pair by `delta` seconds, wrapping minute boundaries.
- * `delta` may be any integer; positive means later, negative earlier.
+ * Adjust ONE component of the HMS triple by `delta`, wrapping
+ * within that component only. Cross-component carry is intentionally
+ * disabled: pressing minutes ▲ at 59 wraps to 0 (still within the
+ * minute slot), it does NOT increment the hour. Same for seconds.
  *
- * Wrap math: total seconds = m*60 + s, then adjust modulo 3600 to
- * stay on the [0, 3600) MM:SS circle (which is what the watch dial
- * itself represents — minutes wrap every hour). Negative results are
- * lifted into the positive range with the canonical
- * `((x % n) + n) % n` idiom.
- */
-export function adjustSeconds(current: MmSs, delta: number): MmSs {
-  const total = current.m * 60 + current.s + delta;
-  const wrapped = ((total % 3600) + 3600) % 3600;
-  return { m: Math.floor(wrapped / 60), s: wrapped % 60 };
-}
-
-/**
- * Wrap-aware shortest signed distance between two MM:SS pairs on
- * the [0, 3600) circle. Returns seconds in [-1800, +1800].
+ * This matches how a manual setting crown on a watch works (you
+ * pull the crown and crank the minute hand; hours don't move with
+ * minute rollover unless you're explicitly setting them).
  *
- * Mirrors `mmSsCircularDistance` in the route handler so the SPA's
- * "X / 30 used" counter matches the server's adjustment-cap math
- * exactly.
+ * Hours wrap 12 → 1 → 12 (12-hour cycle, no zero — analog dials
+ * read "12" not "0"). Minutes and seconds wrap 59 → 0 → 59.
  */
-export function mmSsCircularDistance(a: MmSs, b: MmSs): number {
-  const aTotal = a.m * 60 + a.s;
-  const bTotal = b.m * 60 + b.s;
-  const raw = aTotal - bTotal;
-  const wrapped = (((raw + 1800) % 3600) + 3600) % 3600;
-  return wrapped - 1800;
+export function adjustComponent(
+  current: Hms,
+  component: HmsComponent,
+  delta: number,
+): Hms {
+  if (component === "h") {
+    // 12-hour cycle: map 1..12 to 0..11, add delta, mod 12, map back.
+    const idx = (((current.h - 1 + delta) % 12) + 12) % 12;
+    return { ...current, h: idx + 1 };
+  }
+  if (component === "m") {
+    const next = (((current.m + delta) % 60) + 60) % 60;
+    return { ...current, m: next };
+  }
+  // component === "s"
+  const next = (((current.s + delta) % 60) + 60) % 60;
+  return { ...current, s: next };
 }
 
 /**
- * Absolute seconds the user has nudged away from the prediction,
- * clamped to non-negative integers. Drives the "± X / 30 used" UI
- * counter and the +/- button disable state.
+ * Format an HMS triple as "HH:MM:SS" with zero padding (note: hour
+ * is 1..12 so no leading zeros are stripped — "01:02:03" looks
+ * fine, "1:02:03" would look uneven against the bigger numbers).
  */
-export function clicksUsed(predicted: MmSs, current: MmSs): number {
-  return Math.abs(mmSsCircularDistance(current, predicted));
+export function formatHms(hms: Hms): string {
+  const h = String(hms.h).padStart(2, "0");
+  const m = String(hms.m).padStart(2, "0");
+  const s = String(hms.s).padStart(2, "0");
+  return `${h}:${m}:${s}`;
 }
 
 /**
- * Whether nudging ± seconds further would cross the ±30s cap.
- * Disable the corresponding button when this returns true.
- *
- * NOTE: we look at the *signed* distance, not just the absolute. A
- * user at -30 should still be able to click + (moving toward
- * predicted), but not - (moving away). Symmetric for +30.
+ * Coerce an arbitrary input into a valid Hms or null. Used for
+ * defensive parsing of the server's predicted_hms response — if
+ * something upstream goes off the rails we don't want to render
+ * NaN in the UI or send NaN to /confirm.
  */
-export function canAdjust(predicted: MmSs, current: MmSs, delta: 1 | -1): boolean {
-  const next = adjustSeconds(current, delta);
-  const nextDist = Math.abs(mmSsCircularDistance(next, predicted));
-  return nextDist <= ADJUSTMENT_LIMIT_SECONDS;
-}
-
-/**
- * Format an MM:SS pair as "MM:SS" with zero padding. Used for the
- * big display + a11y labels.
- */
-export function formatMmSs(mmSs: MmSs): string {
-  const m = String(mmSs.m).padStart(2, "0");
-  const s = String(mmSs.s).padStart(2, "0");
-  return `${m}:${s}`;
+export function parseHms(input: unknown): Hms | null {
+  if (input === null || typeof input !== "object") return null;
+  const obj = input as Record<string, unknown>;
+  const h = obj.h;
+  const m = obj.m;
+  const s = obj.s;
+  if (typeof h !== "number" || typeof m !== "number" || typeof s !== "number") {
+    return null;
+  }
+  if (!Number.isInteger(h) || !Number.isInteger(m) || !Number.isInteger(s)) {
+    return null;
+  }
+  if (h < 1 || h > 12) return null;
+  if (m < 0 || m > 59) return null;
+  if (s < 0 || s > 59) return null;
+  return { h, m, s };
 }

--- a/src/domain/reading-token/token.test.ts
+++ b/src/domain/reading-token/token.test.ts
@@ -27,7 +27,8 @@ function makePayload(overrides: Partial<ReadingTokenPayload> = {}): ReadingToken
   return {
     photo_r2_key: "drafts/user-123/abcd-1234.jpg",
     anchor_hms: "10:19:34",
-    predicted_mm_ss: { m: 19, s: 34 },
+    reference_ms: Date.now(),
+    predicted_hms: { h: 10, m: 19, s: 34 },
     user_id: "user-123",
     watch_id: "watch-456",
     expires_at_unix: Math.floor(Date.now() / 1000) + READING_TOKEN_TTL_SECONDS,
@@ -49,7 +50,7 @@ describe("readingToken round-trip", () => {
   it("preserves all payload fields exactly", async () => {
     // Canary against a future field-stripping bug in the encoder.
     const payload = makePayload({
-      predicted_mm_ss: { m: 0, s: 59 },
+      predicted_hms: { h: 11, m: 0, s: 59 },
       anchor_hms: "23:00:01",
     });
     const decoded = await verifyReadingToken(
@@ -172,21 +173,12 @@ describe("readingToken malformed input", () => {
 });
 
 describe("readingToken shape validation", () => {
-  it("rejects a payload missing predicted_mm_ss", async () => {
-    // Manually construct a token whose payload omits a required field.
-    // We craft this so the signature is correct (otherwise we'd be
-    // testing tamper detection, not shape validation).
+  // Helper: forge a correctly-signed token from an arbitrary JSON
+  // body. Lets us drive shape-validation tests without re-deriving
+  // the HMAC math in each case.
+  async function forgeSignedToken(bodyJson: string): Promise<string> {
     const enc = new TextEncoder();
-    const bad = JSON.stringify({
-      photo_r2_key: "x",
-      anchor_hms: "10:00:00",
-      // predicted_mm_ss missing
-      user_id: "u",
-      watch_id: "w",
-      expires_at_unix: Math.floor(Date.now() / 1000) + 60,
-      vlm_model: "openai/gpt-5.2",
-    });
-    const payloadB64 = btoa(bad)
+    const payloadB64 = btoa(bodyJson)
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
@@ -204,6 +196,56 @@ describe("readingToken shape validation", () => {
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
-    expect(await verifyReadingToken(`${payloadB64}.${sigB64}`, SECRET)).toBeNull();
+    return `${payloadB64}.${sigB64}`;
+  }
+
+  function baseBody(): Record<string, unknown> {
+    return {
+      photo_r2_key: "x",
+      anchor_hms: "10:00:00",
+      reference_ms: Date.now(),
+      predicted_hms: { h: 10, m: 19, s: 34 },
+      user_id: "u",
+      watch_id: "w",
+      expires_at_unix: Math.floor(Date.now() / 1000) + 60,
+      vlm_model: "openai/gpt-5.2",
+    };
+  }
+
+  it("rejects a payload missing predicted_hms", async () => {
+    const { predicted_hms: _omit, ...rest } = baseBody();
+    void _omit;
+    const tok = await forgeSignedToken(JSON.stringify(rest));
+    expect(await verifyReadingToken(tok, SECRET)).toBeNull();
+  });
+
+  it("rejects a payload missing reference_ms", async () => {
+    const { reference_ms: _omit, ...rest } = baseBody();
+    void _omit;
+    const tok = await forgeSignedToken(JSON.stringify(rest));
+    expect(await verifyReadingToken(tok, SECRET)).toBeNull();
+  });
+
+  it("rejects predicted_hms with out-of-range hour (0)", async () => {
+    const body = { ...baseBody(), predicted_hms: { h: 0, m: 0, s: 0 } };
+    const tok = await forgeSignedToken(JSON.stringify(body));
+    expect(await verifyReadingToken(tok, SECRET)).toBeNull();
+  });
+
+  it("rejects predicted_hms with out-of-range hour (13)", async () => {
+    const body = { ...baseBody(), predicted_hms: { h: 13, m: 0, s: 0 } };
+    const tok = await forgeSignedToken(JSON.stringify(body));
+    expect(await verifyReadingToken(tok, SECRET)).toBeNull();
+  });
+
+  it("rejects predicted_hms with out-of-range minutes/seconds", async () => {
+    const tooBig = { ...baseBody(), predicted_hms: { h: 10, m: 60, s: 0 } };
+    expect(
+      await verifyReadingToken(await forgeSignedToken(JSON.stringify(tooBig)), SECRET),
+    ).toBeNull();
+    const negative = { ...baseBody(), predicted_hms: { h: 10, m: 0, s: -1 } };
+    expect(
+      await verifyReadingToken(await forgeSignedToken(JSON.stringify(negative)), SECRET),
+    ).toBeNull();
   });
 });

--- a/src/domain/reading-token/token.ts
+++ b/src/domain/reading-token/token.ts
@@ -79,8 +79,32 @@ export const READING_TOKEN_TTL_SECONDS = 5 * 60;
  */
 export interface ReadingTokenPayload {
   photo_r2_key: string;
+  /**
+   * The server's reference clock at moment of capture, formatted as
+   * `HH:MM:SS` (UTC, 24-hour) for human-debug log lines. NOT used in
+   * deviation math — the canonical reference is `reference_ms` below.
+   */
   anchor_hms: string;
-  predicted_mm_ss: { m: number; s: number };
+  /**
+   * The reference timestamp the deviation is computed against, as
+   * unix milliseconds. Source is either EXIF DateTimeOriginal (the
+   * camera's local clock encoded UTC-naively) or server arrival
+   * (`Date.now()` UTC). Stored at draft time so /confirm computes
+   * the same deviation no matter when the user taps Confirm within
+   * the token's 5-min TTL. Added in PR #122 alongside the move from
+   * MM:SS-only to full-HMS deviation.
+   */
+  reference_ms: number;
+  /**
+   * The VLM's predicted reading on a 12-hour analog clock (h ∈
+   * [1, 12], m/s ∈ [0, 59]). Hour comes from the server reference
+   * (the VLM doesn't determine hour — it disambiguates the
+   * rollover-side using the prompt's anchor). Replaces the old
+   * `predicted_mm_ss` field added in slice #6 of PRD #99 because
+   * PR #122 lets the user adjust HH/MM/SS independently and the
+   * SPA needs the predicted hour as the initial value.
+   */
+  predicted_hms: { h: number; m: number; s: number };
   user_id: string;
   watch_id: string;
   expires_at_unix: number;
@@ -218,17 +242,25 @@ function isReadingTokenPayload(value: unknown): value is ReadingTokenPayload {
   const v = value as Record<string, unknown>;
   if (typeof v.photo_r2_key !== "string") return false;
   if (typeof v.anchor_hms !== "string") return false;
+  if (typeof v.reference_ms !== "number" || !Number.isFinite(v.reference_ms)) {
+    return false;
+  }
   if (typeof v.user_id !== "string") return false;
   if (typeof v.watch_id !== "string") return false;
   if (typeof v.vlm_model !== "string") return false;
   if (typeof v.expires_at_unix !== "number" || !Number.isFinite(v.expires_at_unix)) {
     return false;
   }
-  const mm_ss = v.predicted_mm_ss;
-  if (typeof mm_ss !== "object" || mm_ss === null) return false;
-  const m = (mm_ss as { m?: unknown }).m;
-  const s = (mm_ss as { s?: unknown }).s;
-  if (typeof m !== "number" || !Number.isFinite(m)) return false;
-  if (typeof s !== "number" || !Number.isFinite(s)) return false;
+  // PR #122: predicted_hms = { h: 1..12, m: 0..59, s: 0..59 }. Old
+  // tokens carrying `predicted_mm_ss` are rejected here — they
+  // expire within 5 minutes of the deploy anyway.
+  const hms = v.predicted_hms;
+  if (typeof hms !== "object" || hms === null) return false;
+  const h = (hms as { h?: unknown }).h;
+  const m = (hms as { m?: unknown }).m;
+  const s = (hms as { s?: unknown }).s;
+  if (typeof h !== "number" || !Number.isFinite(h) || h < 1 || h > 12) return false;
+  if (typeof m !== "number" || !Number.isFinite(m) || m < 0 || m > 59) return false;
+  if (typeof s !== "number" || !Number.isFinite(s) || s < 0 || s > 59) return false;
   return true;
 }

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -35,7 +35,6 @@ import {
 } from "@/domain/drift-calc";
 import {
   DEFAULT_VLM_MODEL,
-  computeMmSsDeviation,
   verifyVlmReadingFromEnv,
   type VerifyReadingErrorCode,
 } from "@/domain/reading-verifier/verifier";
@@ -409,16 +408,17 @@ readingsByWatchRoute.post("/tap", async (c) => {
 //   1. POST /verified/draft   — accepts the photo, runs the VLM
 //      pipeline, persists the photo to a temporary R2 prefix
 //      (`drafts/{user_id}/{uuid}.jpg`), and returns a signed
-//      `reading_token` + the predicted MM:SS + a photo URL. Does
-//      NOT save a reading row.
+//      `reading_token` + the predicted HH:MM:SS (12-hour) + a
+//      photo URL. Does NOT save a reading row.
 //
 //   2. POST /verified/confirm — accepts `{ reading_token,
-//      final_mm_ss }`. Verifies the token signature and expiry,
+//      final_hms }`. Verifies the token signature and expiry,
 //      cross-checks the payload's user_id/watch_id against the
-//      session and request, validates `final_mm_ss` is within ±30s
-//      of the predicted value (per-click adjustment limit), saves
-//      the reading row, and moves the photo from `drafts/` to
-//      `verified/{user_id}/{reading_id}.jpg`.
+//      session and request, validates `final_hms` shape (h ∈
+//      [1, 12], m/s ∈ [0, 59]), saves the reading row, and
+//      moves the photo from `drafts/` to
+//      `verified/{user_id}/{reading_id}.jpg`. PR #122 removed
+//      the previous ±30s adjustment cap.
 //
 // Anti-cheat property: `/draft` returns the prediction but NOT
 // the deviation. The SPA confirmation page (slice #7) lets the
@@ -440,16 +440,25 @@ readingsByWatchRoute.post("/tap", async (c) => {
 //     re-write of the same bytes.
 
 /**
- * Per-click adjustment cap (in seconds). The slice-#7 confirmation
- * UI lets the user ± seconds with each click; the server enforces
- * the same ±30s limit so a malicious client can't bypass the UI.
- * Larger corrections require retake.
+ * Confirm body schema. PR #122 reworked the adjustment surface from
+ * seconds-only ±30s to per-component HH:MM:SS up/down. The server
+ * accepts any well-shaped 12-hour HH:MM:SS triple — there's no
+ * adjustment cap. The defenses against malicious clients are:
+ *
+ *   * The reading-token's HMAC signature + 5-min expiry.
+ *   * The photo stored in R2 (audit trail).
+ *   * The watch-ownership + auth + rate-limit checks earlier in
+ *     the handler.
+ *
+ * The previous ±30s cap was always more about UI nudge than fraud
+ * prevention — a determined cheater knows the rough current time
+ * from their phone clock and can game the value either way. The
+ * photo audit is the real check.
  */
-const CONFIRM_ADJUSTMENT_LIMIT_SECONDS = 30;
-
 const confirmReadingSchema = z.object({
   reading_token: z.string().min(1),
-  final_mm_ss: z.object({
+  final_hms: z.object({
+    h: z.number().int().min(1).max(12),
     m: z.number().int().min(0).max(59),
     s: z.number().int().min(0).max(59),
   }),
@@ -473,20 +482,45 @@ function formatHms(timestampMs: number): string {
 }
 
 /**
- * Wrap-aware MM:SS distance on the [0, 3600) circle. Returns the
- * shortest signed distance (in seconds) between two MM:SS pairs,
- * always in [-1800, +1800]. The route uses the absolute value to
- * enforce the ±30s adjustment cap.
+ * Convert a 12-hour HH:MM:SS triple to total seconds on the
+ * [0, 43200) 12-hour cycle. Hour 12 maps to 0 seconds (top of the
+ * cycle), hours 1..11 map to 1*3600..11*3600.
  */
-function mmSsCircularDistance(
-  a: { m: number; s: number },
-  b: { m: number; s: number },
+function hmsTotalSeconds(hms: { h: number; m: number; s: number }): number {
+  return (hms.h % 12) * 3600 + hms.m * 60 + hms.s;
+}
+
+/**
+ * Wrap-aware full-HMS deviation on the 12-hour analog cycle (43200
+ * seconds). Returns the shortest signed distance (in seconds)
+ * between two HH:MM:SS triples, always in [-21600, +21600].
+ *
+ * Used by /confirm to compute the saved `deviation_seconds`. PR
+ * #122 graduated this from MM:SS-only (30-min wrap) to full HMS
+ * (6-hour wrap) because the new UX lets the user adjust the hour
+ * — a watch that's actually 1h fast must record as +3600s, not
+ * wrap modulo-30-min into a near-zero value.
+ *
+ * Timezone caveat: when the reference came from server arrival
+ * (no EXIF), the reference's UTC hour ≠ user's local hour by the
+ * TZ offset. The deviation will then include a constant TZ-offset
+ * component that's the same for every reading the user submits,
+ * so DRIFT-RATE math (delta between readings) cancels it out
+ * correctly. Per-reading absolute deviation will look "off" by
+ * the TZ offset for the EXIF-missing case. Acceptable for v1; a
+ * follow-up could pass the user's TZ offset from the SPA.
+ */
+function compute12HourDeviation(
+  dial: { h: number; m: number; s: number },
+  ref: { h: number; m: number; s: number },
 ): number {
-  const aTotal = a.m * 60 + a.s;
-  const bTotal = b.m * 60 + b.s;
-  const raw = aTotal - bTotal;
-  const wrapped = (((raw + 1800) % 3600) + 3600) % 3600;
-  return wrapped - 1800;
+  const dialTotal = hmsTotalSeconds(dial);
+  const refTotal = hmsTotalSeconds(ref);
+  const raw = dialTotal - refTotal;
+  // Map raw delta into [-21600, +21600] via the canonical wrap idiom.
+  // Half-cycle = 21600 (= 6 hours), full cycle = 43200 (= 12 hours).
+  const wrapped = (((raw + 21600) % 43200) + 43200) % 43200;
+  return wrapped - 21600;
 }
 
 /**
@@ -605,10 +639,27 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
   }
 
   const expiresAtUnix = Math.floor(Date.now() / 1000) + READING_TOKEN_TTL_SECONDS;
+
+  // Convert the reference's UTC hour to a 12-hour analog hour
+  // (1..12, no AM/PM marker). The VLM's mm_ss read is paired with
+  // this hour to produce the predicted analog dial display the SPA
+  // shows in the confirmation page. PR #122: full HH:MM:SS
+  // returned to client so per-component up/down can pre-populate
+  // with the right starting values.
+  const refDate = new Date(result.reference_timestamp_ms);
+  const refHour24 = refDate.getUTCHours();
+  const refHour12 = ((refHour24 + 11) % 12) + 1;
+  const predictedHms = {
+    h: refHour12,
+    m: result.mm_ss.m,
+    s: result.mm_ss.s,
+  };
+
   const tokenPayload: ReadingTokenPayload = {
     photo_r2_key: draftKey,
     anchor_hms: formatHms(result.reference_timestamp_ms),
-    predicted_mm_ss: result.mm_ss,
+    reference_ms: result.reference_timestamp_ms,
+    predicted_hms: predictedHms,
     user_id: user.id,
     watch_id: watchId,
     expires_at_unix: expiresAtUnix,
@@ -628,9 +679,14 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
   return c.json(
     {
       reading_token: readingToken,
-      predicted_mm_ss: result.mm_ss,
+      // PR #122: return full predicted HH:MM:SS (12-hour) so the
+      // SPA can pre-populate the per-component up/down adjusters.
+      // `hour_from_server_clock` (24-hour UTC) was previously
+      // returned alongside `predicted_mm_ss`; merging them into a
+      // single `predicted_hms` removes the back-and-forth
+      // 12h/24h conversion the SPA was doing.
+      predicted_hms: predictedHms,
       photo_url: photoUrl,
-      hour_from_server_clock: new Date(result.reference_timestamp_ms).getUTCHours(),
       reference_source: result.reference_source,
       expires_at_unix: expiresAtUnix,
     },
@@ -649,8 +705,9 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
  *                                  missing READING_TOKEN_SECRET
  *   * 403 forbidden              — token user_id/watch_id doesn't
  *                                  match the request session/URL
- *   * 422 adjustment_too_large   — final_mm_ss further than ±30s
- *                                  from the predicted value
+ *
+ * PR #122 removed the `422 adjustment_too_large` branch (no more
+ * ±30s cap; any well-shaped HH:MM:SS triple is accepted).
  *
  * On success returns 201 with the saved reading row (same shape
  * as the manual POST).
@@ -685,7 +742,7 @@ readingsByWatchRoute.post("/verified/confirm", async (c) => {
       400,
     );
   }
-  const { reading_token, final_mm_ss, is_baseline } = parsed.data;
+  const { reading_token, final_hms, is_baseline } = parsed.data;
 
   const payload = await verifyReadingToken(reading_token, c.env.READING_TOKEN_SECRET);
   if (!payload) {
@@ -713,46 +770,40 @@ readingsByWatchRoute.post("/verified/confirm", async (c) => {
     return c.json({ error: "forbidden" }, 403);
   }
 
-  // Adjustment cap. The SPA enforces ±30s client-side; the server
-  // is the security boundary.
-  const adjustmentSeconds = Math.abs(
-    mmSsCircularDistance(final_mm_ss, payload.predicted_mm_ss),
-  );
-  if (adjustmentSeconds > CONFIRM_ADJUSTMENT_LIMIT_SECONDS) {
-    await logEvent(
-      "verified_reading_confirm_rejected",
-      {
-        userId: user.id,
-        watchId,
-        reason: "adjustment_too_large",
-      },
-      c.env,
-    );
-    return c.json(
-      {
-        error: "adjustment_too_large",
-        max_seconds: CONFIRM_ADJUSTMENT_LIMIT_SECONDS,
-      },
-      422,
-    );
-  }
+  // PR #122 removed the ±30s adjustment cap. The Zod schema's
+  // shape validation (h ∈ [1,12], m/s ∈ [0,59]) is the only
+  // server-side bound now. Defense-in-depth comes from:
+  //   * The reading-token's HMAC + 5-min expiry above.
+  //   * The photo persisted to R2 (audit trail).
+  //   * Auth + ownership + rate-limit checks earlier in the
+  //     handler.
+  // The cap was always more about UI nudge than fraud prevention
+  // — a determined cheater knows the rough current time anyway.
+  // Real fraud would surface as a watch with consistently exact
+  // server-clock readings (no drift) which is itself a detection
+  // signal in the leaderboard.
 
-  // Reconstruct the reference MM:SS from the token's anchor_hms.
-  // The hour component is informational; only m/s feed the deviation.
-  const [, anchorM, anchorS] = parseHms(payload.anchor_hms);
+  // Build the reference HMS from the token's stored reference_ms.
+  // The hour comes via 12-hour conversion of the reference's UTC
+  // hour (matches what /draft minted into predicted_hms).
+  const refDate = new Date(payload.reference_ms);
+  const refHour24 = refDate.getUTCHours();
+  const refHour12 = ((refHour24 + 11) % 12) + 1;
+  const referenceHms = {
+    h: refHour12,
+    m: refDate.getUTCMinutes(),
+    s: refDate.getUTCSeconds(),
+  };
 
   const deviationSeconds = is_baseline
     ? 0
-    : computeMmSsDeviation(final_mm_ss, { m: anchorM, s: anchorS });
+    : compute12HourDeviation(final_hms, referenceHms);
 
-  // Reconstruct a unix-ms reference timestamp for the row. We
-  // don't store the EXIF year/month/day in the token, so we
-  // reconstruct against today's UTC date + the anchor's HH:MM:SS.
-  // This is a small fudge — the reading row's `reference_timestamp`
-  // ends up within a few minutes of the actual capture (token
-  // lifetime is 5 min). For drift math the absolute timestamp
-  // doesn't matter much; the deviation is the headline number.
-  const referenceMs = reconstructReferenceMs(payload.anchor_hms);
+  // The reference timestamp on the row is the actual ms the photo
+  // was captured (stored in the token at /draft time). PR #122 no
+  // longer reconstructs from a string — the token carries the
+  // precise ms.
+  const referenceMs = payload.reference_ms;
 
   const id = crypto.randomUUID();
   await db
@@ -832,46 +883,12 @@ readingsByWatchRoute.post("/verified/confirm", async (c) => {
   return c.json(toResponse(created), 201);
 });
 
-/** Parse `HH:MM:SS` into `[h, m, s]`. Returns zeroes on a malformed string. */
-function parseHms(hms: string): [number, number, number] {
-  const m = /^(\d{2}):(\d{2}):(\d{2})$/.exec(hms);
-  if (!m) return [0, 0, 0];
-  return [Number(m[1]), Number(m[2]), Number(m[3])];
-}
-
-/**
- * Reconstruct a unix-ms reference timestamp from the token's
- * `anchor_hms` (HH:MM:SS UTC). Uses today's UTC date — this is
- * accurate to ±5 minutes because token lifetime is 5 minutes.
- *
- * Edge case: if the anchor's HH is >12h ahead of "now" we assume
- * the anchor was set yesterday (e.g. anchor 23:59:00 confirmed at
- * 00:01:00); if it's >12h behind we assume tomorrow. This handles
- * the day-boundary crossing without needing the date in the token.
- */
-function reconstructReferenceMs(anchorHms: string): number {
-  const now = new Date();
-  const [h, m, s] = parseHms(anchorHms);
-  const candidate = Date.UTC(
-    now.getUTCFullYear(),
-    now.getUTCMonth(),
-    now.getUTCDate(),
-    h,
-    m,
-    s,
-    0,
-  );
-  const diff = candidate - now.getTime();
-  if (diff > 12 * 60 * 60 * 1000) {
-    // Candidate is far in the future → must have been yesterday.
-    return candidate - 24 * 60 * 60 * 1000;
-  }
-  if (diff < -12 * 60 * 60 * 1000) {
-    // Candidate is far in the past → must be tomorrow.
-    return candidate + 24 * 60 * 60 * 1000;
-  }
-  return candidate;
-}
+// PR #122: removed `parseHms`/`reconstructReferenceMs` — the token
+// now carries `reference_ms` directly so /confirm doesn't have to
+// reconstruct the timestamp from a HH:MM:SS string + today's date.
+// Old behaviour was a small fudge that drifted by token-TTL (~5
+// min) for the saved row's `reference_timestamp`; the new path is
+// exact.
 
 /**
  * Map a verifier error code to the wire-format error response.

--- a/tests/e2e/verified-reading-confirmation.smoke.test.ts
+++ b/tests/e2e/verified-reading-confirmation.smoke.test.ts
@@ -61,9 +61,12 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
   // the <img> renders something visible without hitting R2.
   //
   // Captured state lets the test assert the SPA POSTs the user-
-  // adjusted final_mm_ss, not the predicted MM:SS.
+  // adjusted final_hms, not the predicted HH:MM:SS.
   const FAKE_TOKEN = "fake-token.fake-sig";
-  const PREDICTED = { m: 19, s: 34 };
+  // PR #122: predicted_hms unifies hour + mm + ss in one field.
+  // We pick h=2 (12-hour analog of UTC 14) so the displayed
+  // "Reading at 02:" matches the watch reading the prompt described.
+  const PREDICTED = { h: 2, m: 19, s: 34 };
   const PHOTO_DATA_URL =
     "data:image/png;base64," +
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg==";
@@ -76,9 +79,8 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
       contentType: "application/json",
       body: JSON.stringify({
         reading_token: FAKE_TOKEN,
-        predicted_mm_ss: PREDICTED,
+        predicted_hms: PREDICTED,
         photo_url: PHOTO_DATA_URL,
-        hour_from_server_clock: 14,
         reference_source: "server",
         expires_at_unix: Math.floor(Date.now() / 1000) + 300,
       }),
@@ -87,7 +89,7 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
 
   let confirmBody: {
     reading_token: string;
-    final_mm_ss: { m: number; s: number };
+    final_hms: { h: number; m: number; s: number };
     is_baseline?: boolean;
   } | null = null;
   await page.route("**/api/v1/watches/**/readings/verified/confirm", async (route) => {
@@ -159,15 +161,17 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
   await expect(confirmation.getByTestId("confirmation-photo")).toBeVisible();
 
   // Prediction display shows the predicted HH:MM:SS verbatim. Hour
-  // is the server-clock hour from the /draft response (14:xx:xx in
-  // this fixture); minutes + seconds come from the VLM's read.
+  // is the 12-hour-analog conversion of the reference's UTC hour
+  // (PREDICTED.h = 2 → "02"); minutes + seconds come from the
+  // VLM's read.
   const predictionEl = confirmation.getByTestId("prediction-hh-mm-ss");
-  await expect(predictionEl).toContainText("14");
+  await expect(predictionEl).toContainText("02");
   await expect(predictionEl).toContainText("19");
   await expect(predictionEl).toContainText("34");
-  // The hour element is its own testid so the rollover-edge-case
-  // verification is independent of the MM:SS sub-elements.
-  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("14");
+  // Each component has its own testid for granular assertions.
+  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("02");
+  await expect(confirmation.getByTestId("confirmation-minutes")).toHaveText("19");
+  await expect(confirmation.getByTestId("confirmation-seconds")).toHaveText("34");
 
   // ---- 4. Anti-cheat DOM probe -----------------------------------
   //
@@ -180,20 +184,34 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
   await expect(confirmation.locator('[data-testid="deviation"]')).toHaveCount(0);
   await expect(confirmation.getByText(/drift|deviation|[+-]\d+\s*s\b/i)).toHaveCount(0);
 
-  // ---- 5. ± buttons adjust seconds in 1s steps -------------------
-  const plusBtn = confirmation.getByTestId("confirmation-plus");
+  // ---- 5. Per-component up/down buttons adjust independently ----
+  //
+  // PR #122 reworked the UX from seconds-only ±30s into per-
+  // component up/down. Each component has its own ▲/▼ pair and
+  // adjustments wrap WITHIN the component (m=59 ▲ → m=0 without
+  // touching h or s). The integration test (server side) covers
+  // the wrap math; here we just verify the buttons hit the right
+  // targets.
+  const secondsUp = confirmation.getByTestId("confirmation-seconds-up");
   for (let i = 0; i < 4; i += 1) {
-    await plusBtn.click();
+    await secondsUp.click();
   }
-  // After 4 clicks: 34 → 35 → 36 → 37 → 38. The minutes display
-  // should still be "19".
   await expect(confirmation.getByTestId("confirmation-seconds")).toHaveText("38");
+  // Hours and minutes should be untouched by seconds adjustments.
+  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("02");
   await expect(confirmation.getByTestId("confirmation-minutes")).toHaveText("19");
 
-  // The "± X / 30 used" counter ticked along.
-  await expect(confirmation.getByTestId("confirmation-clicks-used")).toContainText("4");
+  // Tap minutes ▲ once — proves component independence + that the
+  // hour doesn't carry.
+  await confirmation.getByTestId("confirmation-minutes-up").click();
+  await expect(confirmation.getByTestId("confirmation-minutes")).toHaveText("20");
+  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("02");
 
-  // ---- 6. Confirm posts the user-adjusted MM:SS ------------------
+  // Tap hours ▲ once — proves the hour is independently adjustable.
+  await confirmation.getByTestId("confirmation-hours-up").click();
+  await expect(confirmation.getByTestId("confirmation-hours")).toHaveText("03");
+
+  // ---- 6. Confirm posts the user-adjusted HH:MM:SS ---------------
   await confirmation.getByTestId("confirmation-confirm").click();
 
   // Wait for the success banner to swap in (the parent component
@@ -202,8 +220,8 @@ test("verified-reading confirmation: deviation never rendered, ± buttons adjust
   await expect(panel.getByRole("status")).toContainText(/saved/i);
 
   // The mock captured the POST body — assert the SPA sent the
-  // user-adjusted MM:SS, not the predicted one.
+  // user-adjusted HMS, not the predicted one.
   expect(confirmBody).not.toBeNull();
   expect(confirmBody!.reading_token).toBe(FAKE_TOKEN);
-  expect(confirmBody!.final_mm_ss).toEqual({ m: 19, s: 38 });
+  expect(confirmBody!.final_hms).toEqual({ h: 3, m: 20, s: 38 });
 });

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -167,7 +167,7 @@ async function postConfirm(
   watchId: string,
   body: {
     reading_token: string;
-    final_mm_ss: { m: number; s: number };
+    final_hms: { h: number; m: number; s: number };
     is_baseline?: boolean;
   },
   cookie: string,
@@ -186,9 +186,8 @@ async function postConfirm(
 
 interface DraftResponse {
   reading_token: string;
-  predicted_mm_ss: { m: number; s: number };
+  predicted_hms: { h: number; m: number; s: number };
   photo_url: string;
-  hour_from_server_clock: number;
   reference_source: "exif" | "server";
   expires_at_unix: number;
 }
@@ -238,7 +237,7 @@ const VERIFIED_TIMEOUT = 30_000;
 
 describe("POST /api/v1/watches/:id/readings/verified/draft", () => {
   it.each([["bambino_10_19_34.jpeg"], ["snk803_10_15_40.jpeg"]])(
-    "returns reading_token + predicted_mm_ss for %s",
+    "returns reading_token + predicted_hms for %s",
     async (fixtureName) => {
       const truth = SMOKE_TRUTH[fixtureName]!;
       const refMs = Date.UTC(2026, 3, 29, truth.hh, truth.mm, truth.ss, 0);
@@ -259,15 +258,26 @@ describe("POST /api/v1/watches/:id/readings/verified/draft", () => {
 
       // Token shape: <payload>.<sig>
       expect(body.reading_token).toContain(".");
-      expect(body.predicted_mm_ss).toEqual({ m: truth.mm, s: truth.ss });
-      expect(body.hour_from_server_clock).toBe(truth.hh);
+      // Hour comes from the reference timestamp's UTC hour, converted
+      // to 12-hour analog form (1..12). truth.hh is the watch's
+      // displayed local hour (0..23 in the fixture manifest); for
+      // these EXIF-present fixtures the worker's UTC interpretation
+      // matches the camera's local hour by construction (Date()
+      // parsing of naive EXIF strings under TZ=UTC).
+      const expectedH12 = ((truth.hh + 11) % 12) + 1;
+      expect(body.predicted_hms).toEqual({
+        h: expectedH12,
+        m: truth.mm,
+        s: truth.ss,
+      });
       expect(body.photo_url).toContain("/images/drafts/");
       expect(body.photo_url).toContain(owner.userId);
       expect(body.expires_at_unix).toBeGreaterThan(Math.floor(refMs / 1000));
 
       // Critically: NO deviation field on the response. The whole
-      // anti-cheat point is that the user can adjust ± seconds
-      // without seeing the deviation it would produce.
+      // anti-cheat point is that the user can adjust HH/MM/SS
+      // without seeing the deviation those adjustments would
+      // produce.
       expect(body).not.toHaveProperty("deviation_seconds");
 
       // No reading row should have been written yet.
@@ -329,7 +339,8 @@ describe("POST /api/v1/watches/:id/readings/verified/draft", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as DraftResponse;
       expect(body.reference_source).toBe("server");
-      expect(body.hour_from_server_clock).toBe(14);
+      // Server arrival 14:30:15 UTC → 12-hour h = ((14+11)%12)+1 = 2.
+      expect(body.predicted_hms).toEqual({ h: 2, m: 30, s: 15 });
     },
     VERIFIED_TIMEOUT,
   );
@@ -404,7 +415,7 @@ describe("POST /api/v1/watches/:id/readings/verified/draft", () => {
 
 describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
   it(
-    "saves a verified reading with the user's final_mm_ss",
+    "saves a verified reading with the user's final_hms",
     async () => {
       const truth = SMOKE_TRUTH["bambino_10_19_34.jpeg"]!;
       const refMs = Date.UTC(2026, 3, 29, truth.hh, truth.mm, truth.ss, 0);
@@ -423,12 +434,15 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       expect(draftRes.status).toBe(200);
       const draftBody = (await draftRes.json()) as DraftResponse;
 
-      // User adjusts +5s from the prediction. That's well within
-      // the ±30s cap, so confirm should accept.
-      const finalMmSs = { m: truth.mm, s: truth.ss + 5 };
+      // User keeps the predicted hour + minute, nudges seconds +5.
+      const finalHms = {
+        h: draftBody.predicted_hms.h,
+        m: truth.mm,
+        s: truth.ss + 5,
+      };
       const confirmRes = await postConfirm(
         watchId,
-        { reading_token: draftBody.reading_token, final_mm_ss: finalMmSs },
+        { reading_token: draftBody.reading_token, final_hms: finalHms },
         owner.cookie,
       );
       expect(confirmRes.status).toBe(201);
@@ -437,7 +451,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       expect(reading.user_id).toBe(owner.userId);
       expect(reading.verified).toBe(true);
       expect(reading.is_baseline).toBe(false);
-      // Final user-submitted mm:ss matches the anchor + 5s, so
+      // Final user-submitted hms matches the anchor + 5s, so
       // deviation should be +5.
       expect(reading.deviation_seconds).toBe(5);
 
@@ -453,6 +467,10 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       expect(row!.vlm_model).toBe("openai/gpt-5.2");
       expect(row!.verified).toBe(1);
       expect(row!.photo_r2_key).toBe(`verified/${owner.userId}/${reading.id}.jpg`);
+      // The token now carries reference_ms exactly, so the saved
+      // reference_timestamp is the exact capture time (not a
+      // reconstructed approximation).
+      expect(row!.reference_timestamp).toBe(refMs);
 
       // Photo moved from drafts/ to verified/.
       const r2 = (env as unknown as TestEnv).WATCH_IMAGES;
@@ -487,8 +505,12 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
         watchId,
         {
           reading_token: draftBody.reading_token,
-          // User adjusts to +10s but baseline overrides → 0.
-          final_mm_ss: { m: truth.mm, s: truth.ss + 10 },
+          // User adjusts +10s but baseline overrides → deviation 0.
+          final_hms: {
+            h: draftBody.predicted_hms.h,
+            m: truth.mm,
+            s: truth.ss + 10,
+          },
           is_baseline: true,
         },
         owner.cookie,
@@ -502,8 +524,12 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
   );
 
   it(
-    "accepts a final_mm_ss exactly 30s from predicted",
+    "accepts arbitrarily large adjustments (no ±30s cap any more)",
     async () => {
+      // PR #122 removed the ±30s cap. The server now accepts any
+      // well-shaped HH:MM:SS triple; the user is responsible for
+      // entering what they see on the dial. This test guards
+      // against accidental reintroduction of a server-side cap.
       const truth = SMOKE_TRUTH["bambino_10_19_34.jpeg"]!;
       const refMs = Date.UTC(2026, 3, 29, truth.hh, truth.mm, truth.ss, 0);
       vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -513,30 +539,41 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
 
       const owner = await registerAndGetCookie();
       const { id: watchId } = await createWatch(
-        { name: "30s boundary", movement_id: movementId },
+        { name: "No cap", movement_id: movementId },
         owner.cookie,
       );
       const draftRes = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie);
       const draftBody = (await draftRes.json()) as DraftResponse;
-      // truth.ss = 34, +30 = 64 → wraps to m+1 / s=4
-      const finalSs = (truth.ss + 30) % 60;
-      const finalMm = truth.mm + Math.floor((truth.ss + 30) / 60);
+
+      // User claims their watch is 4 minutes ahead of the
+      // prediction — would have been rejected by the old ±30s cap,
+      // accepted now.
       const confirmRes = await postConfirm(
         watchId,
         {
           reading_token: draftBody.reading_token,
-          final_mm_ss: { m: finalMm, s: finalSs },
+          final_hms: {
+            h: draftBody.predicted_hms.h,
+            m: (truth.mm + 4) % 60,
+            s: truth.ss,
+          },
         },
         owner.cookie,
       );
       expect(confirmRes.status).toBe(201);
+      const reading = (await confirmRes.json()) as ReadingResponseBody;
+      // 4 minutes = 240s. Same hour + same seconds + minutes +4.
+      expect(reading.deviation_seconds).toBe(240);
     },
     VERIFIED_TIMEOUT,
   );
 
   it(
-    "rejects a final_mm_ss 31s from predicted as adjustment_too_large",
+    "computes deviation across hour adjustments via 12-hour wrap",
     async () => {
+      // Reference is 10:19:34. User asserts their watch shows
+      // 11:19:34 — meaning it's 1 hour fast. Deviation should be
+      // +3600s (one hour).
       const truth = SMOKE_TRUTH["bambino_10_19_34.jpeg"]!;
       const refMs = Date.UTC(2026, 3, 29, truth.hh, truth.mm, truth.ss, 0);
       vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -546,28 +583,28 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
 
       const owner = await registerAndGetCookie();
       const { id: watchId } = await createWatch(
-        { name: "31s exceed", movement_id: movementId },
+        { name: "Hour adjust", movement_id: movementId },
         owner.cookie,
       );
       const draftRes = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie);
       const draftBody = (await draftRes.json()) as DraftResponse;
-      const finalSs = (truth.ss + 31) % 60;
-      const finalMm = truth.mm + Math.floor((truth.ss + 31) / 60);
+
       const confirmRes = await postConfirm(
         watchId,
         {
           reading_token: draftBody.reading_token,
-          final_mm_ss: { m: finalMm, s: finalSs },
+          final_hms: {
+            // Predicted h is 10 (12-hour); user nudges to 11.
+            h: (draftBody.predicted_hms.h % 12) + 1 || 1,
+            m: truth.mm,
+            s: truth.ss,
+          },
         },
         owner.cookie,
       );
-      expect(confirmRes.status).toBe(422);
-      const body = (await confirmRes.json()) as {
-        error: string;
-        max_seconds: number;
-      };
-      expect(body.error).toBe("adjustment_too_large");
-      expect(body.max_seconds).toBe(30);
+      expect(confirmRes.status).toBe(201);
+      const reading = (await confirmRes.json()) as ReadingResponseBody;
+      expect(reading.deviation_seconds).toBe(3600);
     },
     VERIFIED_TIMEOUT,
   );
@@ -586,7 +623,8 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       const expiredPayload: ReadingTokenPayload = {
         photo_r2_key: `drafts/${owner.userId}/fake.jpg`,
         anchor_hms: "10:00:00",
-        predicted_mm_ss: { m: 0, s: 30 },
+        reference_ms: Date.now(),
+        predicted_hms: { h: 10, m: 0, s: 30 },
         user_id: owner.userId,
         watch_id: watchId,
         expires_at_unix: Math.floor(Date.now() / 1000) - 1,
@@ -595,7 +633,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       const expiredToken = await signReadingToken(expiredPayload, secret);
       const res = await postConfirm(
         watchId,
-        { reading_token: expiredToken, final_mm_ss: { m: 0, s: 30 } },
+        { reading_token: expiredToken, final_hms: { h: 10, m: 0, s: 30 } },
         owner.cookie,
       );
       expect(res.status).toBe(401);
@@ -618,7 +656,8 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
         {
           photo_r2_key: `drafts/${owner.userId}/fake.jpg`,
           anchor_hms: "10:00:00",
-          predicted_mm_ss: { m: 0, s: 30 },
+          reference_ms: Date.now(),
+          predicted_hms: { h: 10, m: 0, s: 30 },
           user_id: owner.userId,
           watch_id: watchId,
           expires_at_unix: Math.floor(Date.now() / 1000) + 60,
@@ -634,7 +673,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       }`;
       const res = await postConfirm(
         watchId,
-        { reading_token: tampered, final_mm_ss: { m: 0, s: 30 } },
+        { reading_token: tampered, final_hms: { h: 10, m: 0, s: 30 } },
         owner.cookie,
       );
       expect(res.status).toBe(401);
@@ -660,7 +699,8 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
         {
           photo_r2_key: `drafts/${owner.userId}/fake.jpg`,
           anchor_hms: "10:00:00",
-          predicted_mm_ss: { m: 0, s: 30 },
+          reference_ms: Date.now(),
+          predicted_hms: { h: 10, m: 0, s: 30 },
           user_id: owner.userId,
           watch_id: watchA,
           expires_at_unix: Math.floor(Date.now() / 1000) + 60,
@@ -670,7 +710,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       );
       const res = await postConfirm(
         watchB,
-        { reading_token: tokenForA, final_mm_ss: { m: 0, s: 30 } },
+        { reading_token: tokenForA, final_hms: { h: 10, m: 0, s: 30 } },
         owner.cookie,
       );
       expect(res.status).toBe(403);
@@ -687,7 +727,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             reading_token: "x.y",
-            final_mm_ss: { m: 0, s: 0 },
+            final_hms: { h: 1, m: 0, s: 0 },
           }),
         },
       ),
@@ -706,7 +746,7 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       const res = await postConfirm(
         watchId,
         // @ts-expect-error — deliberately bad shape
-        { reading_token: 42, final_mm_ss: "nope" },
+        { reading_token: 42, final_hms: "nope" },
         owner.cookie,
       );
       expect(res.status).toBe(400);


### PR DESCRIPTION
Replaces the seconds-only \`±30s\` adjustment with per-component HH:MM:SS up/down arrows. Drops the server-side cap (any well-shaped triple is accepted). Reworks deviation calc to full HH:MM:SS (12-hour wrap on [-21600, +21600]s) so hour-level corrections record correctly. Token payload + /draft response + /confirm body all updated. **Important**: prod must \`npm run deploy\` after merge — the latest deploy is from yesterday and pre-dates both this and PR #121's photo-route fix. Refs #99