### PR TITLE
ci(deploy): scope deploy job to preview environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: verify
+    # `environment: preview` unlocks the CLOUDFLARE_API_TOKEN +
+    # CLOUDFLARE_ACCOUNT_ID secrets which are scoped to that GitHub
+    # Environment (the only env-scoped secrets in this repo — see
+    # the same comment on the `cheat-regression` job). Without this,
+    # `${{ secrets.CLOUDFLARE_API_TOKEN }}` resolves to an empty
+    # string and the wrangler subprocess fails with "non-interactive
+    # environment, set CLOUDFLARE_API_TOKEN" (caught by the first
+    # main-branch deploy attempt on 2026-04-30, see git history of
+    # this file). The "preview" name is historical — it was created
+    # for the preview-deploy job. We could rename it to "deploy" or
+    # add a separate "production" environment with the same secrets;
+    # both feel like premature ceremony for a single-operator repo,
+    # so we just reuse the existing one.
+    environment: preview
     permissions:
       contents: read
     concurrency:


### PR DESCRIPTION
## Summary

- Add `environment: preview` to the `deploy` job in `ci.yml` so `\${{ secrets.CLOUDFLARE_API_TOKEN }}` resolves correctly.

## Why

The auto-deploys from PR #123 and PR #124 both failed at the D1-migration step with:

```
ERROR: In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

I assumed PR #124's `env:` block fix would do it, but the actual cause is that the `CLOUDFLARE_API_TOKEN` secret is scoped to the `preview` GitHub Environment (the only environment in this repo). The existing `preview` and `cheat-regression` jobs use `environment: preview` to access it; the `cheat-regression` job even has an explicit comment about this exact behavior. My new deploy job had no environment declaration, so `secrets.CLOUDFLARE_API_TOKEN` resolved to an empty string and wrangler bailed.

## Why not create a `production` environment

Splitting into a separate environment would be cleaner conceptually but adds operational ceremony (secret rotation has to happen in two places) for what's a single-operator repo. Reusing `preview` for both PR-preview and production deploy is what existing jobs already do. Can revisit if the deploy job ever needs secrets that differ from preview.

## Test plan

- This PR's own verify job will pass (no env: needed there — verify doesn't touch CF).
- After merge, the auto-deploy will run for the third time and SHOULD finally succeed. Production worker is currently `c379052f` (from manual deploy earlier); this merge will roll it forward to the post-#124 version that fixes the verified-reading upload-latency bias for the user.

## Rollback

Revert this PR. Same as before — the deploy job is purely additive in production effect, doesn't touch product code.

🤖 Generated with [opencode](https://opencode.ai)