### PR TITLE
debug(verified-reading): file-format diagnostics + pickedAt fallback

### DIFF
--- a/src/app/watches/VerifiedReadingCapture.tsx
+++ b/src/app/watches/VerifiedReadingCapture.tsx
@@ -78,12 +78,19 @@ import { estimateClockSkew, type ClockSkewResult } from "./ntpSync";
 // which input is producing the wrong deviation. Remove this once
 // the bug is diagnosed.
 export interface VerifiedReadingDebugInfo {
-  /** EXIF DateTimeOriginal as ISO string, or "(no EXIF)". */
+  /** EXIF DateTimeOriginal as ISO string, or null when none. */
   exifIso: string | null;
   /** Where the captured timestamp came from. */
   captureSource: ExtractedCaptureSource;
   /** What `extractCaptureTime` returned (before NTP correction). */
   rawCaptureMs: number;
+  /**
+   * `Date.now()` captured at the file-picker `onChange` boundary —
+   * tighter approximation of shutter time than `submitMs` for the
+   * fallback path (when EXIF is unreadable, e.g. iOS Safari's
+   * HEIC→JPEG conversion strips DateTimeOriginal). Added in PR #130.
+   */
+  pickedAtMs: number;
   /** SPA's `Date.now()` at the moment of submit. */
   submitMs: number;
   /** Result from the NTP-style estimator (full failure detail when failed). */
@@ -92,6 +99,31 @@ export interface VerifiedReadingDebugInfo {
   clientCaptureMs: number;
   /** TZ offset minutes east of UTC sent as `client_tz_offset_minutes`. */
   clientTzOffsetMinutes: number;
+  /**
+   * The File's MIME type as iOS handed it to the SPA. "image/heic"
+   * means the iPhone gave us the original HEIC; "image/jpeg" means
+   * iOS converted at the picker (which usually strips EXIF).
+   */
+  fileMimeType: string;
+  /** File extension (sniffed from `file.name`), e.g. "HEIC", "JPG". */
+  fileExtension: string;
+  /** File size in bytes, as the SPA received it pre-resize. */
+  fileSize: number;
+  /**
+   * First 12 bytes of the file as hex, separated by spaces. The
+   * leading bytes identify the actual format regardless of what the
+   * MIME claims:
+   *   FF D8 FF              JPEG SOI
+   *   00 00 00 ?? 66 74 79  HEIC/HEIF (ftyp box)
+   *   89 50 4E 47           PNG
+   */
+  fileMagicHex: string;
+  /**
+   * The list of EXIF keys exifr returned, or empty array when nothing
+   * parseable. Helps distinguish "exifr couldn't parse this format"
+   * from "exifr parsed the format but found no DateTimeOriginal".
+   */
+  exifKeys: string[];
 }
 import type { VerifiedReadingErrorMessage } from "./verifiedReadingErrors";
 
@@ -116,7 +148,23 @@ type SubmitProgress = "uploading" | "reading" | "saving";
 
 type UiState =
   | { kind: "idle" }
-  | { kind: "chosen"; file: File; previewUrl: string }
+  | {
+      kind: "chosen";
+      file: File;
+      previewUrl: string;
+      /**
+       * `Date.now()` captured at the file-picker `onChange` callback
+       * — i.e. when iOS hands the file to the SPA, just after the
+       * user taps "Use Photo" in the camera review. Used as a tighter
+       * fallback than submit-time `Date.now()` for the case where
+       * EXIF is missing (iOS converting HEIC → JPEG strips
+       * DateTimeOriginal in some configurations). Closer to the
+       * shutter moment than submit-time by however long the user
+       * spends on the SPA's confirmation page (review-the-prediction-
+       * before-clicking-submit).
+       */
+      pickedAtMs: number;
+    }
   | {
       kind: "submitting";
       file: File;
@@ -260,7 +308,18 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
   const handleFileChosen = useCallback(
     (file: File) => {
       const previewUrl = setPreview(file);
-      setState({ kind: "chosen", file, previewUrl });
+      // Capture `Date.now()` at the file-picker boundary. On a
+      // fresh iPhone capture this fires when the user taps "Use
+      // Photo" in the camera review, which is the closest non-
+      // EXIF approximation we have to the shutter moment. Any
+      // SPA-side time spent reviewing the prediction afterwards
+      // doesn't add bias to `pickedAtMs` (only to `submitMs`).
+      setState({
+        kind: "chosen",
+        file,
+        previewUrl,
+        pickedAtMs: Date.now(),
+      });
     },
     [setPreview],
   );
@@ -286,13 +345,19 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
     // camera's authoritative shutter timestamp. PR #124 fix for the
     // upload-latency bias: this value gets sent to the server as
     // `client_capture_ms`, bounded against arrival, and used as the
-    // reference. When EXIF is missing (HEIC variants, screenshots,
-    // already-stripped photos), we fall back to `Date.now()` here —
-    // still much closer to the actual capture moment than the
-    // server-arrival fallback (which lags by upload latency, 5-15 s
-    // on cellular).
+    // reference. When EXIF is missing — which iOS Safari triggers
+    // when it converts iPhone HEIC → JPEG at the file picker
+    // boundary, stripping DateTimeOriginal in the process — we fall
+    // back to `pickedAtMs`, the `Date.now()` captured at the file-
+    // picker `onChange` (= just after the user taps "Use Photo" in
+    // the iOS camera review). That's typically within 1-2 s of the
+    // shutter, vs `submitMs` (= when they tap our submit button)
+    // which adds the SPA confirmation-page review time too. Per-
+    // reading bias drops from "shutter-to-submit" to "shutter-to-
+    // Use-Photo-tap" — much smaller. PR #130.
+    const pickedAtMs = state.kind === "chosen" ? state.pickedAtMs : Date.now();
     const submitMs = Date.now();
-    const captureRich = await extractCaptureTimeRich(sourceFile, submitMs);
+    const captureRich = await extractCaptureTimeRich(sourceFile, pickedAtMs);
     const rawCaptureMs = captureRich.ms;
 
     // PR #127: estimate the iPhone-vs-NTP clock skew via a
@@ -377,10 +442,16 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
           exifIso: captureRich.exifIso ?? null,
           captureSource: captureRich.source,
           rawCaptureMs,
+          pickedAtMs,
           submitMs,
           skew: skewResult,
           clientCaptureMs,
           clientTzOffsetMinutes,
+          fileMimeType: captureRich.diag?.fileMimeType ?? "(no diag)",
+          fileExtension: captureRich.diag?.fileExtension ?? "(no diag)",
+          fileSize: captureRich.diag?.fileSize ?? 0,
+          fileMagicHex: captureRich.diag?.fileMagicHex ?? "",
+          exifKeys: captureRich.diag?.exifKeys ?? [],
         },
       });
       return;
@@ -484,11 +555,18 @@ export function VerifiedReadingCapture({ watchId, onSubmitted }: Props) {
 
   function handleRetry() {
     if (state.kind !== "error") return;
-    // Same photo, fresh attempt — used for transport_error.
+    // Same photo, fresh attempt — used for transport_error. We
+    // RE-pick `Date.now()` here because the original pickedAtMs is
+    // gone (the error state didn't carry it). For a transport-
+    // error retry the photo is sometimes seconds-to-minutes old at
+    // this point, so this fallback isn't perfect — but it's only
+    // used when EXIF extraction also fails, which is the same
+    // boat as the original submit.
     setState({
       kind: "chosen",
       file: state.file,
       previewUrl: state.previewUrl,
+      pickedAtMs: Date.now(),
     });
     void handleSubmit();
   }

--- a/src/app/watches/VerifiedReadingConfirmation.tsx
+++ b/src/app/watches/VerifiedReadingConfirmation.tsx
@@ -252,11 +252,28 @@ function DebugPanel({
   const wrapped = (((raw + 21600) % 43200) + 43200) % 43200;
   const projectedDeviation = wrapped - 21600;
 
+  const exifKeysSummary =
+    debug.exifKeys.length === 0
+      ? "(empty)"
+      : debug.exifKeys.length > 6
+        ? `${debug.exifKeys.slice(0, 6).join(", ")}, … (+${debug.exifKeys.length - 6})`
+        : debug.exifKeys.join(", ");
   const rows: Array<[string, string]> = [
+    [
+      "File (iOS handed SPA)",
+      `${debug.fileMimeType}, .${debug.fileExtension}, ${debug.fileSize} bytes`,
+    ],
+    ["File magic (first 12 bytes)", debug.fileMagicHex || "(empty)"],
+    ["exifr keys returned", exifKeysSummary],
     ["Photo EXIF DateTimeOriginal", debug.exifIso ?? "(none)"],
     ["Capture source", debug.captureSource],
     ["EXIF / fallback ms", `${debug.rawCaptureMs}  →  ${fmtIso(debug.rawCaptureMs)}`],
+    ["Date.now() at file picked", `${debug.pickedAtMs}  →  ${fmtIso(debug.pickedAtMs)}`],
     ["SPA Date.now() at submit", `${debug.submitMs}  →  ${fmtIso(debug.submitMs)}`],
+    [
+      "Pick-to-submit gap",
+      `${((debug.submitMs - debug.pickedAtMs) / 1000).toFixed(2)} s`,
+    ],
     ["NTP skew", skewLine],
     [
       "Sent client_capture_ms",

--- a/src/app/watches/extractCaptureTime.ts
+++ b/src/app/watches/extractCaptureTime.ts
@@ -77,6 +77,22 @@ export interface ExtractedCaptureTime {
    * exact value the iPhone wrote into the file.
    */
   exifIso?: string;
+  /**
+   * Diagnostic envelope (PR #130). All-or-nothing — populated
+   * whenever the file was inspected at all. Helps the debug panel
+   * surface "iOS gave us format X with EXIF keys Y" so we can see
+   * where in the iOS → SPA → exifr chain the timestamp goes
+   * missing.
+   */
+  diag?: {
+    fileMimeType: string;
+    fileExtension: string;
+    fileSize: number;
+    /** Space-separated hex bytes, e.g. "FF D8 FF E0 00 10 ..." */
+    fileMagicHex: string;
+    /** All keys exifr returned (often non-empty even when DateTimeOriginal is missing). */
+    exifKeys: string[];
+  };
 }
 
 /**
@@ -121,45 +137,91 @@ export async function extractCaptureTimeRich(
   // input shape so we always go through it. This is one extra copy
   // up-front, but on the SPA side the file is typically <2 MB and
   // ArrayBuffer reads are essentially free.
+  // PR #130: capture diagnostic info up-front (mime type, name,
+  // size) so the debug panel can show what iOS handed us even when
+  // exifr extraction fails. Stays attached to the result regardless
+  // of which branch we end up returning through.
+  const fileMimeType = file.type || "(unknown)";
+  const fileExtension = file.name.includes(".")
+    ? file.name.slice(file.name.lastIndexOf(".") + 1).toUpperCase()
+    : "(none)";
+  const fileSize = file.size;
+
   let buffer: ArrayBuffer;
   try {
     buffer = await file.arrayBuffer();
   } catch {
-    return { ms: fallbackMs, source: "fallback" };
+    return {
+      ms: fallbackMs,
+      source: "fallback",
+      diag: { fileMimeType, fileExtension, fileSize, fileMagicHex: "", exifKeys: [] },
+    };
   }
-  if (buffer.byteLength === 0) return { ms: fallbackMs, source: "fallback" };
+  if (buffer.byteLength === 0) {
+    return {
+      ms: fallbackMs,
+      source: "fallback",
+      diag: { fileMimeType, fileExtension, fileSize, fileMagicHex: "", exifKeys: [] },
+    };
+  }
 
-  // We disable IFD0 / GPS / IFD1 / interop and parse only the EXIF
-  // segment (where DateTimeOriginal and CreateDate live). The shorter
-  // `{ pick: [...] }` form is BROKEN in this exifr lite build
-  // (`undefined is not iterable` at setupGlobalFilters) — see the
-  // discovery in PR #124. The segment-on form is the workaround that
-  // lets the parser skip the expensive segments while still finding
-  // the two tags we want.
-  let parsed: { DateTimeOriginal?: unknown; CreateDate?: unknown } | undefined;
+  const fileMagicHex = magicHex(buffer, 12);
+
+  // PR #130: switched from segment-on options to default (full
+  // exifr behavior) for HEIC compatibility. The default parses
+  // ifd0 + exif + gps which adds a ~100µs of work per call but
+  // covers HEIC variants that segment-on misses. The previous
+  // segment-on form was a holdover from the lite build's broken
+  // pick: option workaround (PR #124); now that we're on full,
+  // default is fine.
+  let parsed: Record<string, unknown> | undefined;
   try {
-    parsed = (await exifrParse(buffer, {
-      ifd0: false,
-      exif: true,
-      gps: false,
-      interop: false,
-      ifd1: false,
-    })) as typeof parsed;
+    parsed = await exifrParse(buffer);
   } catch {
-    return { ms: fallbackMs, source: "fallback" };
+    return {
+      ms: fallbackMs,
+      source: "fallback",
+      diag: { fileMimeType, fileExtension, fileSize, fileMagicHex, exifKeys: [] },
+    };
   }
-  if (!parsed) return { ms: fallbackMs, source: "fallback" };
+  const exifKeys = parsed ? Object.keys(parsed) : [];
+  if (!parsed) {
+    return {
+      ms: fallbackMs,
+      source: "fallback",
+      diag: { fileMimeType, fileExtension, fileSize, fileMagicHex, exifKeys },
+    };
+  }
   // Prefer DateTimeOriginal (the moment the shutter fired); fall back
   // to CreateDate (some pipelines — HEIC, certain Android cameras —
   // populate only one of the two).
   const dto = parsed.DateTimeOriginal ?? parsed.CreateDate;
   const ms = toMs(dto);
-  if (ms === null) return { ms: fallbackMs, source: "fallback" };
+  if (ms === null) {
+    return {
+      ms: fallbackMs,
+      source: "fallback",
+      diag: { fileMimeType, fileExtension, fileSize, fileMagicHex, exifKeys },
+    };
+  }
   return {
     ms,
     source: "exif",
     exifIso: dto instanceof Date ? dto.toISOString() : String(dto),
+    diag: { fileMimeType, fileExtension, fileSize, fileMagicHex, exifKeys },
   };
+}
+
+/**
+ * Format the first `n` bytes of `buffer` as space-separated upper-
+ * case hex. Used to identify the actual on-disk file format
+ * regardless of what the MIME type claims.
+ */
+function magicHex(buffer: ArrayBuffer, n: number): string {
+  const view = new Uint8Array(buffer, 0, Math.min(n, buffer.byteLength));
+  return Array.from(view)
+    .map((b) => b.toString(16).toUpperCase().padStart(2, "0"))
+    .join(" ");
 }
 
 // Defensive: exifr usually returns a JS Date for revivable date


### PR DESCRIPTION
## Summary

After PR #129 (switch to exifr full), user reports the debug panel STILL shows `Photo EXIF DateTimeOriginal: (none)` on iPhone HEIC captures. Verified locally that exifr full extracts DateTimeOriginal cleanly from a real iPhone HEIC, so the issue is upstream of exifr — most likely iOS Safari converting HEIC → JPEG at the `<input type=file>` boundary and stripping EXIF.

This PR doesn't fix the missing-EXIF case yet — it surfaces enough data to confirm the theory and partially mitigates with a tighter fallback.

## Three changes

### 1. File-format diagnostics in the debug panel

Three new rows so we can see what iOS hands the SPA:

| Row | Tells us |
|---|---|
| File (iOS handed SPA) | MIME type, extension, byte size — `image/heic` vs `image/jpeg` is the deciding diagnostic |
| File magic (first 12 bytes) | Identifies actual format regardless of MIME claim. `FF D8 FF` = JPEG, `ftyp...heic/heix/mif1` = HEIC |
| exifr keys returned | Full list of EXIF fields exifr extracted. If empty, exifr can't parse the file at all. If non-empty but no `DateTimeOriginal`, the file IS parsed but the date is missing (consistent with "iOS converted to JPEG and stripped dates") |

### 2. `pickedAtMs` as a tighter fallback than `submitMs`

Currently when EXIF is missing, we fall back to `Date.now()` at the moment the user taps the SPA's submit button. That includes review time on the SPA confirmation page (could be many seconds).

PR #130 captures `Date.now()` at the file-picker `onChange` callback — fires when iOS hands the file to the SPA, just after the user taps "Use Photo" in the iOS camera review. This is typically <2s after the actual shutter, vs many seconds for `submitMs`.

When EXIF is missing, `pickedAtMs` becomes the fallback. The deviation bias drops from "shutter-to-final-submit" to "shutter-to-Use-Photo-tap" — much smaller.

### 3. Switch from segment-on options to exifr default

`extractCaptureTime` now calls `exifr.parse(buffer)` with no options instead of `{ ifd0: false, exif: true, gps: false, interop: false, ifd1: false }`. The segment-on form was a leftover workaround from the lite build's broken `pick:` option (PR #124). On full it's unnecessary — default handles HEIC variants more robustly.

## Test plan

641 existing tests pass unchanged. `extractCaptureTime.test.ts` now exercises the default-options call and continues to extract DateTimeOriginal cleanly from the JPEG fixture.

## What we'll learn after deploy

User takes a fresh iPhone capture. The debug panel reveals the actual flow:

- If `File (iOS handed SPA)` says `image/jpeg` and `exifr keys returned` is empty → iOS converted HEIC→JPEG at the picker AND stripped EXIF. We need to either re-encode less aggressively or skip the canvas resize for HEIC and let server handle.
- If `image/heic` and `exifr keys returned` is non-empty but no `DateTimeOriginal` → exifr can't reach this HEIC variant's EXIF. We'd need a manual ISO BMFF parser or different lib.
- If `image/heic` and `exifr keys returned` is empty → exifr completely failed on this HEIC. Same fix path as above.
- If `image/jpeg` and `exifr keys returned` includes `DateTimeOriginal` → it works! Theory falsified, look elsewhere.

## Rollback

Revert this PR. Back to the previous SPA bundle behavior. Tests are intact since they didn't change.

🤖 Generated with [opencode](https://opencode.ai)