### PR TITLE
fix(verified-reading): client TZ offset eliminates 3600s TZ-bias-as-deviation

### DIFF
--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -259,6 +259,17 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
     const submitMs = Date.now();
     const clientCaptureMs = await extractCaptureTime(sourceFile, submitMs);
 
+    // Capture the user's TZ offset (minutes east of UTC) at the
+    // capture moment, so the server can express the reference HMS
+    // in the user's local-clock frame when computing deviation.
+    // PR #126 fix for the "watch on local time gets +3600 s
+    // deviation bias" report. `getTimezoneOffset()` returns minutes
+    // WEST of UTC (Lisbon WEST = −60, NYC EDT = +240) — we negate
+    // to match the server's "east of UTC" convention. Computing
+    // against `new Date(clientCaptureMs)` ensures DST transitions
+    // are handled correctly for the actual moment of capture.
+    const clientTzOffsetMinutes = -new Date(clientCaptureMs).getTimezoneOffset();
+
     // Show "uploading" immediately. The resize runs synchronously
     // (well, microtask-based via canvas.toBlob) BEFORE the network
     // call so users see the progress bar move even on fast networks.
@@ -292,6 +303,7 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
     const result = await draftVerifiedReading(watchId, {
       image: resized.file,
       clientCaptureMs,
+      clientTzOffsetMinutes,
     });
     clearTimeout(flipToReading);
 

--- a/src/app/watches/readings.ts
+++ b/src/app/watches/readings.ts
@@ -199,6 +199,19 @@ export interface VerifiedReadingDraftSubmission {
    * envelope as byte-EXIF.
    */
   clientCaptureMs?: number;
+  /**
+   * Optional client TZ offset in MINUTES east of UTC (Lisbon WEST =
+   * +60, NYC EDT = −240). PR #126 fix for the TZ-bias-as-deviation
+   * report: a watch displaying local time was being compared
+   * against a UTC-derived reference, baking 3600 s of TZ offset
+   * into every reading. When this field is present, the server
+   * shifts the reference into the user's local-clock frame before
+   * extracting H/M/S, so deviation reflects watch-vs-local-clock.
+   *
+   * Captured as `-new Date(captureMs).getTimezoneOffset()` so it's
+   * DST-aware for the moment of capture. Server bounds: ±840 min.
+   */
+  clientTzOffsetMinutes?: number;
 }
 
 /**
@@ -259,6 +272,11 @@ export async function draftVerifiedReading(
     // Bounds-checked against arrival on the server — sending a
     // wildly out-of-bounds value yields HTTP 422 exif_clock_skew.
     form.append("client_capture_ms", String(submission.clientCaptureMs));
+  }
+  if (submission.clientTzOffsetMinutes !== undefined) {
+    // Server bounds: ±840 min (covers all real TZs incl. UTC+14 and
+    // UTC−12 with DST variants). Out-of-bounds → HTTP 400.
+    form.append("client_tz_offset_minutes", String(submission.clientTzOffsetMinutes));
   }
 
   const response = await fetch(

--- a/src/domain/reading-token/token.ts
+++ b/src/domain/reading-token/token.ts
@@ -109,6 +109,27 @@ export interface ReadingTokenPayload {
   watch_id: string;
   expires_at_unix: number;
   vlm_model: string;
+  /**
+   * Optional client TZ offset in minutes east of UTC (e.g. Lisbon
+   * WEST = +60, Berlin CEST = +120, New York EDT = −240). Captured
+   * by the SPA via `-new Date(captureMs).getTimezoneOffset()` so it's
+   * DST-aware for the moment of capture.
+   *
+   * When present, the route layer shifts `reference_ms` by this
+   * offset before extracting H/M/S components (both at /draft for
+   * `predicted_hms.h` and at /confirm for the deviation calc), so a
+   * watch displaying local time produces a clean small deviation
+   * rather than a 3600 s TZ-bias-as-deviation. PR #126 fix for the
+   * "I saved the correct time, but it still showed a 1h deviation"
+   * report against PR #124's behaviour.
+   *
+   * Optional for backward compat — clients on the pre-#126 SPA omit
+   * it and the server falls back to UTC components (the old wrong-
+   * for-non-UTC-watches behaviour). Bounds on input: ±840 minutes
+   * (covers all real TZs incl. UTC+14 and UTC−12, with DST
+   * variants).
+   */
+  client_tz_offset_minutes?: number;
 }
 
 /**

--- a/src/server/routes/readings.ts
+++ b/src/server/routes/readings.ts
@@ -491,6 +491,53 @@ function hmsTotalSeconds(hms: { h: number; m: number; s: number }): number {
 }
 
 /**
+ * Convert a unix-ms timestamp into HMS components matching what the
+ * USER'S watch should be displaying at that moment, on the 12-hour
+ * analog clock. When `clientTzOffsetMinutes` is provided, we shift
+ * the timestamp by that offset before extracting H/M/S so a watch
+ * displaying local time gets compared against local-clock HMS rather
+ * than UTC-clock HMS.
+ *
+ * Background — PR #126 fix: prior to this helper, both /draft and
+ * /confirm called `refDate.getUTCHours()` directly. For a user in
+ * Lisbon WEST (+60 min) with a watch on local time, this produced a
+ * predicted hour that was UTC-relative while the watch dial was
+ * local-relative — so every reading had a 3600 s constant TZ-bias
+ * baked into its `deviation_seconds`. Drift-rate math cancelled the
+ * bias (constant offset), but per-reading absolute deviation looked
+ * 1 hour off. The user noticed and reported it. The fix: SPA sends
+ * `client_tz_offset_minutes` (DST-aware, captured via
+ * `-new Date(captureMs).getTimezoneOffset()`), persisted in the
+ * reading-token, and threaded into both endpoints' HMS computation.
+ *
+ * Backward compat: when offset is undefined we fall back to UTC
+ * components — matches the pre-#126 behaviour for any in-flight
+ * tokens minted before the deploy.
+ *
+ * @param referenceMs unix ms (UTC, the moment the photo was captured)
+ * @param clientTzOffsetMinutes  east-of-UTC offset in minutes; +60
+ *   for WEST, +120 for CEST, −240 for EDT, etc. Optional.
+ */
+function referenceHmsForUserClock(
+  referenceMs: number,
+  clientTzOffsetMinutes?: number,
+): { h: number; m: number; s: number } {
+  // Shift the unix-ms forward into the user's local clock by adding
+  // the offset. The resulting Date's `getUTC*()` methods now return
+  // components that match what a watch in the user's TZ would
+  // display at moment of capture.
+  const shiftedMs =
+    clientTzOffsetMinutes !== undefined
+      ? referenceMs + clientTzOffsetMinutes * 60_000
+      : referenceMs;
+  const d = new Date(shiftedMs);
+  const h24 = d.getUTCHours();
+  // Map 0..23 → 12, 1..11, 12, 1..11 on the analog 12-hour dial.
+  const h12 = ((h24 + 11) % 12) + 1;
+  return { h: h12, m: d.getUTCMinutes(), s: d.getUTCSeconds() };
+}
+
+/**
  * Wrap-aware full-HMS deviation on the 12-hour analog cycle (43200
  * seconds). Returns the shortest signed distance (in seconds)
  * between two HH:MM:SS triples, always in [-21600, +21600].
@@ -501,14 +548,10 @@ function hmsTotalSeconds(hms: { h: number; m: number; s: number }): number {
  * — a watch that's actually 1h fast must record as +3600s, not
  * wrap modulo-30-min into a near-zero value.
  *
- * Timezone caveat: when the reference came from server arrival
- * (no EXIF), the reference's UTC hour ≠ user's local hour by the
- * TZ offset. The deviation will then include a constant TZ-offset
- * component that's the same for every reading the user submits,
- * so DRIFT-RATE math (delta between readings) cancels it out
- * correctly. Per-reading absolute deviation will look "off" by
- * the TZ offset for the EXIF-missing case. Acceptable for v1; a
- * follow-up could pass the user's TZ offset from the SPA.
+ * Timezone handling now lives in `referenceHmsForUserClock` (PR
+ * #126). The reference HMS passed in here is already in the user's
+ * watch-clock frame, so the deviation calculation itself is a pure
+ * digit-vs-digit comparison.
  */
 function compute12HourDeviation(
   dial: { h: number; m: number; s: number },
@@ -606,6 +649,33 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
     clientCaptureMs = parsed;
   }
 
+  // Optional `client_tz_offset_minutes` form field. PR #126 fix for
+  // the TZ-bias-as-deviation report: a watch on Lisbon local
+  // (UTC+1) compared against a UTC-derived reference produces
+  // every reading with a 3600 s constant offset baked in. Drift
+  // rate cancels it, but per-reading absolute deviation looks 1 h
+  // off. The SPA captures
+  //   `-new Date(captureMs).getTimezoneOffset()`
+  // which is DST-aware (the offset that was in effect at the moment
+  // of capture, not at handler-entry time). Server bounds it to
+  // ±840 minutes (covers all real TZs incl. UTC+14 / UTC−12).
+  //
+  // Same "invalid → 400" treatment as `client_capture_ms` — a SPA
+  // that drifts out of contract should fail loud, not silently
+  // produce TZ-biased readings.
+  const clientTzOffsetMinutesRaw = form.get("client_tz_offset_minutes");
+  let clientTzOffsetMinutes: number | undefined;
+  if (
+    typeof clientTzOffsetMinutesRaw === "string" &&
+    clientTzOffsetMinutesRaw.length > 0
+  ) {
+    const parsed = Number(clientTzOffsetMinutesRaw);
+    if (!Number.isFinite(parsed) || parsed < -840 || parsed > 840) {
+      return c.json({ error: "invalid_input", field: "client_tz_offset_minutes" }, 400);
+    }
+    clientTzOffsetMinutes = parsed;
+  }
+
   const imageBuffer = await image.arrayBuffer();
 
   const aiGatewayId = c.env.AI_GATEWAY_ID ?? "dial-reader-bakeoff";
@@ -664,17 +734,24 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
 
   const expiresAtUnix = Math.floor(Date.now() / 1000) + READING_TOKEN_TTL_SECONDS;
 
-  // Convert the reference's UTC hour to a 12-hour analog hour
-  // (1..12, no AM/PM marker). The VLM's mm_ss read is paired with
-  // this hour to produce the predicted analog dial display the SPA
-  // shows in the confirmation page. PR #122: full HH:MM:SS
-  // returned to client so per-component up/down can pre-populate
-  // with the right starting values.
-  const refDate = new Date(result.reference_timestamp_ms);
-  const refHour24 = refDate.getUTCHours();
-  const refHour12 = ((refHour24 + 11) % 12) + 1;
+  // Convert the reference timestamp to a 12-hour analog HOUR position
+  // matching what the user's watch should be displaying. The VLM's
+  // mm_ss read is paired with this hour to produce the predicted
+  // analog dial display the SPA shows in the confirmation page.
+  //
+  // PR #122 added per-component HH/MM/SS adjusters. PR #126 added the
+  // optional `clientTzOffsetMinutes` shift so watches on local time
+  // (e.g. Lisbon WEST) get a predicted hour that matches their dial
+  // rather than UTC's. The minute/second components come straight
+  // from the VLM's mm_ss read (TZ doesn't affect MM:SS for any real
+  // TZ — they're all whole-hour or whole-half-hour offsets, and the
+  // half-hour cases round trivially since we never cross 30 min).
+  const refHmsAtUserClock = referenceHmsForUserClock(
+    result.reference_timestamp_ms,
+    clientTzOffsetMinutes,
+  );
   const predictedHms = {
-    h: refHour12,
+    h: refHmsAtUserClock.h,
     m: result.mm_ss.m,
     s: result.mm_ss.s,
   };
@@ -688,6 +765,10 @@ readingsByWatchRoute.post("/verified/draft", async (c) => {
     watch_id: watchId,
     expires_at_unix: expiresAtUnix,
     vlm_model: result.vlm_model,
+    // PR #126: persist client TZ offset so /confirm reproduces the
+    // same local-clock reference HMS used here for predicted_hms.h.
+    // Optional — pre-#126 SPAs omit it.
+    client_tz_offset_minutes: clientTzOffsetMinutes,
   };
   const readingToken = await signReadingToken(tokenPayload, c.env.READING_TOKEN_SECRET);
 
@@ -807,17 +888,16 @@ readingsByWatchRoute.post("/verified/confirm", async (c) => {
   // server-clock readings (no drift) which is itself a detection
   // signal in the leaderboard.
 
-  // Build the reference HMS from the token's stored reference_ms.
-  // The hour comes via 12-hour conversion of the reference's UTC
-  // hour (matches what /draft minted into predicted_hms).
-  const refDate = new Date(payload.reference_ms);
-  const refHour24 = refDate.getUTCHours();
-  const refHour12 = ((refHour24 + 11) % 12) + 1;
-  const referenceHms = {
-    h: refHour12,
-    m: refDate.getUTCMinutes(),
-    s: refDate.getUTCSeconds(),
-  };
+  // Build the reference HMS from the token's stored reference_ms,
+  // shifted into the user's local-clock frame using the same TZ
+  // offset that was used when /draft minted `predicted_hms.h`.
+  // Without this shift, a watch on local time (e.g. Lisbon WEST,
+  // +60 min) ends up with a 3600 s constant TZ-bias added to every
+  // saved deviation. PR #126.
+  const referenceHms = referenceHmsForUserClock(
+    payload.reference_ms,
+    payload.client_tz_offset_minutes,
+  );
 
   const deviationSeconds = is_baseline
     ? 0

--- a/tests/integration/readings.verified.test.ts
+++ b/tests/integration/readings.verified.test.ts
@@ -146,7 +146,7 @@ async function postDraft(
   watchId: string,
   fixtureName: string,
   cookie: string,
-  options?: { clientCaptureMs?: number },
+  options?: { clientCaptureMs?: number; clientTzOffsetMinutes?: number },
 ): Promise<Response> {
   const bytes = fixtureBytes(fixtureName);
   const form = new FormData();
@@ -154,6 +154,9 @@ async function postDraft(
   form.append("image", file);
   if (options?.clientCaptureMs !== undefined) {
     form.append("client_capture_ms", String(options.clientCaptureMs));
+  }
+  if (options?.clientTzOffsetMinutes !== undefined) {
+    form.append("client_tz_offset_minutes", String(options.clientTzOffsetMinutes));
   }
   return exports.default.fetch(
     new Request(
@@ -469,6 +472,124 @@ describe("POST /api/v1/watches/:id/readings/verified/draft", () => {
     VERIFIED_TIMEOUT,
   );
 
+  // ---- client_tz_offset_minutes (PR #126, fix for TZ-bias-as-deviation) ----
+  //
+  // A user in Lisbon (WEST = UTC+1) with a watch on local time
+  // reported a saved verified reading with a 1-hour deviation even
+  // though they confirmed the correct dial values. Cause: the
+  // server's reference HMS came from `refDate.getUTCHours()`, which
+  // is UTC-relative; the watch dial shows local hour. Every reading
+  // ended up with a constant +3600 s TZ-bias baked into
+  // `deviation_seconds`. Drift rate cancelled it (constant offset),
+  // but per-reading absolute deviation looked an hour off.
+  //
+  // The SPA now sends `client_tz_offset_minutes` (DST-aware,
+  // captured via `-new Date(captureMs).getTimezoneOffset()`).
+  // Server uses it to compute `predicted_hms.h` at /draft and the
+  // reference HMS at /confirm, so deviation reflects watch-clock
+  // vs local-clock comparison rather than UTC.
+
+  it(
+    "uses client_tz_offset_minutes to shift predicted_hms.h into local-clock frame (Lisbon WEST +60)",
+    async () => {
+      // Reference: 2026-04-29 13:30:15 UTC. With +60 min offset (Lisbon
+      // WEST), local clock is 14:30:15 → predicted h = 2 (12-hour),
+      // not 1 (which is what UTC alone would give).
+      const refMs = Date.UTC(2026, 3, 29, 13, 30, 15, 0);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(refMs);
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 15 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Lisbon WEST", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie, {
+        clientTzOffsetMinutes: 60,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as DraftResponse;
+      expect(body.predicted_hms).toEqual({ h: 2, m: 30, s: 15 });
+    },
+    VERIFIED_TIMEOUT,
+  );
+
+  it(
+    "uses client_tz_offset_minutes to shift predicted_hms.h into local-clock frame (New York EDT −240)",
+    async () => {
+      // Reference: 2026-04-29 13:30:15 UTC. With −240 min offset
+      // (New York EDT), local clock is 09:30:15 → predicted h = 9.
+      const refMs = Date.UTC(2026, 3, 29, 13, 30, 15, 0);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(refMs);
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 15 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "NYC EDT", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie, {
+        clientTzOffsetMinutes: -240,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as DraftResponse;
+      expect(body.predicted_hms).toEqual({ h: 9, m: 30, s: 15 });
+    },
+    VERIFIED_TIMEOUT,
+  );
+
+  it(
+    "preserves UTC-relative behaviour when client_tz_offset_minutes is omitted (backward compat)",
+    async () => {
+      const refMs = Date.UTC(2026, 3, 29, 13, 30, 15, 0);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(refMs);
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 15 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Backward compat", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as DraftResponse;
+      // No offset → use UTC components → 13 → h=1 (12-hour).
+      expect(body.predicted_hms).toEqual({ h: 1, m: 30, s: 15 });
+    },
+    VERIFIED_TIMEOUT,
+  );
+
+  it(
+    "returns 400 when client_tz_offset_minutes is out of bounds",
+    async () => {
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 0 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Bad TZ", movement_id: movementId },
+        owner.cookie,
+      );
+      const res = await postDraft(
+        watchId,
+        "bambino_10_19_34.jpeg",
+        owner.cookie,
+        { clientTzOffsetMinutes: 1500 }, // > +840 max
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string; field?: string };
+      expect(body.error).toBe("invalid_input");
+      expect(body.field).toBe("client_tz_offset_minutes");
+    },
+    VERIFIED_TIMEOUT,
+  );
+
   it(
     "returns 422 with retake reason on VLM unparseable",
     async () => {
@@ -604,6 +725,105 @@ describe("POST /api/v1/watches/:id/readings/verified/confirm", () => {
       const draftKey = new URL(draftBody.photo_url).pathname.replace(/^\/images\//, "");
       const draftPhoto = await r2.get(draftKey);
       expect(draftPhoto).toBeNull();
+    },
+    VERIFIED_TIMEOUT,
+  );
+
+  it(
+    "with client_tz_offset_minutes, deviation reflects local-clock comparison (no TZ-bias added)",
+    async () => {
+      // The bug we're fixing: pre-#126, a Lisbon-WEST user (+60 min)
+      // with a watch on local time submitting an HMS that exactly
+      // matches their dial got `deviation_seconds = 3600` because
+      // the server compared against UTC hour. With this fix, the
+      // server shifts reference_ms by +60 min before extracting H/M/S,
+      // so the comparison is local-vs-local and deviation comes out
+      // small.
+      //
+      // Set up: photo captured at 13:30:15 UTC. Watch on Lisbon WEST
+      // (+60 min) shows 14:30:20 (5 s fast). User confirms
+      // {h:2, m:30, s:20}. Pre-fix this would have been compared
+      // against UTC's {h:1, m:30, s:15} → +3605. Post-fix it's
+      // compared against local {h:2, m:30, s:15} → +5.
+      const refMs = Date.UTC(2026, 3, 29, 13, 30, 15, 0);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(refMs);
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 15 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Lisbon local watch", movement_id: movementId },
+        owner.cookie,
+      );
+
+      const draftRes = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie, {
+        clientTzOffsetMinutes: 60,
+      });
+      expect(draftRes.status).toBe(200);
+      const draftBody = (await draftRes.json()) as DraftResponse;
+      // Predicted hour reflects local clock.
+      expect(draftBody.predicted_hms.h).toBe(2);
+
+      // User confirms with a watch reading that's +5 s vs the local
+      // reference clock. Hour they submit (2) matches what they see
+      // on the dial.
+      const confirmRes = await postConfirm(
+        watchId,
+        {
+          reading_token: draftBody.reading_token,
+          final_hms: { h: 2, m: 30, s: 20 },
+        },
+        owner.cookie,
+      );
+      expect(confirmRes.status).toBe(201);
+      const reading = (await confirmRes.json()) as ReadingResponseBody;
+      // No 3600 s TZ bias — deviation reflects the +5 s offset
+      // between watch and local clock.
+      expect(reading.deviation_seconds).toBe(5);
+    },
+    VERIFIED_TIMEOUT,
+  );
+
+  it(
+    "without client_tz_offset_minutes, deviation falls back to UTC-relative behavior (backward compat)",
+    async () => {
+      // Backward-compat smoke: a SPA on a pre-#126 build doesn't
+      // send the offset field. The server falls back to UTC
+      // components for the reference, which means watches on local
+      // time see the historical TZ-bias-as-deviation. We don't fix
+      // that for the legacy path — we just preserve it so old
+      // tokens minted before the deploy still validate correctly
+      // against the same arithmetic.
+      const refMs = Date.UTC(2026, 3, 29, 13, 30, 15, 0);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(refMs);
+      __setTestExifReader(async () => null);
+      installVlmMock({ m: 30, s: 15 });
+
+      const owner = await registerAndGetCookie();
+      const { id: watchId } = await createWatch(
+        { name: "Pre-126 SPA", movement_id: movementId },
+        owner.cookie,
+      );
+
+      const draftRes = await postDraft(watchId, "bambino_10_19_34.jpeg", owner.cookie);
+      const draftBody = (await draftRes.json()) as DraftResponse;
+      expect(draftBody.predicted_hms.h).toBe(1); // UTC's 13 → 1 (12-hour)
+
+      // User submits {h:1, m:30, s:20} matching the UTC-relative
+      // prediction. Deviation is +5 s relative to UTC.
+      const confirmRes = await postConfirm(
+        watchId,
+        {
+          reading_token: draftBody.reading_token,
+          final_hms: { h: 1, m: 30, s: 20 },
+        },
+        owner.cookie,
+      );
+      expect(confirmRes.status).toBe(201);
+      const reading = (await confirmRes.json()) as ReadingResponseBody;
+      expect(reading.deviation_seconds).toBe(5);
     },
     VERIFIED_TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- SPA sends `client_tz_offset_minutes` (DST-aware, captured at moment of photo) so the server can express the reference HMS in the user's local-clock frame when computing deviation.
- `/draft` validates ±840 min, bakes into reading_token, uses for `predicted_hms.h`.
- `/confirm` reads from token, applies same shift to reference HMS before deviation calc.
- New helper `referenceHmsForUserClock(refMs, tzOffsetMinutes?)` so `/draft` and `/confirm` can't drift apart on the H/M/S extraction.
- Backward compatible: omitted field → UTC-relative behavior, identical to pre-#126.

## Why

A user in Lisbon WEST with a watch on local time confirmed correct dial values via the verified-reading flow and saw `deviation_seconds = 3600+`. PR #124 made the reference timestamp accurate (real UTC of capture) but both endpoints extracted H/M/S from `refDate.getUTCHours()` — UTC-relative — while the watch dial shows local-relative time. Every reading had a constant TZ offset baked into deviation.

Drift-rate math was already correct (constant offset cancels), but per-reading absolute looked an hour off. The bias was [documented in AGENTS.md](https://github.com/nmourapt/ratedwatch/blob/d0653ad/AGENTS.md) as a known limitation:

> Per-reading absolute deviation will look "off" by the TZ offset for the EXIF-missing case. Acceptable for v1; a follow-up could pass the user's TZ offset from the SPA.

This is that follow-up.

## Anti-cheat

Bounded ±840 minutes (covers UTC+14 and UTC−12 with DST variants). A malicious client can shift the reference HMS by at most 14 hours; the existing photo audit + HMAC + leaderboard-pattern-detection defenses are unchanged. Lying about TZ to forge drift would manifest as a watch with implausible accuracy relative to other readings on the same movement.

## Test coverage

- `/draft` uses offset to shift `predicted_hms.h` — Lisbon WEST +60 ✓
- `/draft` uses offset to shift `predicted_hms.h` — NYC EDT −240 ✓
- `/draft` falls back to UTC when offset omitted (back-compat) ✓
- `/draft` 400s on out-of-bounds offset (>±840) ✓
- `/confirm` + offset → deviation is local-clock-comparison (no 3600 s bias) ✓
- `/confirm` without offset → falls back to UTC-relative (back-compat) ✓

**Total: 6 new tests. 629 passing (was 623).** No new modules, no migrations, no infra changes.

## Out of scope

- Per-watch TZ override (some users might want to track a watch on UTC even though their phone is in WEST). This PR uses the SPA's TZ offset, which assumes the watch matches the phone's TZ. If that doesn't hold, the user can mentally adjust or we add a per-watch setting later.
- Half-hour TZs (IST, ACST, NPT): the helper handles them correctly because we shift in ms (not just hours). The MM:SS components shift by 30 minutes when applicable, which is what the dial would actually show in those zones.

## Rollback

Revert this PR. The new code path is purely additive — the worker still accepts `/draft` requests without `client_tz_offset_minutes` and falls through to the UTC-relative behavior. Tokens minted before the deploy don't carry the field, so they validate cleanly under the optional-field schema.

🤖 Generated with [opencode](https://opencode.ai)