### PR TITLE
fix(verified-reading): NTP-style clock-skew correction for client_capture_ms

### DIFF
--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -67,6 +67,7 @@ import {
 } from "./readings";
 import { maybeResize } from "./resizePhoto";
 import { extractCaptureTime } from "./extractCaptureTime";
+import { estimateClockSkew } from "./ntpSync";
 import type { VerifiedReadingErrorMessage } from "./verifiedReadingErrors";
 
 interface Props {
@@ -257,7 +258,22 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
     // server-arrival fallback (which lags by upload latency, 5-15 s
     // on cellular).
     const submitMs = Date.now();
-    const clientCaptureMs = await extractCaptureTime(sourceFile, submitMs);
+    const rawCaptureMs = await extractCaptureTime(sourceFile, submitMs);
+
+    // PR #127: estimate the iPhone-vs-NTP clock skew via a
+    // /api/v1/_time round-trip and correct the captured timestamp
+    // before sending. Without this, an iPhone running a few seconds
+    // ahead of NTP truth (real-world failure mode on cellular-only
+    // devices, after airplane-mode toggles, or in spotty Wi-Fi)
+    // bakes that bias into every saved deviation. The estimator
+    // never throws — on network error or implausible response we
+    // skip the correction and submit the raw `rawCaptureMs`. The
+    // server's existing ±5 min / +1 min bound on /draft is the
+    // backstop: a wildly off timestamp gets 422 there regardless.
+    const skewResult = await estimateClockSkew("/api/v1/_time");
+    const clientCaptureMs = skewResult.ok
+      ? rawCaptureMs + skewResult.skewMs
+      : rawCaptureMs;
 
     // Capture the user's TZ offset (minutes east of UTC) at the
     // capture moment, so the server can express the reference HMS

--- a/src/app/watches/ntpSync.test.ts
+++ b/src/app/watches/ntpSync.test.ts
@@ -1,0 +1,180 @@
+// Unit tests for the SPA-side NTP-style clock-skew estimator
+// (PR #127). See ./ntpSync.ts for the design + math.
+//
+// These tests use a fake `fetch` so the helper's contract is
+// exercised without hitting a real worker. The fake captures the
+// outgoing request and returns a response containing `{ now }` —
+// which is the only field the helper reads.
+//
+// Math under test:
+//
+//   T1 = client send       (`Date.now()` before fetch)
+//   T2 = server receive    (the `now` in the response body)
+//   T4 = client receive    (`Date.now()` after fetch resolves)
+//
+//   skew = T2 - (T1 + T4) / 2
+//        = how far ahead the iPhone's clock is of the server's.
+//          positive → iPhone is fast, negative → iPhone is slow.
+//   rtt  = T4 - T1
+//
+// The helper assumes T2 ≈ T3 (server processing is negligible). In
+// production, /api/v1/_time literally returns `Date.now()` and does
+// nothing else, so this is true to within microseconds.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { estimateClockSkew, MAX_RTT_MS, MAX_SKEW_MS } from "./ntpSync";
+
+interface FakeFetchOptions {
+  /** Server's `now` to return in the response. */
+  serverNowMs: number;
+  /** Time elapsed (ms) between the SPA's T1 and T4 — the round trip. */
+  rttMs?: number;
+  /** If true, the fetch rejects (network failure). */
+  reject?: boolean;
+  /** If true, the response status is non-2xx. */
+  errorStatus?: number;
+}
+
+/**
+ * Build a fetch fake that:
+ *   1. Records T1 = `Date.now()` at call time.
+ *   2. Advances the fake clock by `rttMs/2` (one-way latency).
+ *   3. Resolves with a Response whose body is `{ now: serverNowMs }`.
+ *   4. Advances the clock another `rttMs/2`.
+ *
+ * The result: T1 = whatever Date.now() was when the helper called
+ * fetch, T4 = T1 + rttMs. The helper sees `now: serverNowMs` and
+ * computes skew/rtt against its own T1, T4.
+ */
+function makeFetch(opts: FakeFetchOptions): typeof globalThis.fetch {
+  return async () => {
+    if (opts.reject) {
+      throw new Error("network");
+    }
+    // Simulate one-way latency by advancing fake timers.
+    const halfRtt = (opts.rttMs ?? 100) / 2;
+    vi.advanceTimersByTime(halfRtt);
+    if (opts.errorStatus) {
+      const r = new Response("server boom", { status: opts.errorStatus });
+      vi.advanceTimersByTime(halfRtt);
+      return r;
+    }
+    const r = new Response(JSON.stringify({ now: opts.serverNowMs }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    vi.advanceTimersByTime(halfRtt);
+    return r;
+  };
+}
+
+describe("estimateClockSkew", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Anchor SPA's Date.now() at a known moment so we can reason
+    // about T1 / T4 deterministically.
+    vi.setSystemTime(new Date("2026-05-05T12:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 0 skew when server time matches client at midpoint", async () => {
+    // Client at 12:00:00.000 (T1). Server returns 12:00:00.050
+    // (== T1 + 50ms = midpoint of a 100ms RTT). Skew = 0.
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 12, 0, 0, 50),
+      rttMs: 100,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.skewMs).toBe(0);
+    expect(result.roundTripMs).toBe(100);
+  });
+
+  it("returns positive skew when client clock is AHEAD of server", async () => {
+    // Client thinks it's 12:00:00.000 (T1). Server says it's
+    // 11:59:53.050 (= 7s before client + 50ms midpoint). Client is
+    // 7s ahead.
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 11, 59, 53, 50),
+      rttMs: 100,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.skewMs).toBe(-7000); // server says it's earlier → client is ahead → "skew" negative under our convention
+    // Convention reminder: skewMs = T2 - midpoint. Negative skewMs
+    // means server is BEHIND midpoint → client clock is AHEAD of
+    // server. That's the case to subtract from `client_capture_ms`.
+  });
+
+  it("returns negative skew when client clock is BEHIND server", async () => {
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 12, 0, 7, 50),
+      rttMs: 100,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.skewMs).toBe(7000); // server is AHEAD → client is BEHIND
+  });
+
+  it("rejects when round trip exceeds MAX_RTT_MS (network too slow)", async () => {
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 12, 0, 0, 0),
+      rttMs: MAX_RTT_MS + 100,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("rtt_too_high");
+  });
+
+  it("rejects when |skew| exceeds MAX_SKEW_MS (likely garbage server response)", async () => {
+    // Server says it's 100s ahead — implausible. Helper says no.
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 12, 1, 40, 50),
+      rttMs: 100,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("skew_too_high");
+    expect(Math.abs(result.skewMs!)).toBeGreaterThan(MAX_SKEW_MS);
+  });
+
+  it("rejects on network failure", async () => {
+    const fetch = makeFetch({ serverNowMs: 0, reject: true });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("network_error");
+  });
+
+  it("rejects on non-2xx response", async () => {
+    const fetch = makeFetch({
+      serverNowMs: Date.UTC(2026, 4, 5, 12, 0, 0, 50),
+      errorStatus: 500,
+    });
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("non_ok_status");
+  });
+
+  it("rejects on malformed response body (no `now` field)", async () => {
+    const fetch: typeof globalThis.fetch = async () => {
+      vi.advanceTimersByTime(100);
+      return new Response(JSON.stringify({ banana: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const result = await estimateClockSkew("/api/v1/_time", fetch);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("malformed_response");
+  });
+});

--- a/src/app/watches/ntpSync.ts
+++ b/src/app/watches/ntpSync.ts
@@ -1,0 +1,143 @@
+// SPA-side NTP-style clock-skew estimator (PR #127, fix for the
+// iPhone-clock-vs-NTP-truth bias on verified readings).
+//
+// ## What it does
+//
+// One HTTP round-trip against `/api/v1/_time` plus a bit of math
+// gives an estimate of how far the SPA's `Date.now()` is from the
+// Worker's `Date.now()`. Workers run on Cloudflare's NTP-synced edge
+// (atomic-time-anchored), so the server clock is reliably truth.
+// The SPA can then subtract the estimated skew from
+// `client_capture_ms` before submitting `/draft`, eliminating the
+// iPhone-clock-skew source of bias from every verified reading.
+//
+// ## The math
+//
+//   T1 = client send time  (`Date.now()` immediately before fetch)
+//   T2 = server receive time (`now` in the response body — assumed
+//        ≈ T3 because the server returns immediately)
+//   T4 = client receive time (`Date.now()` after fetch resolves)
+//
+//   skewMs       = T2 - (T1 + T4) / 2
+//   roundTripMs  = T4 - T1
+//
+// `skewMs` interpretation: how much the SPA's clock is BEHIND the
+// server's. Positive → SPA behind server (server thinks it's later).
+// Negative → SPA ahead of server (iPhone is fast relative to NTP).
+//
+// To correct a `client_capture_ms` that came from the iPhone clock:
+//
+//   correctedMs = clientCaptureMs + skewMs
+//
+// (If iPhone is ahead by 7 s, skewMs = −7000, and we subtract 7s
+// from the captured timestamp to bring it back to NTP truth.)
+//
+// ## Sanity bounds
+//
+// We reject the estimate when:
+//
+//   * round trip is > MAX_RTT_MS (5 s) — typical mobile networks
+//     come in well under 1 s; 5 s suggests something is wrong (slow
+//     uplink, server cold-start, captive portal). The skew estimate
+//     becomes unreliable above this threshold because the asymmetric-
+//     latency error bound grows with RTT/2.
+//
+//   * |skew| > MAX_SKEW_MS (60 s) — implausible for a well-tended
+//     iPhone. If we're seeing this, either the server is misbehaving
+//     or someone is actively spoofing. Better to fall back to the
+//     existing reference path than to apply a wild correction.
+//
+// On rejection the verified-reading flow continues without
+// correction — the existing server-side ±5min/+1min bound still
+// applies, so we never accept a wildly off `client_capture_ms`.
+
+/**
+ * Maximum round trip time we'll accept for a clock-skew estimate.
+ * Above this the asymmetric-latency error gets too large to give
+ * a useful signal. Production p95 RTT to Cloudflare's nearest
+ * colo is well under 200 ms; 5 s is a generous ceiling.
+ */
+export const MAX_RTT_MS = 5_000;
+
+/**
+ * Maximum |skew| we'll accept. Real iPhones typically drift sub-
+ * second from NTP; even on long-untended cellular-only devices the
+ * skew rarely exceeds tens of seconds. 60 s is a generous ceiling
+ * that catches both runaway iPhones and broken server responses.
+ */
+export const MAX_SKEW_MS = 60_000;
+
+export type ClockSkewResult =
+  | {
+      ok: true;
+      /** How many ms the client clock is BEHIND the server. */
+      skewMs: number;
+      /** How many ms the round trip took. */
+      roundTripMs: number;
+    }
+  | {
+      ok: false;
+      reason:
+        | "rtt_too_high"
+        | "skew_too_high"
+        | "network_error"
+        | "non_ok_status"
+        | "malformed_response";
+      /** Best-effort skew estimate when available, for logging. */
+      skewMs?: number;
+      roundTripMs?: number;
+    };
+
+/**
+ * Hit `/api/v1/_time` and compute the SPA's clock skew vs the
+ * Worker. `fetchImpl` is injectable so tests can avoid hitting a
+ * real network.
+ *
+ * Never throws — every failure mode collapses to `ok: false`.
+ */
+export async function estimateClockSkew(
+  endpoint: string,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+): Promise<ClockSkewResult> {
+  const t1 = Date.now();
+  let response: Response;
+  try {
+    response = await fetchImpl(endpoint, {
+      method: "GET",
+      // The endpoint is unauthed and idempotent. Skip credentials
+      // to avoid an unnecessary cookie round-trip.
+      credentials: "omit",
+      // No-cache: every call needs fresh server time. A cached
+      // response would defeat the point.
+      cache: "no-store",
+    });
+  } catch {
+    return { ok: false, reason: "network_error" };
+  }
+  const t4 = Date.now();
+  if (!response.ok) {
+    return { ok: false, reason: "non_ok_status" };
+  }
+  let body: { now?: unknown } | null = null;
+  try {
+    body = (await response.json()) as { now?: unknown };
+  } catch {
+    return { ok: false, reason: "malformed_response" };
+  }
+  const t2 = body?.now;
+  if (typeof t2 !== "number" || !Number.isFinite(t2)) {
+    return { ok: false, reason: "malformed_response" };
+  }
+
+  const roundTripMs = t4 - t1;
+  const skewMs = t2 - (t1 + t4) / 2;
+
+  if (roundTripMs > MAX_RTT_MS) {
+    return { ok: false, reason: "rtt_too_high", roundTripMs, skewMs };
+  }
+  if (Math.abs(skewMs) > MAX_SKEW_MS) {
+    return { ok: false, reason: "skew_too_high", roundTripMs, skewMs };
+  }
+
+  return { ok: true, skewMs, roundTripMs };
+}

--- a/src/server/routes/time.ts
+++ b/src/server/routes/time.ts
@@ -1,0 +1,58 @@
+// GET /api/v1/_time — server-clock probe for SPA-side NTP-style
+// clock-skew estimation (PR #127).
+//
+// ## Why this exists
+//
+// PR #124 made the verified-reading reference timestamp accurate to
+// the moment of shutter via EXIF DateTimeOriginal. PR #126 fixed the
+// TZ-offset bias on top of that. Both treat the iPhone's clock as
+// authoritative for "when the photo was captured."
+//
+// In practice iPhones — especially on cellular-only or after
+// airplane-mode toggles — can drift several seconds from NTP truth.
+// A user in Lisbon reported a saved deviation of −7 s on a watch
+// that was almost certainly running closer to 0 s/day; the math
+// works if their iPhone clock was ~7 s ahead of NTP. Without an
+// independent server-side clock check, that bias is invisible to the
+// system and gets baked into every reading.
+//
+// This endpoint exposes the Worker's `Date.now()` so the SPA can do
+// a 4-timestamp NTP-style round-trip (T1=client send, T2≈T3=server,
+// T4=client receive) and estimate its own clock skew before sending
+// `client_capture_ms`. Cloudflare's edge nodes are atomic-time-synced
+// so `Date.now()` here is reliably truth.
+//
+// ## What it returns
+//
+//   200 { now: <unix ms at handler entry> }
+//
+// That's it. No auth, no rate limit, no body parsing. The whole
+// request is sub-millisecond on the worker side; the only latency the
+// SPA sees is network round-trip — which is exactly what we want
+// (the SPA averages the latency assuming symmetric one-way).
+//
+// ## Anti-cheat
+//
+// This endpoint changes nothing about the verified-reading server's
+// trust model. The SPA can use the returned `now` to apply a
+// correction to `client_capture_ms` before submitting, but the
+// existing ±5 min / +1 min bound check still applies on /draft. A
+// malicious client claiming a wildly off skew ends up out-of-bounds
+// and gets 422 — same envelope as before.
+
+import { Hono } from "hono";
+
+// This route doesn't read any bindings — it just returns the
+// runtime's `Date.now()`. Typing the env as `object` keeps tsc
+// quiet without dragging in the full Bindings union from
+// worker-configuration.d.ts.
+export const timeRoute = new Hono<{ Bindings: object }>();
+
+timeRoute.get("/", (c) => {
+  // Read once. The SPA assumes T2 ≈ T3 (server processing time is
+  // negligible compared to network RTT). Returning a single value
+  // simplifies that assumption: it's both the receive and send
+  // moment. If we ever add even tiny processing here (logging, KV
+  // reads, etc.) we'll need to return separate T2/T3.
+  return c.json({ now: Date.now() });
+});

--- a/src/worker/index.tsx
+++ b/src/worker/index.tsx
@@ -30,6 +30,7 @@ import {
 import { leaderboardRoute } from "@/server/routes/leaderboard";
 import { meRoute } from "@/server/routes/me";
 import { movementsRoute } from "@/server/routes/movements";
+import { timeRoute } from "@/server/routes/time";
 import { outRoute } from "@/server/routes/out";
 import { readingsByIdRoute, readingsByWatchRoute } from "@/server/routes/readings";
 import { seoRoute } from "@/server/routes/seo";
@@ -303,6 +304,11 @@ app.all("/api/v1/auth/*", (c) => {
 // auth gate and the public movements taxonomy search (slice 7);
 // later slices add watches/readings here.
 app.route("/api/v1/me", meRoute);
+// Server-clock probe used by the SPA's NTP-style sync to estimate
+// iPhone-vs-NTP clock skew before submitting `client_capture_ms` on
+// /draft (PR #127). Public, no auth, sub-millisecond response so the
+// SPA can attribute round-trip time entirely to network latency.
+app.route("/api/v1/_time", timeRoute);
 app.route("/api/v1/movements", movementsRoute);
 // Global leaderboard + per-movement leaderboard (filter via query param).
 // Public — no auth middleware. See src/server/routes/leaderboard.ts.

--- a/tests/integration/time.test.ts
+++ b/tests/integration/time.test.ts
@@ -1,0 +1,68 @@
+// Integration test for `GET /api/v1/_time` (PR #127).
+//
+// The endpoint is the server side of the SPA's NTP-style clock-
+// skew estimator — see src/app/watches/ntpSync.ts for the math
+// and src/server/routes/time.ts for the route. The contract under
+// test:
+//
+//   * 200 with `{ now: <unix ms> }`
+//   * `now` is a finite integer close to test's `Date.now()`
+//   * No auth required (the SPA calls this BEFORE login on the
+//     verified-reading flow's draft-step prefetch)
+//   * No side effects: hitting it twice in a row works (idempotent)
+//
+// Time fakes (vi.useFakeTimers + vi.setSystemTime) are honored by
+// miniflare/workerd, so we can assert exact equality of `now`
+// rather than dealing with a tolerance window.
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { exports } from "cloudflare:workers";
+
+const TIME_ENDPOINT = "https://ratedwatch.test/api/v1/_time";
+
+describe("GET /api/v1/_time", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 200 with the server's current Date.now() in unix ms", async () => {
+    const fixedNow = Date.UTC(2026, 4, 5, 14, 23, 7, 250);
+    vi.setSystemTime(fixedNow);
+    const res = await exports.default.fetch(new Request(TIME_ENDPOINT));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { now: unknown };
+    expect(body.now).toBe(fixedNow);
+  });
+
+  it("does not require authentication", async () => {
+    // No cookie, no auth header. Public endpoint per PR #127's
+    // design: the SPA might call it before sign-in flows complete
+    // and we don't want to leak login state through 401s.
+    const res = await exports.default.fetch(
+      new Request(TIME_ENDPOINT, { method: "GET" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("is idempotent — two consecutive calls return increasing now values", async () => {
+    const t0 = Date.UTC(2026, 4, 5, 14, 23, 7, 0);
+    vi.setSystemTime(t0);
+    const r1 = await exports.default.fetch(new Request(TIME_ENDPOINT));
+    const b1 = (await r1.json()) as { now: number };
+    vi.setSystemTime(t0 + 1500);
+    const r2 = await exports.default.fetch(new Request(TIME_ENDPOINT));
+    const b2 = (await r2.json()) as { now: number };
+    expect(b2.now).toBe(t0 + 1500);
+    expect(b2.now).toBeGreaterThan(b1.now);
+  });
+
+  it("rejects non-GET methods (Hono default 405)", async () => {
+    const res = await exports.default.fetch(
+      new Request(TIME_ENDPOINT, { method: "POST" }),
+    );
+    expect([404, 405]).toContain(res.status);
+  });
+});


### PR DESCRIPTION
## Summary

- New `GET /api/v1/_time` route in the Worker — returns `{ now: Date.now() }`. Public, no auth, sub-millisecond response time.
- New `src/app/watches/ntpSync.ts` SPA helper that does a 4-timestamp NTP-style round-trip and returns the SPA's clock skew vs the Worker. Sanity-bounded to reject implausible estimates (RTT > 5s or |skew| > 60s).
- `VerifiedReadingCapture.tsx` now estimates skew before submit and corrects `client_capture_ms` so the saved reference is in NTP truth, not iPhone-clock time.
- 12 new tests (8 SPA + 4 integration). 641 total (was 629).

## Why

A user with a baseline 16h prior to a verified reading saw a saved deviation of −7s, implying −10s/day drift on an Aqua Terra (way out of character). Working through the math:

```
saved_deviation = real_watch_drift − iphone_clock_offset_vs_NTP
```

If the iPhone is ~7s ahead of NTP truth, saved deviation reads −7 even though the real watch drift is ~0. The PR #124 design treated EXIF `DateTimeOriginal` as authoritative for moment-of-shutter — but EXIF inherits whatever skew the iPhone's clock has. Previous tap-style readings masked this because of their 15s quantization noise; high-precision verified readings expose it.

Cloudflare Workers run on atomic-time-anchored edge nodes, so the Worker's `Date.now()` is reliable truth. The SPA can compare its own clock to the Worker's via a quick round-trip and correct the captured timestamp before sending.

## How (the math)

```
T1 = client send       Date.now() before fetch
T2 = server receive    `now` field in the /api/v1/_time response
T4 = client receive    Date.now() after fetch resolves

skew    = T2 − (T1 + T4) / 2     positive → SPA behind server
rtt     = T4 − T1
```

Assumes T2 ≈ T3 (server processing time is negligible — the route returns `Date.now()` and does nothing else) and that one-way latency is roughly symmetric (true on TCP/HTTPS within ~10-20ms — fine for our ±1s precision needs).

To correct a captured timestamp:

```
correctedCaptureMs = clientCaptureMs + skewMs
```

If iPhone is +7s ahead, `skewMs = −7000`, the correction subtracts 7s from the captured timestamp to bring it back to NTP truth.

## Failure modes (graceful degrade)

| Cause | Behavior |
|---|---|
| Network error fetching `/api/v1/_time` | Submit raw `clientCaptureMs`; server bound check is the backstop |
| Non-2xx from `/api/v1/_time` | Same |
| RTT > 5s (likely cellular dropout) | Skip correction; latency-asymmetry error too large to give a useful signal |
| \|skew\| > 60s | Skip correction; either spoof or broken server response |
| Malformed response body | Skip correction |

## Anti-cheat (unchanged)

Server's existing ±5min / +1min bound on `client_capture_ms` still applies. A malicious client claiming a wild skew just hits the bound and gets 422. The new route adds zero attack surface — it's a read-only `Date.now()` echo, no state.

## Test plan

- `src/app/watches/ntpSync.test.ts` — 8 cases: zero skew, positive skew (iPhone behind), negative skew (iPhone ahead), RTT bound, skew bound, network error, non-2xx, malformed body.
- `tests/integration/time.test.ts` — 4 cases: `Date.now()` round-trip, no-auth, idempotency, method rejection.
- Manual verification on production after merge: take a reading and check whether `deviation_seconds` lands closer to expected.

## Out of scope

- Surfacing the skew to the user as a "your phone is N seconds off" warning. Helpful diagnostic but more UX. Could ship as a follow-up if iPhone skew turns out to be a chronic issue.
- Multi-sample averaging (NTP-proper does several round-trips and discards outliers). Single sample is fine for our precision target; can revisit if cellular jitter creates noise floor problems.
- Server-side authoritative reference for the verified-reading flow (ditch EXIF entirely). Bigger architectural change. PR #127 keeps EXIF as the moment-of-shutter signal but corrects for client clock skew.

## Rollback

Revert this PR. The new route is purely additive; pre-#127 SPAs don't call it. The capture component falls through to raw `clientCaptureMs` on any failure of the new path, so removing the helper won't break existing flows.

🤖 Generated with [opencode](https://opencode.ai)