### PR TITLE
fix(verified-reading): switch SPA exifr to full build for HEIC EXIF support

### DIFF
--- a/src/app/watches/extractCaptureTime.ts
+++ b/src/app/watches/extractCaptureTime.ts
@@ -46,7 +46,14 @@
 // fall back to `fallbackMs`. We log nothing on failure because
 // non-EXIF photos are a normal user flow, not an error condition.
 
-import { parse as exifrParse } from "exifr/dist/lite.esm.mjs";
+// PR #129: switched from `exifr/dist/lite.esm.mjs` to the full
+// build because lite's HEIC EXIF extractor has gaps that leave
+// DateTimeOriginal undefined for the HEIC variants iPhone Camera
+// produces by default. The full build (~75 KB minified vs lite's
+// ~45 KB) has complete HEIC support. The Worker side stays on lite
+// (the byte-EXIF path there is structurally dead since the SPA's
+// canvas-resize strips EXIF anyway — keeping Worker bundle small).
+import { parse as exifrParse } from "exifr/dist/full.esm.mjs";
 
 /**
  * Source of the returned capture-time. Useful for debug panels:

--- a/src/types/exifr-lite.d.ts
+++ b/src/types/exifr-lite.d.ts
@@ -1,48 +1,64 @@
 // exifr ships its top-level types via `index.d.ts` but does not
 // declare types for the per-bundle entrypoints (`dist/lite.esm.mjs`,
-// `dist/full.esm.mjs`, `dist/mini.esm.mjs`). The lite build exposes
-// the same `parse(input, options)` shape as the top-level package —
-// minus the GPS / thumbnail / orientation helpers we don't use. We
-// declare a narrow shim here so the import in `./exif.ts` typechecks
-// against the surface we actually call.
+// `dist/full.esm.mjs`, `dist/mini.esm.mjs`). All three builds expose
+// the same `parse(input, options)` surface — they differ only in
+// which file formats / segment parsers are bundled. We declare a
+// shared narrow shim here so both Worker (`exif.ts`, lite) and SPA
+// (`extractCaptureTime.ts`, full) imports typecheck.
+//
+// Why two builds: lite (~45 KB) is plenty for the Worker since the
+// byte-EXIF path is structurally dead in production (the SPA's
+// canvas-resize strips EXIF before bytes reach the Worker). Full
+// (~75 KB) lives in the SPA because lite's HEIC EXIF extractor has
+// gaps for the HEIC variants iPhone Camera produces, and we read
+// EXIF client-side from the ORIGINAL file before resize.
 //
 // If a future exifr version reorganises its bundles, drop this file
-// and switch back to the top-level `import { parse } from "exifr"`
-// (with the bundle-size cost it incurs).
+// and switch back to `import { parse } from "exifr"` (the package
+// root has its own types in index.d.ts) at the cost of a larger
+// import.
+
+interface ExifrParseOptions {
+  // Tag-filter forms. Both are exposed but `pick` is BROKEN in the
+  // current lite build (`undefined is not iterable` at
+  // setupGlobalFilters when you call it with `pick` — segments are
+  // not all registered in the dictionary lookup). See PR #124's
+  // discovery + the `{ exif: true }` workaround used in
+  // `src/domain/reading-verifier/exif.ts` and
+  // `src/app/watches/extractCaptureTime.ts`.
+  pick?: Array<string | number>;
+  skip?: Array<string | number>;
+  translateKeys?: boolean;
+  translateValues?: boolean;
+  reviveValues?: boolean;
+  // Per-segment toggles. Setting any of these to a boolean disables
+  // (or enables) parsing of that segment entirely. The narrow
+  // approach we use is `{ ifd0: false, exif: true, gps: false,
+  // interop: false, ifd1: false }` — parses just the EXIF segment
+  // where DateTimeOriginal / CreateDate live, skipping the rest.
+  ifd0?: boolean;
+  exif?: boolean;
+  gps?: boolean;
+  interop?: boolean;
+  ifd1?: boolean;
+  xmp?: boolean;
+  icc?: boolean;
+  iptc?: boolean;
+  jfif?: boolean;
+}
+
+type ExifrParseInput = ArrayBuffer | SharedArrayBuffer | Uint8Array | DataView;
 
 declare module "exifr/dist/lite.esm.mjs" {
-  interface ParseOptions {
-    // Tag-filter forms. Both are exposed but `pick` is BROKEN in the
-    // current lite build (`undefined is not iterable` at
-    // setupGlobalFilters when you call it with `pick` → segments are
-    // not all registered in the dictionary lookup). See PR #124's
-    // discovery + the `{ exif: true }` workaround used in `./exif.ts`
-    // and `src/app/watches/extractCaptureTime.ts`.
-    pick?: Array<string | number>;
-    skip?: Array<string | number>;
-    translateKeys?: boolean;
-    translateValues?: boolean;
-    reviveValues?: boolean;
-    // Per-segment toggles. Setting any of these to a boolean disables
-    // (or enables) parsing of that segment entirely. The narrow
-    // approach we use is `{ ifd0: false, exif: true, gps: false,
-    // interop: false, ifd1: false }` — parses just the EXIF segment
-    // where DateTimeOriginal / CreateDate live, skipping the rest.
-    ifd0?: boolean;
-    exif?: boolean;
-    gps?: boolean;
-    interop?: boolean;
-    ifd1?: boolean;
-    xmp?: boolean;
-    icc?: boolean;
-    iptc?: boolean;
-    jfif?: boolean;
-  }
-
-  type ParseInput = ArrayBuffer | SharedArrayBuffer | Uint8Array | DataView;
-
   export function parse(
-    input: ParseInput,
-    options?: ParseOptions | string[] | true,
+    input: ExifrParseInput,
+    options?: ExifrParseOptions | string[] | true,
+  ): Promise<Record<string, unknown> | undefined>;
+}
+
+declare module "exifr/dist/full.esm.mjs" {
+  export function parse(
+    input: ExifrParseInput,
+    options?: ExifrParseOptions | string[] | true,
   ): Promise<Record<string, unknown> | undefined>;
 }


### PR DESCRIPTION
## Summary

Switch SPA-side `exifr` import from `dist/lite.esm.mjs` to `dist/full.esm.mjs` so iPhone HEIC photos (the iOS Camera default) yield their `DateTimeOriginal`. The Worker side stays on lite — its byte-EXIF path is structurally dead in production anyway.

## Why

User reports: every fresh iPhone capture goes through `extractCaptureTime`'s fallback path:

```
Photo EXIF DateTimeOriginal: (none)
Capture source: fallback
EXIF / fallback ms: <Date.now() at submit>
SPA Date.now() at submit: <same value>
```

The lite build of `exifr` registers a HEIC **file** parser (finds the `meta` box where EXIF lives in the ISO BMFF container) but its EXIF **segment** extraction has gaps for the HEIC variants iPhone Camera produces by default. DateTimeOriginal comes back undefined; we fall back to `Date.now()` at submit; user-decision time gets baked into deviation.

The four prior fixes in this stack (PR #124 client EXIF, PR #126 TZ offset, PR #127 NTP skew correction) all assumed EXIF would be present on the SPA side. They couldn't reach this issue because the EXIF was never read in the first place.

## What changes

| File | Change |
|---|---|
| `src/app/watches/extractCaptureTime.ts` | Import path: `exifr/dist/lite.esm.mjs` → `exifr/dist/full.esm.mjs`. No code changes — the segment-on options form (`{ ifd0: false, exif: true, ... }`) works identically on both builds. |
| `src/types/exifr-lite.d.ts` | Adds a second `declare module` for `exifr/dist/full.esm.mjs` against the same options interface. Both builds share the same parse() shape. |

Worker side (`src/domain/reading-verifier/exif.ts`) stays on lite.

## Bundle impact

- **SPA**: 426 KB → 456 KB (+30 KB raw / +12 KB gzipped)
- **Worker**: unchanged

Acceptable — for this single regression we gain accurate moment-of-shutter timestamps for every iPhone-shot photo.

## Test plan

641 existing tests pass unchanged. The `extractCaptureTime.test.ts` JPEG-fixture happy-path test now exercises the full build and continues to confirm the contract.

No new test for HEIC specifically — building a synthetic HEIC fixture is significant work, and exifr's own test suite covers HEIC EXIF extraction. Practical verification: the user takes a fresh iPhone capture after deploy and confirms the debug panel shows `Capture source: exif` instead of `fallback`.

## Rollback

Revert this PR. Reverting puts the SPA back on lite — falls through to `Date.now()` at submit on iPhone HEIC, but the verified-reading flow continues to work (just with the upload-latency bias the stack is trying to fix).

🤖 Generated with [opencode](https://opencode.ai)